### PR TITLE
fix: use WP_Ability::check_permissions() not has_permission() in network-media route

### DIFF
--- a/inc/routes/media/network-media.php
+++ b/inc/routes/media/network-media.php
@@ -79,7 +79,13 @@ function extrachill_api_network_media_permission( WP_REST_Request $request ) {
 		return new WP_Error( 'ability_missing', 'Network media ability not registered.', array( 'status' => 500 ) );
 	}
 
-	return $ability->has_permission( $request->get_params() );
+	$check = $ability->check_permissions( $request->get_params() );
+
+	if ( is_wp_error( $check ) ) {
+		return $check;
+	}
+
+	return (bool) $check;
 }
 
 /**


### PR DESCRIPTION
Hotfix for the network-media permission check. WP_Ability exposes `check_permissions($input)` (plural, returns bool|WP_Error) — there's no `has_permission()` method. The route was throwing PHP fatals on every request.

Pattern matches what `extrachill-api` and `data-machine-socials` already use elsewhere when invoking abilities directly.