### PR TITLE
Add REST routes for user settings, profile, and subscriptions

### DIFF
--- a/inc/routes/users/artist-access-request.php
+++ b/inc/routes/users/artist-access-request.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Artist Access Request REST API Endpoint
+ *
+ * POST /wp-json/extrachill/v1/users/me/artist-access  - Request artist platform access
+ *
+ * User-facing endpoint. Delegates to extrachill-users ability.
+ * Admin-facing approve/reject lives in admin/artist-access.php.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_user_artist_access_request_route' );
+
+function extrachill_api_register_user_artist_access_request_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/users/me/artist-access',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_user_artist_access_request',
+			'permission_callback' => 'extrachill_api_user_artist_access_permission',
+			'args'                => array(
+				'type' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'enum'              => array( 'artist', 'professional' ),
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Permission check — must be logged in.
+ */
+function extrachill_api_user_artist_access_permission( WP_REST_Request $request ) {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'You must be logged in.', 'extrachill-api' ),
+			array( 'status' => 401 )
+		);
+	}
+	return true;
+}
+
+/**
+ * POST /users/me/artist-access
+ */
+function extrachill_api_user_artist_access_request( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/request-artist-access' );
+
+	if ( ! $ability ) {
+		return new WP_Error( 'service_unavailable', 'Artist access request service not available.', array( 'status' => 503 ) );
+	}
+
+	$result = $ability->execute(
+		array(
+			'user_id' => get_current_user_id(),
+			'type'    => $request->get_param( 'type' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return new WP_Error( $result->get_error_code(), $result->get_error_message(), array( 'status' => 400 ) );
+	}
+
+	return rest_ensure_response( $result );
+}

--- a/inc/routes/users/profile.php
+++ b/inc/routes/users/profile.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * User Profile REST API Endpoints
+ *
+ * GET  /wp-json/extrachill/v1/users/me/profile    - Get profile
+ * POST /wp-json/extrachill/v1/users/me/profile    - Update profile
+ * POST /wp-json/extrachill/v1/users/me/links      - Update links
+ *
+ * Delegates to extrachill-users abilities.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_user_profile_routes' );
+
+function extrachill_api_register_user_profile_routes() {
+	// Profile (GET + POST).
+	register_rest_route(
+		'extrachill/v1',
+		'/users/me/profile',
+		array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_user_profile_get',
+				'permission_callback' => 'extrachill_api_user_profile_permission',
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => 'extrachill_api_user_profile_update',
+				'permission_callback' => 'extrachill_api_user_profile_permission',
+				'args'                => array(
+					'custom_title' => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'bio'          => array(
+						'type' => 'string',
+					),
+					'local_city'   => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			),
+		)
+	);
+
+	// Links (POST — replaces all links).
+	register_rest_route(
+		'extrachill/v1',
+		'/users/me/links',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_user_links_update',
+			'permission_callback' => 'extrachill_api_user_profile_permission',
+			'args'                => array(
+				'links' => array(
+					'required' => true,
+					'type'     => 'array',
+					'items'    => array(
+						'type'       => 'object',
+						'properties' => array(
+							'type_key'     => array( 'type' => 'string' ),
+							'url'          => array( 'type' => 'string' ),
+							'custom_label' => array( 'type' => 'string' ),
+						),
+					),
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Permission check — must be logged in.
+ */
+function extrachill_api_user_profile_permission( WP_REST_Request $request ) {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'You must be logged in.', 'extrachill-api' ),
+			array( 'status' => 401 )
+		);
+	}
+	return true;
+}
+
+/**
+ * GET /users/me/profile
+ */
+function extrachill_api_user_profile_get( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/get-user-profile' );
+
+	if ( ! $ability ) {
+		return new WP_Error( 'service_unavailable', 'User profile service not available.', array( 'status' => 503 ) );
+	}
+
+	$result = $ability->execute( array( 'user_id' => get_current_user_id() ) );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}
+
+/**
+ * POST /users/me/profile
+ */
+function extrachill_api_user_profile_update( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/update-user-profile' );
+
+	if ( ! $ability ) {
+		return new WP_Error( 'service_unavailable', 'User profile service not available.', array( 'status' => 503 ) );
+	}
+
+	$input = array( 'user_id' => get_current_user_id() );
+
+	if ( null !== $request->get_param( 'custom_title' ) ) {
+		$input['custom_title'] = $request->get_param( 'custom_title' );
+	}
+	if ( null !== $request->get_param( 'bio' ) ) {
+		$input['bio'] = $request->get_param( 'bio' );
+	}
+	if ( null !== $request->get_param( 'local_city' ) ) {
+		$input['local_city'] = $request->get_param( 'local_city' );
+	}
+
+	$result = $ability->execute( $input );
+
+	if ( is_wp_error( $result ) ) {
+		return new WP_Error( $result->get_error_code(), $result->get_error_message(), array( 'status' => 400 ) );
+	}
+
+	return rest_ensure_response( $result );
+}
+
+/**
+ * POST /users/me/links
+ */
+function extrachill_api_user_links_update( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/update-user-links' );
+
+	if ( ! $ability ) {
+		return new WP_Error( 'service_unavailable', 'User links service not available.', array( 'status' => 503 ) );
+	}
+
+	$result = $ability->execute(
+		array(
+			'user_id' => get_current_user_id(),
+			'links'   => $request->get_param( 'links' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return new WP_Error( $result->get_error_code(), $result->get_error_message(), array( 'status' => 400 ) );
+	}
+
+	return rest_ensure_response( $result );
+}

--- a/inc/routes/users/settings.php
+++ b/inc/routes/users/settings.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * User Settings REST API Endpoints
+ *
+ * GET  /wp-json/extrachill/v1/users/me/settings       - Get settings
+ * POST /wp-json/extrachill/v1/users/me/settings       - Update settings
+ * POST /wp-json/extrachill/v1/users/me/email           - Change email
+ * POST /wp-json/extrachill/v1/users/me/password        - Change password
+ *
+ * Delegates to extrachill-users abilities.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_user_settings_routes' );
+
+function extrachill_api_register_user_settings_routes() {
+	// Settings (GET + POST).
+	register_rest_route(
+		'extrachill/v1',
+		'/users/me/settings',
+		array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_user_settings_get',
+				'permission_callback' => 'extrachill_api_user_settings_permission',
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => 'extrachill_api_user_settings_update',
+				'permission_callback' => 'extrachill_api_user_settings_permission',
+				'args'                => array(
+					'first_name'   => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'last_name'    => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'display_name' => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			),
+		)
+	);
+
+	// Email change.
+	register_rest_route(
+		'extrachill/v1',
+		'/users/me/email',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_user_email_change',
+			'permission_callback' => 'extrachill_api_user_settings_permission',
+			'args'                => array(
+				'new_email' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_email',
+				),
+			),
+		)
+	);
+
+	// Password change.
+	register_rest_route(
+		'extrachill/v1',
+		'/users/me/password',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_user_password_change',
+			'permission_callback' => 'extrachill_api_user_settings_permission',
+			'args'                => array(
+				'current_password' => array(
+					'required' => true,
+					'type'     => 'string',
+				),
+				'new_password'     => array(
+					'required' => true,
+					'type'     => 'string',
+				),
+				'confirm_password' => array(
+					'required' => true,
+					'type'     => 'string',
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Permission check — must be logged in.
+ */
+function extrachill_api_user_settings_permission( WP_REST_Request $request ) {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'You must be logged in.', 'extrachill-api' ),
+			array( 'status' => 401 )
+		);
+	}
+	return true;
+}
+
+/**
+ * GET /users/me/settings
+ */
+function extrachill_api_user_settings_get( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/get-user-settings' );
+
+	if ( ! $ability ) {
+		return new WP_Error( 'service_unavailable', 'User settings service not available.', array( 'status' => 503 ) );
+	}
+
+	$result = $ability->execute( array( 'user_id' => get_current_user_id() ) );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}
+
+/**
+ * POST /users/me/settings
+ */
+function extrachill_api_user_settings_update( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/update-user-settings' );
+
+	if ( ! $ability ) {
+		return new WP_Error( 'service_unavailable', 'User settings service not available.', array( 'status' => 503 ) );
+	}
+
+	$input = array( 'user_id' => get_current_user_id() );
+
+	if ( null !== $request->get_param( 'first_name' ) ) {
+		$input['first_name'] = $request->get_param( 'first_name' );
+	}
+	if ( null !== $request->get_param( 'last_name' ) ) {
+		$input['last_name'] = $request->get_param( 'last_name' );
+	}
+	if ( null !== $request->get_param( 'display_name' ) ) {
+		$input['display_name'] = $request->get_param( 'display_name' );
+	}
+
+	$result = $ability->execute( $input );
+
+	if ( is_wp_error( $result ) ) {
+		return new WP_Error( $result->get_error_code(), $result->get_error_message(), array( 'status' => 400 ) );
+	}
+
+	return rest_ensure_response( $result );
+}
+
+/**
+ * POST /users/me/email
+ */
+function extrachill_api_user_email_change( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/change-user-email' );
+
+	if ( ! $ability ) {
+		return new WP_Error( 'service_unavailable', 'Email change service not available.', array( 'status' => 503 ) );
+	}
+
+	$result = $ability->execute(
+		array(
+			'user_id'   => get_current_user_id(),
+			'new_email' => $request->get_param( 'new_email' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return new WP_Error( $result->get_error_code(), $result->get_error_message(), array( 'status' => 400 ) );
+	}
+
+	return rest_ensure_response( $result );
+}
+
+/**
+ * POST /users/me/password
+ */
+function extrachill_api_user_password_change( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/change-user-password' );
+
+	if ( ! $ability ) {
+		return new WP_Error( 'service_unavailable', 'Password change service not available.', array( 'status' => 503 ) );
+	}
+
+	$result = $ability->execute(
+		array(
+			'user_id'          => get_current_user_id(),
+			'current_password' => $request->get_param( 'current_password' ),
+			'new_password'     => $request->get_param( 'new_password' ),
+			'confirm_password' => $request->get_param( 'confirm_password' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return new WP_Error( $result->get_error_code(), $result->get_error_message(), array( 'status' => 400 ) );
+	}
+
+	return rest_ensure_response( $result );
+}

--- a/inc/routes/users/subscriptions.php
+++ b/inc/routes/users/subscriptions.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * User Subscriptions REST API Endpoints
+ *
+ * GET  /wp-json/extrachill/v1/users/me/subscriptions  - Get subscriptions
+ * POST /wp-json/extrachill/v1/users/me/subscriptions  - Update subscriptions
+ *
+ * Delegates to extrachill-users abilities.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_user_subscriptions_routes' );
+
+function extrachill_api_register_user_subscriptions_routes() {
+	register_rest_route(
+		'extrachill/v1',
+		'/users/me/subscriptions',
+		array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_user_subscriptions_get',
+				'permission_callback' => 'extrachill_api_user_subscriptions_permission',
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => 'extrachill_api_user_subscriptions_update',
+				'permission_callback' => 'extrachill_api_user_subscriptions_permission',
+				'args'                => array(
+					'consented_artists' => array(
+						'required' => true,
+						'type'     => 'array',
+						'items'    => array( 'type' => 'integer' ),
+					),
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Permission check — must be logged in.
+ */
+function extrachill_api_user_subscriptions_permission( WP_REST_Request $request ) {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'You must be logged in.', 'extrachill-api' ),
+			array( 'status' => 401 )
+		);
+	}
+	return true;
+}
+
+/**
+ * GET /users/me/subscriptions
+ */
+function extrachill_api_user_subscriptions_get( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/get-subscriptions' );
+
+	if ( ! $ability ) {
+		return new WP_Error( 'service_unavailable', 'Subscriptions service not available.', array( 'status' => 503 ) );
+	}
+
+	$result = $ability->execute( array( 'user_id' => get_current_user_id() ) );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}
+
+/**
+ * POST /users/me/subscriptions
+ */
+function extrachill_api_user_subscriptions_update( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/update-subscriptions' );
+
+	if ( ! $ability ) {
+		return new WP_Error( 'service_unavailable', 'Subscriptions service not available.', array( 'status' => 503 ) );
+	}
+
+	$result = $ability->execute(
+		array(
+			'user_id'           => get_current_user_id(),
+			'consented_artists' => $request->get_param( 'consented_artists' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return new WP_Error( $result->get_error_code(), $result->get_error_message(), array( 'status' => 400 ) );
+	}
+
+	return rest_ensure_response( $result );
+}


### PR DESCRIPTION
## Summary

Thin REST wrappers for the new user management abilities. All delegate to `extrachill-users` abilities.

### New Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/users/me/settings` | GET | Read account settings |
| `/users/me/settings` | POST | Update name/display name |
| `/users/me/email` | POST | Email change with verification |
| `/users/me/password` | POST | Password change |
| `/users/me/profile` | GET | Read profile fields |
| `/users/me/profile` | POST | Update title/bio/city |
| `/users/me/links` | POST | Replace all profile links |
| `/users/me/subscriptions` | GET | Read artist email consent |
| `/users/me/subscriptions` | POST | Update email consent |
| `/users/me/artist-access` | POST | Request artist platform access |

All endpoints require authentication (logged in user). Uses the `/users/me/` pattern for self-service operations.

Depends on: Extra-Chill/extrachill-users (abilities PR)
Part of: User Management Modernization