### PR TITLE
docs: document Google OAuth auto-link on verified email match

### DIFF
--- a/docs/routes/auth/google.md
+++ b/docs/routes/auth/google.md
@@ -54,12 +54,19 @@ Authenticate users with Google OAuth using ID tokens and return access + refresh
 
 **Error Responses**:
 - `400` - Missing/invalid ID token, invalid device_id format, or validation errors
+- `401` - Google ID token signature/issuer/audience invalid, or `email_verified` not true
+- `403` - User exists but is not a member of the community blog
 - `500` - Google OAuth service unavailable or dependency missing
 
 **Implementation Details**:
 - Validates device_id as UUID v4 format
 - Calls `ec_google_login_with_tokens()` from extrachill-users plugin
-- Handles user creation via Google if account doesn't exist
+- Verifies the ID token via Google's JWKS and rejects tokens without `email_verified=true`
+- Account linking strategy:
+  1. Match by `google_user_id` user meta and log the user in.
+  2. Otherwise match by verified email and auto-link the Google account to the existing user.
+  3. Otherwise create a new account and link Google to it.
+- Auto-linking can be disabled per-site via the `ec_google_auto_link_verified_email` filter
 - Supports device tracking for session management
 - Optionally sets WordPress authentication cookie
 


### PR DESCRIPTION
## Summary

Documents the new linking strategy and previously-undocumented error responses on `POST /wp-json/extrachill/v1/auth/google`.

Companion to Extra-Chill/extrachill-users#15, which switches the Google OAuth service from returning a dead-end `409 account_exists_unlinked` to auto-linking on verified email match.

## Changes

- Added 401 (token verification failure / unverified email) and 403 (not a community member) to the error response list
- Documented the 3-step linking strategy: existing Google sub → verified email auto-link → new account
- Documented the new `ec_google_auto_link_verified_email` filter