### PR TITLE
Align REST handlers with ability contract (WP_Error returns)

### DIFF
--- a/inc/routes/analytics/click.php
+++ b/inc/routes/analytics/click.php
@@ -154,6 +154,10 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 				)
 			);
 
+			if ( is_wp_error( $event_id ) ) {
+				return $event_id;
+			}
+
 			if ( empty( $event_id ) ) {
 				return new WP_Error(
 					'tracking_failed',

--- a/inc/routes/blog/taxonomy-counts.php
+++ b/inc/routes/blog/taxonomy-counts.php
@@ -91,9 +91,7 @@ function extrachill_api_blog_taxonomy_counts_handler( WP_REST_Request $request )
 		}
 
 		// Cold cache — call the ability.
-		$ability = function_exists( 'wp_get_ability' )
-			? wp_get_ability( 'extrachill/taxonomy-post-counts' )
-			: null;
+		$ability = wp_get_ability( 'extrachill/taxonomy-post-counts' );
 
 		if ( ! $ability ) {
 			return rest_ensure_response( array() );
@@ -106,7 +104,11 @@ function extrachill_api_blog_taxonomy_counts_handler( WP_REST_Request $request )
 			)
 		);
 
-		$terms = ( ! empty( $result['success'] ) ) ? ( $result['terms'] ?? array() ) : array();
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$terms = $result['terms'] ?? array();
 
 		set_transient( $cache_key, $terms, 6 * HOUR_IN_SECONDS );
 

--- a/inc/routes/community/drafts.php
+++ b/inc/routes/community/drafts.php
@@ -159,6 +159,10 @@ function extrachill_api_community_drafts_get_handler( WP_REST_Request $request )
 
 	$draft = $ability->execute( $context );
 
+	if ( is_wp_error( $draft ) ) {
+		return $draft;
+	}
+
 	return rest_ensure_response( [ 'draft' => $draft ] );
 }
 
@@ -193,6 +197,10 @@ function extrachill_api_community_drafts_post_handler( WP_REST_Request $request 
 
 	$saved = $ability->execute( $draft );
 
+	if ( is_wp_error( $saved ) ) {
+		return $saved;
+	}
+
     return rest_ensure_response( [
         'saved' => true,
         'draft' => $saved,
@@ -213,6 +221,10 @@ function extrachill_api_community_drafts_delete_handler( WP_REST_Request $reques
 	$context = extrachill_api_community_drafts_get_context_from_request( $request );
 	$context['user_id'] = get_current_user_id();
 	$deleted = $ability->execute( $context );
+
+	if ( is_wp_error( $deleted ) ) {
+		return $deleted;
+	}
 
 	return rest_ensure_response( [ 'deleted' => (bool) $deleted ] );
 }

--- a/inc/routes/events/event-submissions.php
+++ b/inc/routes/events/event-submissions.php
@@ -34,7 +34,7 @@ function extrachill_api_register_event_submission_route() {
 }
 
 function extrachill_api_handle_event_submission( WP_REST_Request $request ) {
-	$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/submit-event' ) : null;
+	$ability = wp_get_ability( 'extrachill/submit-event' );
 	if ( ! $ability ) {
 		return new WP_Error(
 			'ability_unavailable',
@@ -67,20 +67,8 @@ function extrachill_api_handle_event_submission( WP_REST_Request $request ) {
 
 	$result = $ability->execute( $input );
 
-	if ( isset( $result['error'] ) ) {
-		$status = 400;
-
-		// Map specific errors to appropriate HTTP status codes.
-		$error_message = $result['error'];
-		if ( str_contains( $error_message, 'Security verification' ) ) {
-			$status = 403;
-		} elseif ( str_contains( $error_message, 'unavailable' ) || str_contains( $error_message, 'Scheduler' ) ) {
-			$status = 500;
-		} elseif ( str_contains( $error_message, 'not found' ) ) {
-			$status = 404;
-		}
-
-		return new WP_Error( 'submission_failed', $error_message, array( 'status' => $status ) );
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
 	return rest_ensure_response( $result );

--- a/inc/routes/events/geocode.php
+++ b/inc/routes/events/geocode.php
@@ -71,19 +71,7 @@ function extrachill_api_events_geocode_handler( WP_REST_Request $request ) {
 		) );
 
 		if ( is_wp_error( $result ) ) {
-			return new WP_Error(
-				'geocode_error',
-				$result->get_error_message(),
-				array( 'status' => 500 )
-			);
-		}
-
-		if ( empty( $result['success'] ) ) {
-			return new WP_Error(
-				'geocode_failed',
-				$result['error'] ?? __( 'Geocode search failed.', 'extrachill-api' ),
-				array( 'status' => 400 )
-			);
+			return $result;
 		}
 
 		// Transform Nominatim results to GeoSearchResult shape.

--- a/inc/routes/shop/taxonomy-counts.php
+++ b/inc/routes/shop/taxonomy-counts.php
@@ -92,9 +92,7 @@ function extrachill_api_shop_taxonomy_counts_handler( WP_REST_Request $request )
 		}
 
 		// Cold cache — call the ability.
-		$ability = function_exists( 'wp_get_ability' )
-			? wp_get_ability( 'extrachill/taxonomy-post-counts' )
-			: null;
+		$ability = wp_get_ability( 'extrachill/taxonomy-post-counts' );
 
 		if ( ! $ability ) {
 			return rest_ensure_response( array() );
@@ -108,7 +106,11 @@ function extrachill_api_shop_taxonomy_counts_handler( WP_REST_Request $request )
 			)
 		);
 
-		$terms = ( ! empty( $result['success'] ) ) ? ( $result['terms'] ?? array() ) : array();
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$terms = $result['terms'] ?? array();
 
 		set_transient( $cache_key, $terms, 6 * HOUR_IN_SECONDS );
 

--- a/inc/routes/wire/taxonomy-counts.php
+++ b/inc/routes/wire/taxonomy-counts.php
@@ -91,9 +91,7 @@ function extrachill_api_wire_taxonomy_counts_handler( WP_REST_Request $request )
 		}
 
 		// Cold cache — call the ability.
-		$ability = function_exists( 'wp_get_ability' )
-			? wp_get_ability( 'extrachill/taxonomy-post-counts' )
-			: null;
+		$ability = wp_get_ability( 'extrachill/taxonomy-post-counts' );
 
 		if ( ! $ability ) {
 			return rest_ensure_response( array() );
@@ -107,7 +105,11 @@ function extrachill_api_wire_taxonomy_counts_handler( WP_REST_Request $request )
 			)
 		);
 
-		$terms = ( ! empty( $result['success'] ) ) ? ( $result['terms'] ?? array() ) : array();
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$terms = $result['terms'] ?? array();
 
 		set_transient( $cache_key, $terms, 6 * HOUR_IN_SECONDS );
 


### PR DESCRIPTION
## Summary

Aligns extrachill-api REST handlers with the unified ability contract from data-machine#999 / data-machine#1000.

### Changes

- **Remove `function_exists('wp_get_ability')` guards** from taxonomy-counts (shop, wire, blog) and event-submissions — the Abilities API is always available
- **Replace `$result['success']` checks** in 3 taxonomy-counts handlers with `is_wp_error()` — abilities now return `WP_Error` on failure, not `['success' => false]`
- **Replace `$result['error']` string-matching** in event-submissions with `is_wp_error()` — removes fragile `str_contains()` HTTP status mapping; the ability's `WP_Error` already carries the correct status
- **Simplify geocode handler** — remove redundant `$result['success']` check and error re-wrapping; return `WP_Error` directly
- **Add missing `is_wp_error()` checks** in community/drafts (3 handlers) and analytics/click — these were passing ability results to `rest_ensure_response()` without error guards

All REST handlers now return `WP_Error` directly on failure — the WP REST API automatically converts this to a proper JSON error response with the correct HTTP status code.

**7 files changed, -2 lines net.**

Refs Extra-Chill/data-machine#999
Closes #17