### PR TITLE
refactor(routes/community): invoke abilities (#26)

### DIFF
--- a/inc/routes/community/upvote.php
+++ b/inc/routes/community/upvote.php
@@ -38,32 +38,23 @@ function extrachill_api_register_community_upvote_route() {
 	));
 }
 
-function extrachill_api_community_upvote_handler($request) {
-	$post_id = $request->get_param('post_id');
-	$type = $request->get_param('type');
-	$user_id = get_current_user_id();
-
-	if (!function_exists('extrachill_process_upvote')) {
-		return new WP_Error(
-			'function_missing',
-			'Upvote function not available. Please ensure extrachill-community plugin is activated.',
-			array('status' => 500)
-		);
+function extrachill_api_community_upvote_handler( $request ) {
+	$ability = wp_get_ability( 'extrachill/community-upvote' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_missing', 'community-upvote ability not available.', array( 'status' => 503 ) );
 	}
 
-	$result = extrachill_process_upvote($post_id, $type, $user_id);
+	$result = $ability->execute(
+		array(
+			'post_id' => (int) $request->get_param( 'post_id' ),
+			'type'    => (string) $request->get_param( 'type' ),
+			'user_id' => get_current_user_id(),
+		)
+	);
 
-	if ( $result['success'] ) {
-		return rest_ensure_response( array(
-			'message'   => $result['message'],
-			'new_count' => $result['new_count'],
-			'upvoted'   => $result['upvoted'],
-		) );
-	} else {
-		return new WP_Error(
-			'upvote_failed',
-			$result['message'],
-			array('status' => 400)
-		);
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
+
+	return rest_ensure_response( $result );
 }


### PR DESCRIPTION
## Summary

Refactors community-domain REST route handlers to invoke the canonical ability pattern (`wp_get_ability()` → `execute()` → `rest_ensure_response()`), per the umbrella issue #26.

### What changed

- **`inc/routes/community/upvote.php`** — replaced direct `extrachill_process_upvote()` call with `extrachill/community-upvote` ability invocation. This was the only community route still owning its own implementation.

### Already using abilities (no changes needed)

| File | Abilities |
|---|---|
| `forums.php` | `extrachill/community-list-forums` |
| `topics.php` | `extrachill/community-list-topics`, `extrachill/community-get-topic`, `extrachill/community-create-topic` |
| `replies.php` | `extrachill/community-list-replies`, `extrachill/community-create-reply` |
| `notifications.php` | `extrachill/community-get-notifications`, `extrachill/community-mark-notifications-read` |
| `drafts.php` | `extrachill/get-bbpress-draft`, `extrachill/save-bbpress-draft`, `extrachill/delete-bbpress-draft` |

### Gaps (no matching ability — left as-is)

| Route | Reason |
|---|---|
| `taxonomy-counts.php` | Community-specific taxonomy-counts handler returns forum URLs + topic counts for cross-site linking. The generic `extrachill/taxonomy-post-counts` ability (in extrachill-multisite) serves a different purpose. No community-specific taxonomy-counts ability is registered. |

### Checklist

- [x] Every community-domain route handler with a matching ability uses the canonical 6-line invoke pattern
- [x] Permission callbacks unchanged
- [x] Args / validation unchanged
- [x] No custom redirects in community domain
- [x] PHP lint clean (`find inc -name '*.php' -exec php -l {} \;`)
- [x] PR opened, NOT merged

Closes part of #26 (community domain batch).