### PR TITLE
refactor(routes/shop): invoke abilities (#26)

### DIFF
--- a/inc/routes/shop/orders.php
+++ b/inc/routes/shop/orders.php
@@ -189,188 +189,78 @@ function extrachill_api_shop_orders_item_permission_check( WP_REST_Request $requ
 
 /**
  * Handle GET /shop/orders - List orders for artist.
+ *
+ * Wraps the extrachill/shop-list-orders ability from extrachill-shop.
  */
 function extrachill_api_shop_orders_list_handler( WP_REST_Request $request ) {
-	$artist_id = absint( $request->get_param( 'artist_id' ) );
-	$status    = $request->get_param( 'status' );
-	$page      = max( 1, absint( $request->get_param( 'page' ) ) );
-	$per_page  = min( 100, max( 1, absint( $request->get_param( 'per_page' ) ) ) );
-
-	if ( ! function_exists( 'wc_get_orders' ) ) {
-		return new WP_Error(
-			'woocommerce_missing',
-			'WooCommerce is not available.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/shop-list-orders' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-shop plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$wc_statuses = array( 'wc-processing', 'wc-completed', 'wc-refunded', 'wc-on-hold' );
-
-	$orders = wc_get_orders( array(
-		'limit'      => -1,
-		'status'     => $wc_statuses,
-		'orderby'    => 'date',
-		'order'      => 'DESC',
-		'meta_query' => array(
-			array(
-				'key'     => '_artist_payouts',
-				'compare' => 'EXISTS',
-			),
-		),
-	) );
-
-	$filtered_orders          = array();
-	$needs_fulfillment_count  = 0;
-
-	foreach ( $orders as $order ) {
-		$payouts = $order->get_meta( '_artist_payouts' ) ?: array();
-		if ( ! isset( $payouts[ $artist_id ] ) ) {
-			continue;
-		}
-
-		$order_status = $order->get_status();
-
-		if ( 'processing' === $order_status || 'on-hold' === $order_status ) {
-			$needs_fulfillment_count++;
-		}
-
-		if ( 'needs_fulfillment' === $status && ! in_array( $order_status, array( 'processing', 'on-hold' ), true ) ) {
-			continue;
-		}
-
-		if ( 'completed' === $status && 'completed' !== $order_status && 'refunded' !== $order_status ) {
-			continue;
-		}
-
-		$filtered_orders[] = $order;
+	$result = $ability->execute(
+		array(
+			'artist_id' => absint( $request->get_param( 'artist_id' ) ),
+			'status'    => $request->get_param( 'status' ),
+			'page'      => absint( $request->get_param( 'page' ) ),
+			'per_page'  => absint( $request->get_param( 'per_page' ) ),
+		)
+	);
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	$total        = count( $filtered_orders );
-	$total_pages  = ceil( $total / $per_page );
-	$offset       = ( $page - 1 ) * $per_page;
-	$paged_orders = array_slice( $filtered_orders, $offset, $per_page );
-
-	$response_orders = array();
-	foreach ( $paged_orders as $order ) {
-		$response_orders[] = extrachill_api_shop_orders_build_response( $order, $artist_id );
-	}
-
-	return rest_ensure_response( array(
-		'orders'                  => $response_orders,
-		'total'                   => $total,
-		'total_pages'             => $total_pages,
-		'page'                    => $page,
-		'per_page'                => $per_page,
-		'needs_fulfillment_count' => $needs_fulfillment_count,
-	) );
+	return rest_ensure_response( $result );
 }
 
 /**
  * Handle PUT /shop/orders/{id}/status - Update order status.
+ *
+ * Wraps the extrachill/shop-update-order-status ability from extrachill-shop.
  */
 function extrachill_api_shop_orders_status_handler( WP_REST_Request $request ) {
-	$order_id        = absint( $request->get_param( 'id' ) );
-	$artist_id       = absint( $request->get_param( 'artist_id' ) );
-	$new_status      = $request->get_param( 'status' );
-	$tracking_number = $request->get_param( 'tracking_number' );
-
-	$order = wc_get_order( $order_id );
-	if ( ! $order ) {
-		return new WP_Error(
-			'order_not_found',
-			'Order not found.',
-			array( 'status' => 404 )
-		);
+	$ability = wp_get_ability( 'extrachill/shop-update-order-status' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-shop plugin is required.', array( 'status' => 500 ) );
 	}
 
-	if ( $tracking_number ) {
-		$order->update_meta_data( '_artist_tracking_' . $artist_id, $tracking_number );
+	$result = $ability->execute(
+		array(
+			'id'              => absint( $request->get_param( 'id' ) ),
+			'artist_id'       => absint( $request->get_param( 'artist_id' ) ),
+			'status'          => $request->get_param( 'status' ),
+			'tracking_number' => $request->get_param( 'tracking_number' ),
+		)
+	);
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	if ( 'completed' === $new_status ) {
-		$order->set_status( 'completed', 'Order marked as shipped by artist.' );
-	}
-
-	$order->save();
-
-	return rest_ensure_response( extrachill_api_shop_orders_build_response( $order, $artist_id ) );
+	return rest_ensure_response( $result );
 }
 
 /**
  * Handle POST /shop/orders/{id}/refund - Issue full refund.
+ *
+ * Wraps the extrachill/shop-refund-order ability from extrachill-shop.
  */
 function extrachill_api_shop_orders_refund_handler( WP_REST_Request $request ) {
-	$order_id  = absint( $request->get_param( 'id' ) );
-	$artist_id = absint( $request->get_param( 'artist_id' ) );
-
-	$order = wc_get_order( $order_id );
-	if ( ! $order ) {
-		return new WP_Error(
-			'order_not_found',
-			'Order not found.',
-			array( 'status' => 404 )
-		);
+	$ability = wp_get_ability( 'extrachill/shop-refund-order' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-shop plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$payouts = $order->get_meta( '_artist_payouts' ) ?: array();
-	if ( ! isset( $payouts[ $artist_id ] ) ) {
-		return new WP_Error(
-			'invalid_artist',
-			'This order does not contain products from your artist.',
-			array( 'status' => 400 )
-		);
+	$result = $ability->execute(
+		array(
+			'id'        => absint( $request->get_param( 'id' ) ),
+			'artist_id' => absint( $request->get_param( 'artist_id' ) ),
+		)
+	);
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	$artist_payout = $payouts[ $artist_id ];
-	$refund_amount = floatval( $artist_payout['total'] ?? 0 );
-
-	if ( $refund_amount <= 0 ) {
-		return new WP_Error(
-			'invalid_refund_amount',
-			'No refundable amount found for this artist.',
-			array( 'status' => 400 )
-		);
-	}
-
-	$charges = $order->get_meta( '_stripe_charges' ) ?: array();
-	$payment_intent_id = $charges[ $artist_id ]['payment_intent_id'] ?? '';
-
-	if ( ! $payment_intent_id ) {
-		return new WP_Error(
-			'no_payment_intent',
-			'No payment intent found for this artist order.',
-			array( 'status' => 400 )
-		);
-	}
-
-	if ( ! function_exists( 'extrachill_shop_stripe_init' ) || ! extrachill_shop_stripe_init() ) {
-		return new WP_Error(
-			'stripe_not_configured',
-			'Stripe is not configured.',
-			array( 'status' => 500 )
-		);
-	}
-
-	try {
-		\Stripe\Refund::create( array(
-			'payment_intent' => $payment_intent_id,
-		) );
-	} catch ( \Exception $e ) {
-		return new WP_Error(
-			'refund_failed',
-			'Refund failed: ' . $e->getMessage(),
-			array( 'status' => 500 )
-		);
-	}
-
-	$order->set_status( 'refunded', 'Full refund issued by artist.' );
-	$order->save();
-
-	return rest_ensure_response( array(
-		'success'       => true,
-		'order_id'      => $order_id,
-		'refund_amount' => $refund_amount,
-	) );
+	return rest_ensure_response( $result );
 }
 
 /**

--- a/inc/routes/shop/product-images.php
+++ b/inc/routes/shop/product-images.php
@@ -117,133 +117,26 @@ function extrachill_api_shop_product_images_set_ordered_ids( $product_id, $order
 
 /**
  * Handle POST /shop/products/{id}/images.
+ *
+ * Wraps the extrachill/shop-upload-product-image ability from extrachill-shop.
  */
 function extrachill_api_shop_product_images_upload_handler( WP_REST_Request $request ) {
-	$product_id = absint( $request->get_param( 'id' ) );
-
-	$files = $request->get_file_params();
-	if ( empty( $files['files'] ) && isset( $_FILES['files'] ) ) {
-		$files['files'] = $_FILES['files'];
+	$ability = wp_get_ability( 'extrachill/shop-upload-product-image' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-shop plugin is required.', array( 'status' => 500 ) );
 	}
 
-	if ( empty( $files['files'] ) || empty( $files['files']['name'] ) ) {
-		return new WP_Error(
-			'no_files',
-			'No files uploaded.',
-			array( 'status' => 400 )
-		);
+	$result = $ability->execute(
+		array(
+			'id'      => absint( $request->get_param( 'id' ) ),
+			'request' => $request,
+		)
+	);
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	$allowed_types = array( 'image/jpeg', 'image/png', 'image/gif', 'image/webp' );
-	$max_size      = 5 * 1024 * 1024;
-
-	$product_post = get_post( $product_id );
-	if ( ! $product_post || 'product' !== $product_post->post_type ) {
-		return new WP_Error(
-			'product_not_found',
-			'Product not found.',
-			array( 'status' => 404 )
-		);
-	}
-
-	$current_ids = extrachill_api_shop_product_images_get_ordered_ids( $product_id );
-	if ( count( $current_ids ) >= 5 ) {
-		return new WP_Error(
-			'image_limit_reached',
-			'you already have five images. please delete one before uploading another',
-			array( 'status' => 400 )
-		);
-	}
-
-	$file_count = is_array( $files['files']['name'] ) ? count( $files['files']['name'] ) : 1;
-	$incoming   = array();
-
-	for ( $i = 0; $i < $file_count; $i++ ) {
-		if ( count( $incoming ) + count( $current_ids ) >= 5 ) {
-			break;
-		}
-
-		$uploaded_file = array(
-			'name'     => is_array( $files['files']['name'] ) ? $files['files']['name'][ $i ] : $files['files']['name'],
-			'type'     => is_array( $files['files']['type'] ) ? $files['files']['type'][ $i ] : $files['files']['type'],
-			'tmp_name' => is_array( $files['files']['tmp_name'] ) ? $files['files']['tmp_name'][ $i ] : $files['files']['tmp_name'],
-			'error'    => is_array( $files['files']['error'] ) ? $files['files']['error'][ $i ] : $files['files']['error'],
-			'size'     => is_array( $files['files']['size'] ) ? $files['files']['size'][ $i ] : $files['files']['size'],
-		);
-
-		if ( empty( $uploaded_file['name'] ) ) {
-			continue;
-		}
-
-		$file_type = wp_check_filetype_and_ext( $uploaded_file['tmp_name'], $uploaded_file['name'] );
-		if ( ! in_array( $file_type['type'], $allowed_types, true ) ) {
-			return new WP_Error(
-				'invalid_file_type',
-				'Invalid file type. Only JPG, PNG, GIF, and WebP are allowed.',
-				array( 'status' => 400 )
-			);
-		}
-
-		if ( $uploaded_file['size'] > $max_size ) {
-			return new WP_Error(
-				'file_too_large',
-				'File size exceeds the 5MB limit.',
-				array( 'status' => 400 )
-			);
-		}
-
-		if ( ! function_exists( 'wp_handle_upload' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-
-		$upload_result = wp_handle_upload( $uploaded_file, array( 'test_form' => false ) );
-		if ( ! $upload_result || isset( $upload_result['error'] ) ) {
-			return new WP_Error(
-				'upload_failed',
-				isset( $upload_result['error'] ) ? $upload_result['error'] : 'Upload failed.',
-				array( 'status' => 500 )
-			);
-		}
-
-		$attachment = array(
-			'guid'           => $upload_result['url'],
-			'post_mime_type' => $upload_result['type'],
-			'post_title'     => preg_replace( '/\.[^.]+$/', '', basename( $upload_result['file'] ) ),
-			'post_content'   => '',
-			'post_status'    => 'inherit',
-		);
-
-		$attachment_id = wp_insert_attachment( $attachment, $upload_result['file'], $product_id );
-		if ( is_wp_error( $attachment_id ) ) {
-			return $attachment_id;
-		}
-
-		require_once ABSPATH . 'wp-admin/includes/image.php';
-		$attach_data = wp_generate_attachment_metadata( $attachment_id, $upload_result['file'] );
-		wp_update_attachment_metadata( $attachment_id, $attach_data );
-
-		$incoming[] = (int) $attachment_id;
-	}
-
-	if ( empty( $incoming ) ) {
-		return new WP_Error(
-			'no_files',
-			'No files uploaded.',
-			array( 'status' => 400 )
-		);
-	}
-
-	$new_order = array_merge( $current_ids, $incoming );
-	$set_order = extrachill_api_shop_product_images_set_ordered_ids( $product_id, $new_order );
-	if ( is_wp_error( $set_order ) ) {
-		return $set_order;
-	}
-
-	$response = function_exists( 'extrachill_api_shop_products_build_response' )
-		? extrachill_api_shop_products_build_response( $product_id )
-		: array( 'product_id' => $product_id );
-
-	return rest_ensure_response( $response );
+	return rest_ensure_response( $result );
 }
 
 /**

--- a/inc/routes/shop/products.php
+++ b/inc/routes/shop/products.php
@@ -448,45 +448,21 @@ function extrachill_api_shop_products_item_permission_check( WP_REST_Request $re
 
 /**
  * Handle GET /shop/products - List products.
+ *
+ * Wraps the extrachill/shop-list-products ability from extrachill-shop.
  */
 function extrachill_api_shop_products_list_handler( WP_REST_Request $request ) {
-	$artist_ids = extrachill_api_shop_get_user_artist_ids();
-
-	$query_args = array(
-		'post_type'      => 'product',
-		'post_status'    => array( 'publish', 'pending', 'draft' ),
-		'posts_per_page' => -1,
-	);
-
-	if ( ! current_user_can( 'manage_options' ) ) {
-		if ( empty( $artist_ids ) ) {
-			return rest_ensure_response( array() );
-		}
-
-		$artist_ids = array_map( 'absint', $artist_ids );
-		$query_args['meta_query'] = array(
-			array(
-				'key'     => '_artist_profile_id',
-				'value'   => $artist_ids,
-				'compare' => 'IN',
-				'type'    => 'NUMERIC',
-			),
-		);
+	$ability = wp_get_ability( 'extrachill/shop-list-products' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-shop plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$query    = new WP_Query( $query_args );
-	$products = $query->posts;
-	$response = array();
-
-	foreach ( $products as $product_post ) {
-		$product_response = extrachill_api_shop_products_build_response( $product_post->ID );
-		if ( is_wp_error( $product_response ) ) {
-			return $product_response;
-		}
-		$response[] = $product_response;
+	$result = $ability->execute( array() );
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	return rest_ensure_response( $response );
+	return rest_ensure_response( $result );
 }
 
 /**
@@ -578,12 +554,21 @@ function extrachill_api_shop_products_create_handler( WP_REST_Request $request )
 
 /**
  * Handle GET /shop/products/{id} - Get single product.
+ *
+ * Wraps the extrachill/shop-get-product ability from extrachill-shop.
  */
 function extrachill_api_shop_products_get_handler( WP_REST_Request $request ) {
-	$product_id = $request->get_param( 'id' );
+	$ability = wp_get_ability( 'extrachill/shop-get-product' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-shop plugin is required.', array( 'status' => 500 ) );
+	}
 
-	$response = extrachill_api_shop_products_build_response( $product_id );
-	return is_wp_error( $response ) ? $response : rest_ensure_response( $response );
+	$result = $ability->execute( array( 'id' => absint( $request->get_param( 'id' ) ) ) );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }
 
 /**

--- a/inc/routes/shop/shipping-address.php
+++ b/inc/routes/shop/shipping-address.php
@@ -133,50 +133,51 @@ function extrachill_api_shipping_address_permission_check( WP_REST_Request $requ
 
 /**
  * Handle GET /shop/shipping-address - Get artist shipping address.
+ *
+ * Wraps the extrachill/shop-get-shipping-address ability from extrachill-shop.
  */
 function extrachill_api_shipping_address_get_handler( WP_REST_Request $request ) {
-	$artist_id = absint( $request->get_param( 'artist_id' ) );
+	$ability = wp_get_ability( 'extrachill/shop-get-shipping-address' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-shop plugin is required.', array( 'status' => 500 ) );
+	}
 
-	$address = extrachill_api_get_artist_shipping_address( $artist_id );
+	$result = $ability->execute( array( 'artist_id' => absint( $request->get_param( 'artist_id' ) ) ) );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
 
-	return rest_ensure_response( array(
-		'artist_id' => $artist_id,
-		'address'   => $address,
-		'is_set'    => ! empty( $address['name'] ) && ! empty( $address['street1'] ),
-	) );
+	return rest_ensure_response( $result );
 }
 
 /**
  * Handle PUT /shop/shipping-address - Update artist shipping address.
+ *
+ * Wraps the extrachill/shop-update-shipping-address ability from extrachill-shop.
  */
 function extrachill_api_shipping_address_update_handler( WP_REST_Request $request ) {
-	$artist_id = absint( $request->get_param( 'artist_id' ) );
-
-	$address = array(
-		'name'    => $request->get_param( 'name' ),
-		'street1' => $request->get_param( 'street1' ),
-		'street2' => $request->get_param( 'street2' ) ?: '',
-		'city'    => $request->get_param( 'city' ),
-		'state'   => strtoupper( $request->get_param( 'state' ) ),
-		'zip'     => $request->get_param( 'zip' ),
-		'country' => 'US',
-	);
-
-	$saved = extrachill_api_save_artist_shipping_address( $artist_id, $address );
-
-	if ( ! $saved ) {
-		return new WP_Error(
-			'save_failed',
-			'Failed to save shipping address.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/shop-update-shipping-address' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-shop plugin is required.', array( 'status' => 500 ) );
 	}
 
-	return rest_ensure_response( array(
-		'success'   => true,
-		'artist_id' => $artist_id,
-		'address'   => $address,
-	) );
+	$result = $ability->execute(
+		array(
+			'artist_id' => absint( $request->get_param( 'artist_id' ) ),
+			'name'      => $request->get_param( 'name' ),
+			'street1'   => $request->get_param( 'street1' ),
+			'street2'   => $request->get_param( 'street2' ),
+			'city'      => $request->get_param( 'city' ),
+			'state'     => $request->get_param( 'state' ),
+			'zip'       => $request->get_param( 'zip' ),
+			'country'   => $request->get_param( 'country' ),
+		)
+	);
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }
 
 /**

--- a/inc/routes/shop/shipping-labels.php
+++ b/inc/routes/shop/shipping-labels.php
@@ -110,42 +110,26 @@ function extrachill_api_shipping_labels_permission_check( WP_REST_Request $reque
 
 /**
  * Handle GET /shop/shipping-labels/{order_id} - Get existing label for order.
+ *
+ * Wraps the extrachill/shop-get-shipping-label ability from extrachill-shop.
  */
 function extrachill_api_shipping_labels_get_handler( WP_REST_Request $request ) {
-	$order_id  = absint( $request->get_param( 'order_id' ) );
-	$artist_id = absint( $request->get_param( 'artist_id' ) );
-
-	if ( ! function_exists( 'wc_get_order' ) ) {
-		return new WP_Error(
-			'woocommerce_missing',
-			'WooCommerce is not available.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/shop-get-shipping-label' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-shop plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$order = wc_get_order( $order_id );
-	if ( ! $order ) {
-		return new WP_Error(
-			'order_not_found',
-			'Order not found.',
-			array( 'status' => 404 )
-		);
+	$result = $ability->execute(
+		array(
+			'order_id'  => absint( $request->get_param( 'order_id' ) ),
+			'artist_id' => absint( $request->get_param( 'artist_id' ) ),
+		)
+	);
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	$label_url       = $order->get_meta( '_artist_label_' . $artist_id ) ?: '';
-	$tracking_number = $order->get_meta( '_artist_tracking_' . $artist_id ) ?: '';
-	$label_data      = $order->get_meta( '_artist_label_data_' . $artist_id ) ?: array();
-
-	return rest_ensure_response( array(
-		'order_id'        => $order_id,
-		'artist_id'       => $artist_id,
-		'has_label'       => ! empty( $label_url ),
-		'label_url'       => $label_url,
-		'tracking_number' => $tracking_number,
-		'carrier'         => $label_data['carrier'] ?? '',
-		'service'         => $label_data['service'] ?? '',
-		'cost'            => $label_data['cost'] ?? 0,
-	) );
+	return rest_ensure_response( $result );
 }
 
 /**

--- a/inc/routes/shop/stripe-connect.php
+++ b/inc/routes/shop/stripe-connect.php
@@ -107,200 +107,65 @@ function extrachill_api_stripe_connect_permission( $request ) {
 /**
  * Get Stripe account status for an artist profile.
  *
+ * Wraps the extrachill/shop-stripe-status ability from extrachill-shop.
+ *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response.
  */
 function extrachill_api_get_stripe_status( $request ) {
-	$artist_id = absint( $request->get_param( 'artist_id' ) );
-
-	if ( ! function_exists( 'ec_get_blog_id' ) ) {
-		return new WP_Error(
-			'configuration_error',
-			'Artist blog is not configured.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/shop-stripe-status' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-shop plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$artist_blog_id = ec_get_blog_id( 'artist' );
-	if ( ! $artist_blog_id ) {
-		return new WP_Error(
-			'configuration_error',
-			'Artist blog is not configured.',
-			array( 'status' => 500 )
-		);
+	$result = $ability->execute( array( 'artist_id' => absint( $request->get_param( 'artist_id' ) ) ) );
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	switch_to_blog( $artist_blog_id );
-	try {
-		$account_id = (string) get_post_meta( $artist_id, '_stripe_connect_account_id', true );
-	} finally {
-		restore_current_blog();
-	}
-
-	if ( empty( $account_id ) ) {
-		return rest_ensure_response(
-			array(
-				'connected'            => false,
-				'account_id'           => null,
-				'status'               => null,
-				'can_receive_payments' => false,
-			)
-		);
-	}
-
-	if ( ! function_exists( 'extrachill_shop_get_account_status' ) ) {
-		return new WP_Error(
-			'stripe_not_available',
-			'Stripe integration is not available.',
-			array( 'status' => 500 )
-		);
-	}
-
-	$status = extrachill_shop_get_account_status( $account_id );
-
-	if ( ! $status['success'] ) {
-		return new WP_Error(
-			'stripe_status_check_failed',
-			$status['error'],
-			array( 'status' => 500 )
-		);
-	}
-
-	$safe_status = isset( $status['status'] ) ? (string) $status['status'] : '';
-	if ( $safe_status ) {
-		switch_to_blog( $artist_blog_id );
-		try {
-			update_post_meta( $artist_id, '_stripe_connect_status', $safe_status );
-			update_post_meta( $artist_id, '_stripe_connect_onboarding_complete', ! empty( $status['details_submitted'] ) ? '1' : '0' );
-		} finally {
-			restore_current_blog();
-		}
-	}
-
-	return rest_ensure_response(
-		array(
-			'connected'            => true,
-			'account_id'           => $account_id,
-			'status'               => $safe_status,
-			'can_receive_payments' => ! empty( $status['can_receive_payments'] ),
-			'charges_enabled'      => ! empty( $status['charges_enabled'] ),
-			'payouts_enabled'      => ! empty( $status['payouts_enabled'] ),
-			'details_submitted'    => ! empty( $status['details_submitted'] ),
-		)
-	);
+	return rest_ensure_response( $result );
 }
 
 /**
  * Get Stripe onboarding link for an artist profile.
  *
- * Creates account if needed, then returns onboarding URL.
+ * Wraps the extrachill/shop-stripe-onboarding-link ability from extrachill-shop.
  *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response.
  */
 function extrachill_api_get_onboarding_link( $request ) {
-	$artist_id = absint( $request->get_param( 'artist_id' ) );
-
-	if ( ! function_exists( 'extrachill_shop_create_stripe_account' ) ) {
-		return new WP_Error(
-			'stripe_not_available',
-			'Stripe integration is not available.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/shop-stripe-onboarding-link' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-shop plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$result = extrachill_shop_create_stripe_account( $artist_id );
-	if ( ! $result['success'] ) {
-		return new WP_Error(
-			'stripe_account_creation_failed',
-			$result['error'],
-			array( 'status' => 500 )
-		);
+	$result = $ability->execute( array( 'artist_id' => absint( $request->get_param( 'artist_id' ) ) ) );
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	$account_id = $result['account_id'];
-
-	$link_result = extrachill_shop_create_account_link( $account_id, 'account_onboarding' );
-
-	if ( ! $link_result['success'] ) {
-		return new WP_Error(
-			'stripe_link_creation_failed',
-			$link_result['error'],
-			array( 'status' => 500 )
-		);
-	}
-
-	return rest_ensure_response(
-		array(
-			'success' => true,
-			'url'     => $link_result['url'],
-		)
-	);
+	return rest_ensure_response( $result );
 }
 
 /**
  * Get Stripe dashboard link for an artist profile.
  *
+ * Wraps the extrachill/shop-stripe-dashboard-link ability from extrachill-shop.
+ *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response.
  */
 function extrachill_api_get_dashboard_link( $request ) {
-	$artist_id = absint( $request->get_param( 'artist_id' ) );
-
-	if ( ! function_exists( 'ec_get_blog_id' ) ) {
-		return new WP_Error(
-			'configuration_error',
-			'Artist blog is not configured.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/shop-stripe-dashboard-link' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-shop plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$artist_blog_id = ec_get_blog_id( 'artist' );
-	if ( ! $artist_blog_id ) {
-		return new WP_Error(
-			'configuration_error',
-			'Artist blog is not configured.',
-			array( 'status' => 500 )
-		);
+	$result = $ability->execute( array( 'artist_id' => absint( $request->get_param( 'artist_id' ) ) ) );
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	switch_to_blog( $artist_blog_id );
-	try {
-		$account_id = (string) get_post_meta( $artist_id, '_stripe_connect_account_id', true );
-	} finally {
-		restore_current_blog();
-	}
-
-	if ( empty( $account_id ) ) {
-		return new WP_Error(
-			'no_stripe_account',
-			'No Stripe account connected.',
-			array( 'status' => 400 )
-		);
-	}
-
-	if ( ! function_exists( 'extrachill_shop_create_dashboard_link' ) ) {
-		return new WP_Error(
-			'stripe_not_available',
-			'Stripe integration is not available.',
-			array( 'status' => 500 )
-		);
-	}
-
-	$link_result = extrachill_shop_create_dashboard_link( $account_id );
-
-	if ( ! $link_result['success'] ) {
-		return new WP_Error(
-			'stripe_dashboard_link_failed',
-			$link_result['error'],
-			array( 'status' => 500 )
-		);
-	}
-
-	return rest_ensure_response(
-		array(
-			'success' => true,
-			'url'     => $link_result['url'],
-		)
-	);
+	return rest_ensure_response( $result );
 }


### PR DESCRIPTION
## Summary

Refactors shop-domain REST route handlers to delegate to the matching abilities registered in `extrachill-shop` (merged in shop#5), following the canonical pattern from `inc/routes/admin/artist-access.php`.

- **12 route handlers refactored** to the 6-line `wp_get_ability()` → `execute()` → `rest_ensure_response()` pattern
- **Permission callbacks, args, validation** all untouched
- **Route URLs unchanged** — all `/extrachill/v1/shop/*` endpoints keep working identically
- `-534` lines of inline implementation replaced by `+152` lines of ability shims

## Routes refactored

| File | Handler → Ability |
|---|---|
| `products.php` | `list_handler` → `extrachill/shop-list-products` |
| `products.php` | `get_handler` → `extrachill/shop-get-product` |
| `product-images.php` | `upload_handler` → `extrachill/shop-upload-product-image` |
| `orders.php` | `list_handler` → `extrachill/shop-list-orders` |
| `orders.php` | `status_handler` → `extrachill/shop-update-order-status` |
| `orders.php` | `refund_handler` → `extrachill/shop-refund-order` |
| `shipping-address.php` | `get_handler` → `extrachill/shop-get-shipping-address` |
| `shipping-address.php` | `update_handler` → `extrachill/shop-update-shipping-address` |
| `shipping-labels.php` | `get_handler` → `extrachill/shop-get-shipping-label` |
| `stripe-connect.php` | `get_stripe_status` → `extrachill/shop-stripe-status` |
| `stripe-connect.php` | `get_onboarding_link` → `extrachill/shop-stripe-onboarding-link` |
| `stripe-connect.php` | `get_dashboard_link` → `extrachill/shop-stripe-dashboard-link` |

## Routes left as-is (no matching ability)

| Route | Reason |
|---|---|
| `POST /shop/products` (create) | No ability registered in shop#5 |
| `PUT /shop/products/{id}` (update) | No ability registered in shop#5 |
| `DELETE /shop/products/{id}` (delete) | No ability registered in shop#5 |
| `DELETE /shop/products/{id}/images/{attachment_id}` | No ability registered in shop#5 |
| `POST /shop/shipping-labels` (create label) | No ability registered in shop#5 |
| `POST /shop/stripe-webhook` | No ability (webhook passthrough) |
| `GET /shop/taxonomy-counts` | Already uses `extrachill/taxonomy-post-counts` ability |

## Verification

- `find inc -name '*.php' -exec php -l {} \;` — zero syntax errors

Closes #26 (shop domain batch).