### PR TITLE
refactor(routes/artists): invoke abilities (#26)

### DIFF
--- a/inc/routes/artists/artist.php
+++ b/inc/routes/artists/artist.php
@@ -158,7 +158,7 @@ function extrachill_api_artist_permission_check( WP_REST_Request $request ) {
 function extrachill_api_artist_get_handler( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/get-artist-data' );
 	if ( ! $ability ) {
-		return new WP_Error( 'ability_missing', 'Artist data ability not available.', array( 'status' => 500 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute( array( 'artist_id' => $request->get_param( 'id' ) ) );
@@ -177,7 +177,7 @@ function extrachill_api_artist_get_handler( WP_REST_Request $request ) {
 function extrachill_api_artist_post_handler( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/create-artist' );
 	if ( ! $ability ) {
-		return new WP_Error( 'ability_missing', 'Create artist ability not available.', array( 'status' => 500 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$input = array( 'name' => $request->get_param( 'name' ) );
@@ -206,7 +206,7 @@ function extrachill_api_artist_post_handler( WP_REST_Request $request ) {
 function extrachill_api_artist_put_handler( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/update-artist' );
 	if ( ! $ability ) {
-		return new WP_Error( 'ability_missing', 'Update artist ability not available.', array( 'status' => 500 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$body = $request->get_json_params();

--- a/inc/routes/artists/links.php
+++ b/inc/routes/artists/links.php
@@ -95,7 +95,7 @@ function extrachill_api_artist_links_permission_check( WP_REST_Request $request 
 function extrachill_api_artist_links_get_handler( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/get-link-page-data' );
 	if ( ! $ability ) {
-		return new WP_Error( 'ability_missing', 'Link page data ability not available.', array( 'status' => 500 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute( array( 'artist_id' => $request->get_param( 'id' ) ) );
@@ -142,7 +142,7 @@ function extrachill_api_artist_links_put_handler( WP_REST_Request $request ) {
 
 		$ability = wp_get_ability( 'extrachill/save-link-page-links' );
 		if ( ! $ability ) {
-			return new WP_Error( 'ability_missing', 'Save links ability not available.', array( 'status' => 500 ) );
+			return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 		}
 
 		$result = $ability->execute(
@@ -165,7 +165,7 @@ function extrachill_api_artist_links_put_handler( WP_REST_Request $request ) {
 
 		$ability = wp_get_ability( 'extrachill/save-link-page-styles' );
 		if ( ! $ability ) {
-			return new WP_Error( 'ability_missing', 'Save styles ability not available.', array( 'status' => 500 ) );
+			return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 		}
 
 		$result = $ability->execute(
@@ -189,7 +189,7 @@ function extrachill_api_artist_links_put_handler( WP_REST_Request $request ) {
 
 		$ability = wp_get_ability( 'extrachill/save-link-page-settings' );
 		if ( ! $ability ) {
-			return new WP_Error( 'ability_missing', 'Save settings ability not available.', array( 'status' => 500 ) );
+			return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 		}
 
 		$settings_input = array( 'artist_id' => $artist_id );
@@ -218,7 +218,7 @@ function extrachill_api_artist_links_put_handler( WP_REST_Request $request ) {
 
 		$ability = wp_get_ability( 'extrachill/save-social-links' );
 		if ( ! $ability ) {
-			return new WP_Error( 'ability_missing', 'Save socials ability not available.', array( 'status' => 500 ) );
+			return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 		}
 
 		$result = $ability->execute(
@@ -236,7 +236,7 @@ function extrachill_api_artist_links_put_handler( WP_REST_Request $request ) {
 	// Return fresh data via read ability.
 	$read_ability = wp_get_ability( 'extrachill/get-link-page-data' );
 	if ( ! $read_ability ) {
-		return new WP_Error( 'ability_missing', 'Link page data ability not available.', array( 'status' => 500 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$fresh_data = $read_ability->execute( array( 'artist_id' => $artist_id ) );

--- a/inc/routes/artists/socials.php
+++ b/inc/routes/artists/socials.php
@@ -118,7 +118,7 @@ function extrachill_api_artist_socials_put_handler( WP_REST_Request $request ) {
 
 	$ability = wp_get_ability( 'extrachill/save-social-links' );
 	if ( ! $ability ) {
-		return new WP_Error( 'ability_missing', 'Save social links ability not available.', array( 'status' => 500 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute(


### PR DESCRIPTION
## Summary

Batch 2 of the [REST routes → ability shims umbrella (#26)](https://github.com/Extra-Chill/extrachill-api/issues/26). Audits all artists-domain routes, confirms ability invocations follow the canonical pattern, and normalizes error handling.

## Changes

Normalizes `ability_not_found` error code and message across all 10 ability invocations in artist routes to match the canonical pattern from `admin/artist-access.php`:

| File | Handlers | Abilities invoked | Change |
|---|---|---|---|
| `artist.php` | GET, POST, PUT | `get-artist-data`, `create-artist`, `update-artist` | `ability_missing` → `ability_not_found` |
| `links.php` | GET, PUT | `get-link-page-data`, `save-link-page-links`, `save-link-page-styles`, `save-link-page-settings`, `save-social-links` | `ability_missing` → `ability_not_found` |
| `socials.php` | PUT | `save-social-links` | `ability_missing` → `ability_not_found` |

## Unchanged

- **Permission callbacks** — all untouched
- **Args / validation** — all untouched
- **Route registrations** (URLs, methods) — all untouched
- **Error-code-to-status mapping** in handlers — kept as-is (transport-specific concern)

## Gaps (no matching ability registered)

These route handlers still own their implementation via `apply_filters()` or direct function calls. They will be refactored when matching abilities are registered in `extrachill-artist-platform`:

| File | Route | Current mechanism | Missing ability |
|---|---|---|---|
| `analytics.php` | `GET /artists/{id}/analytics` | `apply_filters('extrachill_get_link_page_analytics')` | `extrachill/get-link-page-analytics` |
| `subscribers.php` | `GET /artists/{id}/subscribers` | `apply_filters('extrachill_get_artist_subscribers')` | `extrachill/list-artist-subscribers` |
| `subscribers.php` | `GET /artists/{id}/subscribers/export` | `apply_filters('extrachill_export_artist_subscribers')` | `extrachill/export-artist-subscribers` |
| `subscribe.php` | `POST /artists/{id}/subscribe` | `apply_filters('extrachill_artist_subscribe')` | `extrachill/artist-subscribe` |
| `roster.php` | `GET /artists/{id}/roster` | direct `ec_get_linked_members()` + `ec_get_pending_invitations()` | `extrachill/list-roster` |
| `roster.php` | `POST /artists/{id}/roster` | `apply_filters('extrachill_artist_invite_member')` | `extrachill/invite-roster-member` |
| `roster.php` | `DELETE /artists/{id}/roster/{user_id}` | direct `ec_remove_artist_membership()` | `extrachill/remove-roster-member` |
| `roster.php` | `DELETE /artists/{id}/roster/invites/{invite_id}` | direct `ec_remove_pending_invitation()` | `extrachill/cancel-roster-invite` |
| `permissions.php` | `GET /artists/{id}/permissions` | direct implementation | `extrachill/check-artist-permissions` |
| `socials.php` | `GET /artists/{id}/socials` | direct `extrachill_artist_platform_social_links()` | `extrachill/get-social-links` |

## Testing

- `find inc -name '*.php' -exec php -l {} \;` — no syntax errors