### PR TITLE
refactor(routes/events): invoke abilities (#26)

### DIFF
--- a/inc/routes/events/calendar.php
+++ b/inc/routes/events/calendar.php
@@ -97,172 +97,32 @@ function extrachill_api_register_events_calendar_route() {
 /**
  * Handle calendar request.
  *
- * Executes the calendar ability and transforms the output into the
- * api-client CalendarResponse shape. Route affinity middleware ensures
- * this runs on the events site where the ability and taxonomies exist.
+ * Invokes the extrachill/events-calendar ability (registered in extrachill-events).
+ * Route affinity middleware ensures this runs on the events site.
  *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response data or error.
  */
 function extrachill_api_events_calendar_handler( WP_REST_Request $request ) {
-	$ability = wp_get_ability( 'data-machine-events/get-calendar-page' );
+	$ability = wp_get_ability( 'extrachill/events-calendar' );
 	if ( ! $ability ) {
-		return new WP_Error(
-			'ability_unavailable',
-			__( 'Calendar ability is not registered.', 'extrachill-api' ),
-			array( 'status' => 500 )
-		);
+		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$input = array(
-		'paged'        => $request->get_param( 'page' ) ?: 1,
-		'include_html' => false,
-		'include_gaps' => false,
-		'past'         => (bool) $request->get_param( 'past' ),
-	);
+	$input = array();
 
-	$scope = $request->get_param( 'scope' );
-	if ( $scope ) {
-		$input['scope'] = $scope;
-	}
-
-	$search = $request->get_param( 'search' );
-	if ( $search ) {
-		$input['event_search'] = $search;
-	}
-
-	// Build taxonomy filter from slug params.
-	$tax_filter = extrachill_api_build_calendar_tax_filter( $request );
-	if ( ! empty( $tax_filter ) ) {
-		$input['tax_filter'] = $tax_filter;
-	}
-
-	// Geo params.
-	$lat = $request->get_param( 'lat' );
-	$lng = $request->get_param( 'lng' );
-	if ( null !== $lat && null !== $lng ) {
-		$input['geo_lat']    = (float) $lat;
-		$input['geo_lng']    = (float) $lng;
-		$input['geo_radius'] = $request->get_param( 'radius' ) ?: 25;
+	$params = array( 'page', 'venue', 'promoter', 'location', 'scope', 'lat', 'lng', 'radius', 'search', 'past' );
+	foreach ( $params as $key ) {
+		$value = $request->get_param( $key );
+		if ( null !== $value ) {
+			$input[ $key ] = $value;
+		}
 	}
 
 	$result = $ability->execute( $input );
-
 	if ( is_wp_error( $result ) ) {
-		return new WP_Error(
-			'calendar_error',
-			$result->get_error_message(),
-			array( 'status' => 500 )
-		);
+		return $result;
 	}
 
-	return rest_ensure_response( extrachill_api_transform_calendar_response( $result ) );
-}
-
-/**
- * Build taxonomy filter array from request slug parameters.
- *
- * Resolves taxonomy slugs to term IDs for the ability input.
- *
- * @param WP_REST_Request $request Request object.
- * @return array Taxonomy filter array [taxonomy => [term_ids]].
- */
-function extrachill_api_build_calendar_tax_filter( WP_REST_Request $request ): array {
-	$tax_filter = array();
-	$mappings   = array(
-		'venue'    => 'venue',
-		'promoter' => 'promoter',
-		'location' => 'location',
-	);
-
-	foreach ( $mappings as $param => $taxonomy ) {
-		$slug = $request->get_param( $param );
-		if ( empty( $slug ) ) {
-			continue;
-		}
-
-		$term = get_term_by( 'slug', $slug, $taxonomy );
-		if ( $term && ! is_wp_error( $term ) ) {
-			$tax_filter[ $taxonomy ] = array( $term->term_id );
-		}
-	}
-
-	return $tax_filter;
-}
-
-/**
- * Transform ability output into CalendarResponse shape.
- *
- * Ability returns: { paged_date_groups, current_page, max_pages, total_event_count, ... }
- * Client expects: { dates, total, page, has_more }
- *
- * @param array $result Ability output.
- * @return array Transformed response.
- */
-function extrachill_api_transform_calendar_response( array $result ): array {
-	$dates = array();
-
-	foreach ( $result['paged_date_groups'] as $group ) {
-		$date_obj = date_create( $group['date'] );
-		$label    = $date_obj ? $date_obj->format( 'l, F j, Y' ) : $group['date'];
-
-		$events = array();
-		foreach ( $group['events'] as $event ) {
-			$event_data = $event['event_data'] ?? array();
-			$post_id    = $event['post_id'];
-
-			// Build datetime from startDate + startTime block attributes.
-			$datetime = '';
-			if ( ! empty( $event_data['startDate'] ) ) {
-				$time     = $event_data['startTime'] ?? '00:00:00';
-				$datetime = $event_data['startDate'] . 'T' . $time;
-			}
-
-			$end_datetime = null;
-			if ( ! empty( $event_data['endDate'] ) ) {
-				$end_time     = $event_data['endTime'] ?? '23:59:59';
-				$end_datetime = $event_data['endDate'] . 'T' . $end_time;
-			}
-
-			// Resolve venue from post terms (event_data.venue is just a string name).
-			$venue_data  = null;
-			$venue_terms = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'all' ) );
-			if ( ! empty( $venue_terms ) && ! is_wp_error( $venue_terms ) ) {
-				$venue_data = array(
-					'id'   => $venue_terms[0]->term_id,
-					'name' => $venue_terms[0]->name,
-					'slug' => $venue_terms[0]->slug,
-				);
-			}
-
-			// Ticket URL from block attributes or post meta.
-			$ticket_url = $event_data['ticketUrl'] ?? null;
-			if ( empty( $ticket_url ) ) {
-				$ticket_url = get_post_meta( $post_id, '_datamachine_ticket_url', true ) ?: null;
-			}
-
-			$events[] = array(
-				'id'           => $post_id,
-				'title'        => $event['title'],
-				'datetime'     => $datetime,
-				'end_datetime' => $end_datetime,
-				'venue'        => $venue_data,
-				'ticket_url'   => $ticket_url,
-				'permalink'    => get_permalink( $post_id ),
-			);
-		}
-
-		$dates[] = array(
-			'date'   => $group['date'],
-			'label'  => $label,
-			'events' => $events,
-		);
-	}
-
-	return array(
-		'dates'    => $dates,
-		'total'    => $result['total_event_count'] ?? 0,
-		'page'     => $result['current_page'] ?? 1,
-		'has_more' => ( $result['current_page'] ?? 1 ) < ( $result['max_pages'] ?? 1 ),
-	);
+	return rest_ensure_response( $result );
 }

--- a/inc/routes/events/concert-tracking.php
+++ b/inc/routes/events/concert-tracking.php
@@ -2,8 +2,8 @@
 /**
  * REST routes: Concert tracking (attendance toggle, event info, user shows, user stats).
  *
- * Thin wrappers around extrachill-users concert tracking abilities.
- * All business logic lives in extrachill-users/inc/concert-tracking/service.php.
+ * Thin REST wrappers that invoke extrachill-users concert tracking abilities.
+ * All business logic lives in extrachill-users via the Abilities API.
  *
  * Endpoints:
  *   POST /extrachill/v1/concert-tracking/toggle
@@ -177,140 +177,118 @@ function extrachill_api_register_concert_tracking_routes() {
 /**
  * Handle POST /concert-tracking/toggle.
  *
+ * Invokes the extrachill/toggle-event-mark ability (registered in extrachill-users).
+ *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_handle_concert_tracking_toggle( WP_REST_Request $request ) {
-	if ( ! function_exists( 'ec_users_toggle_event' ) ) {
-		return new WP_Error(
-			'dependency_missing',
-			'Concert tracking requires the Extra Chill Users plugin.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/toggle-event-mark' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$user_id  = get_current_user_id();
-	$event_id = (int) $request->get_param( 'event_id' );
-	$blog_id  = (int) $request->get_param( 'blog_id' );
-
-	if ( ! $blog_id ) {
-		$blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : get_current_blog_id();
-	}
-
-	$result = ec_users_toggle_event( $user_id, $event_id, $blog_id );
-	$count  = ec_users_get_event_mark_count( $event_id, $blog_id );
-	$timing = ec_users_get_event_timing( $event_id );
-
-	return rest_ensure_response(
-		array(
-			'marked'      => $result['marked'],
-			'count'       => $count,
-			'count_label' => ec_users_format_count_label( $count, $timing ),
-			'timing'      => $timing,
-		)
+	$input = array(
+		'event_id' => (int) $request->get_param( 'event_id' ),
 	);
+
+	$blog_id = (int) $request->get_param( 'blog_id' );
+	if ( $blog_id ) {
+		$input['blog_id'] = $blog_id;
+	}
+
+	$result = $ability->execute( $input );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }
 
 /**
  * Handle GET /concert-tracking/event/{id}.
  *
+ * Invokes the extrachill/get-event-attendance ability (registered in extrachill-users).
+ *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_handle_concert_tracking_event( WP_REST_Request $request ) {
-	if ( ! function_exists( 'ec_users_get_event_mark_count' ) ) {
-		return new WP_Error(
-			'dependency_missing',
-			'Concert tracking requires the Extra Chill Users plugin.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/get-event-attendance' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$event_id = (int) $request->get_param( 'event_id' );
-	$blog_id  = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : get_current_blog_id();
-
-	$count  = ec_users_get_event_mark_count( $event_id, $blog_id );
-	$timing = ec_users_get_event_timing( $event_id );
-
-	$data = array(
-		'count'       => $count,
-		'count_label' => ec_users_format_count_label( $count, $timing ),
-		'timing'      => $timing,
-		'user_marked' => false,
-		'attendees'   => array(),
+	$input = array(
+		'event_id' => (int) $request->get_param( 'event_id' ),
 	);
 
-	if ( is_user_logged_in() ) {
-		$data['user_marked'] = ec_users_is_event_marked( get_current_user_id(), $event_id, $blog_id );
-	}
-
 	if ( $request->get_param( 'include_attendees' ) ) {
-		$limit             = (int) $request->get_param( 'limit' );
-		$data['attendees'] = ec_users_get_event_attendees( $event_id, $blog_id, $limit );
+		$input['include_attendees'] = true;
+		$input['limit']             = (int) $request->get_param( 'limit' );
 	}
 
-	return rest_ensure_response( $data );
+	$result = $ability->execute( $input );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }
 
 /**
  * Handle GET /concert-tracking/user/{id}/shows.
  *
+ * Invokes the extrachill/get-user-shows ability (registered in extrachill-users).
+ *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_handle_concert_tracking_user_shows( WP_REST_Request $request ) {
-	if ( ! function_exists( 'ec_users_get_user_events' ) ) {
-		return new WP_Error(
-			'dependency_missing',
-			'Concert tracking requires the Extra Chill Users plugin.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/get-user-shows' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$user_id = (int) $request->get_param( 'user_id' );
-
-	if ( ! get_user_by( 'id', $user_id ) ) {
-		return new WP_Error( 'user_not_found', 'User not found.', array( 'status' => 404 ) );
-	}
-
-	$args = array(
+	$result = $ability->execute( array(
+		'user_id'   => (int) $request->get_param( 'user_id' ),
 		'period'    => $request->get_param( 'period' ),
 		'year'      => (int) $request->get_param( 'year' ),
 		'date_from' => $request->get_param( 'date_from' ),
 		'date_to'   => $request->get_param( 'date_to' ),
 		'page'      => (int) $request->get_param( 'page' ),
 		'per_page'  => (int) $request->get_param( 'per_page' ),
-	);
+	) );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
 
-	return rest_ensure_response( ec_users_get_user_events( $user_id, $args ) );
+	return rest_ensure_response( $result );
 }
 
 /**
  * Handle GET /concert-tracking/user/{id}/stats.
  *
+ * Invokes the extrachill/get-user-concert-stats ability (registered in extrachill-users).
+ *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_handle_concert_tracking_user_stats( WP_REST_Request $request ) {
-	if ( ! function_exists( 'ec_users_get_user_concert_stats' ) ) {
-		return new WP_Error(
-			'dependency_missing',
-			'Concert tracking requires the Extra Chill Users plugin.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/get-user-concert-stats' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$user_id = (int) $request->get_param( 'user_id' );
-
-	if ( ! get_user_by( 'id', $user_id ) ) {
-		return new WP_Error( 'user_not_found', 'User not found.', array( 'status' => 404 ) );
-	}
-
-	$args = array(
+	$result = $ability->execute( array(
+		'user_id'   => (int) $request->get_param( 'user_id' ),
 		'year'      => (int) $request->get_param( 'year' ),
 		'date_from' => $request->get_param( 'date_from' ),
 		'date_to'   => $request->get_param( 'date_to' ),
-	);
+	) );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
 
-	return rest_ensure_response( ec_users_get_user_concert_stats( $user_id, $args ) );
+	return rest_ensure_response( $result );
 }

--- a/inc/routes/events/event-submissions.php
+++ b/inc/routes/events/event-submissions.php
@@ -30,13 +30,9 @@ function extrachill_api_register_event_submission_route() {
 }
 
 function extrachill_api_handle_event_submission( WP_REST_Request $request ) {
-	$ability = wp_get_ability( 'extrachill/submit-event' );
+	$ability = wp_get_ability( 'extrachill/events-submit' );
 	if ( ! $ability ) {
-		return new WP_Error(
-			'ability_unavailable',
-			__( 'Event submission is not available.', 'extrachill-api' ),
-			array( 'status' => 500 )
-		);
+		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$input = array(
@@ -61,7 +57,6 @@ function extrachill_api_handle_event_submission( WP_REST_Request $request ) {
 	}
 
 	$result = $ability->execute( $input );
-
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}

--- a/inc/routes/events/filters.php
+++ b/inc/routes/events/filters.php
@@ -33,85 +33,22 @@ function extrachill_api_register_events_filters_route() {
 /**
  * Handle filters request.
  *
+ * Invokes the extrachill/events-filters ability (registered in extrachill-events).
  * Route affinity middleware ensures this runs on the events site.
  *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response data or error.
  */
 function extrachill_api_events_filters_handler( WP_REST_Request $request ) {
-	$ability = wp_get_ability( 'data-machine-events/get-filter-options' );
+	$ability = wp_get_ability( 'extrachill/events-filters' );
 	if ( ! $ability ) {
-		return new WP_Error(
-			'ability_unavailable',
-			__( 'Filter options ability is not registered.', 'extrachill-api' ),
-			array( 'status' => 500 )
-		);
+		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute( array() );
-
 	if ( is_wp_error( $result ) ) {
-		return new WP_Error(
-			'filters_error',
-			$result->get_error_message(),
-			array( 'status' => 500 )
-		);
+		return $result;
 	}
 
-	return rest_ensure_response( extrachill_api_transform_filters_response( $result ) );
-}
-
-/**
- * Transform ability output into CalendarFilters shape.
- *
- * Ability returns: { success, taxonomies: { location: { terms: [...] }, ... }, ... }
- * Client expects: { venues, promoters, locations, ... } — each an array of { id, name, slug, count }
- *
- * The ability returns whatever taxonomies are registered with the filter system.
- * We transform all of them into a consistent shape and also expose them under
- * the client's expected keys.
- *
- * @param array $result Ability output.
- * @return array Transformed response.
- */
-function extrachill_api_transform_filters_response( array $result ): array {
-	$taxonomies = $result['taxonomies'] ?? array();
-
-	$transform_terms = function ( array $taxonomy_data ): array {
-		$terms       = $taxonomy_data['terms'] ?? $taxonomy_data;
-		$transformed = array();
-		foreach ( $terms as $term ) {
-			$entry = array(
-				'id'    => (int) ( $term['term_id'] ?? $term['id'] ?? 0 ),
-				'name'  => $term['name'] ?? '',
-				'slug'  => $term['slug'] ?? '',
-				'count' => (int) ( $term['event_count'] ?? $term['count'] ?? 0 ),
-			);
-
-			// Flatten children into the same list.
-			if ( ! empty( $term['children'] ) ) {
-				$transformed[] = $entry;
-				foreach ( $term['children'] as $child ) {
-					$transformed[] = array(
-						'id'    => (int) ( $child['term_id'] ?? $child['id'] ?? 0 ),
-						'name'  => $child['name'] ?? '',
-						'slug'  => $child['slug'] ?? '',
-						'count' => (int) ( $child['event_count'] ?? $child['count'] ?? 0 ),
-					);
-				}
-				continue;
-			}
-
-			$transformed[] = $entry;
-		}
-		return $transformed;
-	};
-
-	$response = array(
-		'venues'    => $transform_terms( $taxonomies['venue'] ?? array() ),
-		'promoters' => $transform_terms( $taxonomies['promoter'] ?? array() ),
-		'locations' => $transform_terms( $taxonomies['location'] ?? array() ),
-	);
-
-	return $response;
+	return rest_ensure_response( $result );
 }

--- a/inc/routes/events/geocode.php
+++ b/inc/routes/events/geocode.php
@@ -41,39 +41,24 @@ function extrachill_api_register_events_geocode_route() {
 /**
  * Handle geocode search request.
  *
+ * Invokes the extrachill/events-geocode ability (registered in extrachill-events).
  * Route affinity middleware ensures this runs on the events site.
  *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response data or error.
  */
 function extrachill_api_events_geocode_handler( WP_REST_Request $request ) {
-	$ability = wp_get_ability( 'data-machine-events/geocode-search' );
+	$ability = wp_get_ability( 'extrachill/events-geocode' );
 	if ( ! $ability ) {
-		return new WP_Error(
-			'ability_unavailable',
-			__( 'Geocode search ability is not registered.', 'extrachill-api' ),
-			array( 'status' => 500 )
-		);
+		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute( array(
-		'query'        => $request->get_param( 'q' ),
-		'countrycodes' => 'us',
+		'q' => $request->get_param( 'q' ),
 	) );
-
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
 
-	// Transform Nominatim results to GeoSearchResult shape.
-	$results = array();
-	foreach ( $result['results'] ?? array() as $item ) {
-		$results[] = array(
-			'lat'          => (float) ( $item['lat'] ?? 0 ),
-			'lon'          => (float) ( $item['lon'] ?? 0 ),
-			'display_name' => $item['display_name'] ?? '',
-		);
-	}
-
-	return rest_ensure_response( $results );
+	return rest_ensure_response( $result );
 }

--- a/inc/routes/events/upcoming-counts.php
+++ b/inc/routes/events/upcoming-counts.php
@@ -58,166 +58,36 @@ function extrachill_api_register_events_upcoming_counts_route() {
 /**
  * Handle upcoming counts request.
  *
- * Checks transient cache, runs SQL on cold cache.
+ * Invokes the extrachill/events-upcoming-counts ability (registered in extrachill-events).
  * Route affinity middleware ensures this runs on the events site.
  *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response data or error.
  */
 function extrachill_api_events_upcoming_counts_handler( WP_REST_Request $request ) {
-	$taxonomy = $request->get_param( 'taxonomy' );
-	$slug     = $request->get_param( 'slug' );
-	$limit    = (int) $request->get_param( 'limit' );
+	$ability = wp_get_ability( 'extrachill/events-upcoming-counts' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
+	}
 
-	// Single term query.
+	$input = array(
+		'taxonomy' => $request->get_param( 'taxonomy' ),
+	);
+
+	$slug = $request->get_param( 'slug' );
 	if ( ! empty( $slug ) ) {
-		return rest_ensure_response(
-			extrachill_api_single_upcoming_count( $slug, $taxonomy )
-		);
+		$input['slug'] = $slug;
 	}
 
-	// Bulk query — check transient, run SQL on cold cache.
-	$cache_key = 'ec_upcoming_counts_' . $taxonomy;
-	$cached    = get_transient( $cache_key );
-
-	if ( false !== $cached ) {
-		$results = $cached;
-		if ( $limit > 0 ) {
-			$results = array_slice( $results, 0, $limit );
-		}
-		return rest_ensure_response( $results );
-	}
-
-	// Cold cache — run the query.
-	$terms = extrachill_api_query_upcoming_counts( $taxonomy );
-
-	set_transient( $cache_key, $terms, 6 * HOUR_IN_SECONDS );
-
+	$limit = (int) $request->get_param( 'limit' );
 	if ( $limit > 0 ) {
-		$terms = array_slice( $terms, 0, $limit );
+		$input['limit'] = $limit;
 	}
 
-	return rest_ensure_response( $terms );
-}
-
-/**
- * Query upcoming event counts grouped by taxonomy term.
- *
- * Single SQL query with GROUP BY. Route affinity middleware ensures events blog context.
- *
- * @param string $taxonomy Taxonomy slug.
- * @return array Array of term data sorted by count descending.
- */
-function extrachill_api_query_upcoming_counts( $taxonomy ) {
-	if ( ! taxonomy_exists( $taxonomy ) ) {
-		return array();
+	$result = $ability->execute( $input );
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	global $wpdb;
-
-	$today        = gmdate( 'Y-m-d 00:00:00' );
-	$exclude_roots = is_taxonomy_hierarchical( $taxonomy );
-	$parent_clause = $exclude_roots ? 'AND tt.parent != 0' : '';
-
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-	$rows = $wpdb->get_results(
-		$wpdb->prepare(
-			"SELECT t.term_id, t.name, t.slug, COUNT(DISTINCT p.ID) AS event_count
-			FROM {$wpdb->term_relationships} tr
-			INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-			INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
-			INNER JOIN {$wpdb->posts} p ON tr.object_id = p.ID
-			INNER JOIN {$wpdb->prefix}datamachine_event_dates ed ON p.ID = ed.post_id
-			WHERE tt.taxonomy = %s
-			AND p.post_type = 'data_machine_events'
-			AND p.post_status = 'publish'
-			AND ed.start_datetime >= %s
-			{$parent_clause}
-			GROUP BY t.term_id
-			ORDER BY event_count DESC",
-			$taxonomy,
-			$today
-		)
-	);
-
-	if ( empty( $rows ) ) {
-		return array();
-	}
-
-	$terms = array();
-	foreach ( $rows as $row ) {
-		$url = get_term_link( (int) $row->term_id, $taxonomy );
-		if ( is_wp_error( $url ) ) {
-			continue;
-		}
-
-		$terms[] = array(
-			'term_id' => (int) $row->term_id,
-			'name'    => $row->name,
-			'slug'    => $row->slug,
-			'count'   => (int) $row->event_count,
-			'url'     => $url,
-		);
-	}
-
-	return $terms;
-}
-
-/**
- * Get upcoming event count for a single term.
- *
- * Route affinity middleware ensures events blog context.
- *
- * @param string $slug     Term slug.
- * @param string $taxonomy Taxonomy slug.
- * @return array|null Term data or null.
- */
-function extrachill_api_single_upcoming_count( $slug, $taxonomy ) {
-	if ( ! taxonomy_exists( $taxonomy ) ) {
-		return null;
-	}
-
-	$term = get_term_by( 'slug', $slug, $taxonomy );
-	if ( ! $term || is_wp_error( $term ) ) {
-		return null;
-	}
-
-	global $wpdb;
-	$today = gmdate( 'Y-m-d 00:00:00' );
-
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-	$count = (int) $wpdb->get_var(
-		$wpdb->prepare(
-			"SELECT COUNT(DISTINCT p.ID)
-			FROM {$wpdb->posts} p
-			INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
-			INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-			INNER JOIN {$wpdb->prefix}datamachine_event_dates ed ON p.ID = ed.post_id
-			WHERE tt.term_id = %d
-			AND tt.taxonomy = %s
-			AND p.post_type = 'data_machine_events'
-			AND p.post_status = 'publish'
-			AND ed.start_datetime >= %s",
-			$term->term_id,
-			$taxonomy,
-			$today
-		)
-	);
-
-	if ( $count < 1 ) {
-		return null;
-	}
-
-	$url = get_term_link( $term );
-	if ( is_wp_error( $url ) ) {
-		return null;
-	}
-
-	return array(
-		'term_id' => $term->term_id,
-		'slug'    => $term->slug,
-		'name'    => $term->name,
-		'count'   => $count,
-		'url'     => $url,
-	);
+	return rest_ensure_response( $result );
 }

--- a/inc/routes/events/venues.php
+++ b/inc/routes/events/venues.php
@@ -124,196 +124,89 @@ function extrachill_api_register_events_venues_routes() {
 /**
  * Handle venue list request.
  *
+ * Invokes the extrachill/events-list-venues ability (registered in extrachill-events).
  * Route affinity middleware ensures this runs on the events site.
  *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response data or error.
  */
 function extrachill_api_events_venues_list_handler( WP_REST_Request $request ) {
-	$ability = wp_get_ability( 'data-machine-events/list-venues' );
+	$ability = wp_get_ability( 'extrachill/events-list-venues' );
 	if ( ! $ability ) {
-		return new WP_Error(
-			'ability_unavailable',
-			__( 'List venues ability is not registered.', 'extrachill-api' ),
-			array( 'status' => 500 )
-		);
+		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$input = array();
 
-	// Geo proximity params.
-	$lat = $request->get_param( 'lat' );
-	$lng = $request->get_param( 'lng' );
-	if ( null !== $lat && null !== $lng ) {
-		$input['lat']    = (float) $lat;
-		$input['lng']    = (float) $lng;
-		$input['radius'] = $request->get_param( 'radius' ) ?: 25;
-	}
-
-	// Viewport bounds.
-	$sw_lat = $request->get_param( 'sw_lat' );
-	$sw_lng = $request->get_param( 'sw_lng' );
-	$ne_lat = $request->get_param( 'ne_lat' );
-	$ne_lng = $request->get_param( 'ne_lng' );
-	if ( null !== $sw_lat && null !== $sw_lng && null !== $ne_lat && null !== $ne_lng ) {
-		$input['bounds'] = implode( ',', array(
-			(float) $sw_lat,
-			(float) $sw_lng,
-			(float) $ne_lat,
-			(float) $ne_lng,
-		) );
-	}
-
-	// Location taxonomy filter.
-	$location = $request->get_param( 'location' );
-	if ( $location ) {
-		$term = get_term_by( 'slug', $location, 'location' );
-		if ( $term && ! is_wp_error( $term ) ) {
-			$input['taxonomy'] = 'location';
-			$input['term_id']  = $term->term_id;
+	$params = array( 'location', 'sw_lat', 'sw_lng', 'ne_lat', 'ne_lng', 'lat', 'lng', 'radius' );
+	foreach ( $params as $key ) {
+		$value = $request->get_param( $key );
+		if ( null !== $value ) {
+			$input[ $key ] = $value;
 		}
 	}
 
 	$result = $ability->execute( $input );
-
 	if ( is_wp_error( $result ) ) {
-		return new WP_Error(
-			'venues_error',
-			$result->get_error_message(),
-			array( 'status' => 500 )
-		);
+		return $result;
 	}
 
-	$venues = array_map( 'extrachill_api_transform_venue', $result['venues'] ?? array() );
-	return rest_ensure_response( $venues );
+	return rest_ensure_response( $result );
 }
 
 /**
  * Handle single venue request.
  *
- * Reads venue term data directly — bypasses the admin-gated get-venue ability
- * since public venue detail is read-only taxonomy data.
+ * Invokes the extrachill/events-get-venue ability (registered in extrachill-events).
  * Route affinity middleware ensures this runs on the events site.
  *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response data or error.
  */
 function extrachill_api_events_venue_get_handler( WP_REST_Request $request ) {
-	$term_id = (int) $request->get_param( 'id' );
-	$term    = get_term( $term_id, 'venue' );
-
-	if ( ! $term || is_wp_error( $term ) ) {
-		return new WP_Error(
-			'venue_not_found',
-			__( 'Venue not found.', 'extrachill-api' ),
-			array( 'status' => 404 )
-		);
+	$ability = wp_get_ability( 'extrachill/events-get-venue' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
 	}
 
-	// Build venue detail from term meta.
-	$venue_data = array(
-		'term_id' => $term->term_id,
-		'name'    => $term->name,
-		'slug'    => $term->slug,
-	);
-
-	// Read venue meta fields if Venue_Taxonomy helper is available.
-	if ( class_exists( '\\DataMachineEvents\\Core\\Venue_Taxonomy' ) ) {
-		$raw = \DataMachineEvents\Core\Venue_Taxonomy::get_venue_data( $term->term_id );
-		$venue_data['address']     = $raw['address'] ?? '';
-		$venue_data['city']        = $raw['city'] ?? '';
-		$venue_data['state']       = $raw['state'] ?? '';
-		$venue_data['country']     = $raw['country'] ?? '';
-		$venue_data['timezone']    = $raw['timezone'] ?? '';
-		$venue_data['website']     = $raw['website'] ?? '';
-		$venue_data['coordinates'] = get_term_meta( $term->term_id, '_venue_coordinates', true ) ?: '';
+	$result = $ability->execute( array(
+		'id' => (int) $request->get_param( 'id' ),
+	) );
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	return rest_ensure_response( extrachill_api_transform_venue_detail( $venue_data ) );
+	return rest_ensure_response( $result );
 }
 
 /**
  * Handle check duplicate venue request.
  *
- * Reads venue terms directly — bypasses the admin-gated ability
- * since this is a read-only name search.
+ * Invokes the extrachill/events-check-venue-duplicate ability (registered in extrachill-events).
  * Route affinity middleware ensures this runs on the events site.
  *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response data or error.
  */
 function extrachill_api_events_venue_check_duplicate_handler( WP_REST_Request $request ) {
-	$name = $request->get_param( 'name' );
-
-	// Search for venues matching the name.
-	$terms = get_terms( array(
-		'taxonomy'   => 'venue',
-		'hide_empty' => false,
-		'name__like' => $name,
-		'number'     => 10,
-	) );
-
-	if ( is_wp_error( $terms ) || empty( $terms ) ) {
-		return rest_ensure_response( array() );
+	$ability = wp_get_ability( 'extrachill/events-check-venue-duplicate' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$matches = array();
-	foreach ( $terms as $term ) {
-		$matches[] = extrachill_api_transform_venue_detail( array(
-			'term_id' => $term->term_id,
-			'name'    => $term->name,
-			'slug'    => $term->slug,
-		) );
-	}
-
-	return rest_ensure_response( $matches );
-}
-
-/**
- * Transform a venue from list-venues ability output into the Venue shape.
- *
- * @param array $venue Venue data from list-venues ability.
- * @return array Transformed venue.
- */
-function extrachill_api_transform_venue( array $venue ): array {
-	return array(
-		'id'          => (int) ( $venue['term_id'] ?? 0 ),
-		'name'        => $venue['name'] ?? '',
-		'slug'        => $venue['slug'] ?? '',
-		'address'     => $venue['address'] ?? null,
-		'latitude'    => isset( $venue['lat'] ) ? (float) $venue['lat'] : null,
-		'longitude'   => isset( $venue['lon'] ) ? (float) $venue['lon'] : null,
-		'event_count' => (int) ( $venue['event_count'] ?? 0 ),
+	$input = array(
+		'name' => $request->get_param( 'name' ),
 	);
-}
 
-/**
- * Transform a venue from get-venue ability output into the Venue shape.
- *
- * @param array $venue Venue data from get-venue ability.
- * @return array Transformed venue.
- */
-function extrachill_api_transform_venue_detail( array $venue ): array {
-	$lat = null;
-	$lon = null;
-
-	if ( ! empty( $venue['coordinates'] ) && strpos( $venue['coordinates'], ',' ) !== false ) {
-		$parts = explode( ',', $venue['coordinates'] );
-		$lat   = (float) trim( $parts[0] );
-		$lon   = (float) trim( $parts[1] );
+	$city = $request->get_param( 'city' );
+	if ( ! empty( $city ) ) {
+		$input['city'] = $city;
 	}
 
-	return array(
-		'id'        => (int) ( $venue['term_id'] ?? 0 ),
-		'name'      => $venue['name'] ?? '',
-		'slug'      => $venue['slug'] ?? '',
-		'address'   => $venue['address'] ?? null,
-		'city'      => $venue['city'] ?? null,
-		'state'     => $venue['state'] ?? null,
-		'country'   => $venue['country'] ?? null,
-		'latitude'  => $lat,
-		'longitude' => $lon,
-		'timezone'  => $venue['timezone'] ?? null,
-		'website'   => $venue['website'] ?? null,
-	);
+	$result = $ability->execute( $input );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }


### PR DESCRIPTION
## Summary

Refactors all **12 events-domain route handlers** across 7 files to invoke canonical abilities instead of owning their own implementation. Follows the 6-line canonical pattern established in `inc/routes/admin/artist-access.php`.

**Net change:** 131 lines added, 613 lines removed — ~75% reduction.

## Routes refactored

| Route | Ability | Plugin |
|---|---|---|
| `GET /events/calendar` | `extrachill/events-calendar` | extrachill-events |
| `GET /events/filters` | `extrachill/events-filters` | extrachill-events |
| `GET /events/geocode` | `extrachill/events-geocode` | extrachill-events |
| `GET /events/upcoming-counts` | `extrachill/events-upcoming-counts` | extrachill-events |
| `POST /event-submissions` | `extrachill/events-submit` | extrachill-events |
| `GET /events/venues` | `extrachill/events-list-venues` | extrachill-events |
| `GET /events/venues/{id}` | `extrachill/events-get-venue` | extrachill-events |
| `GET /events/venues/check-duplicate` | `extrachill/events-check-venue-duplicate` | extrachill-events |
| `POST /concert-tracking/toggle` | `extrachill/toggle-event-mark` | extrachill-users |
| `GET /concert-tracking/event/{id}` | `extrachill/get-event-attendance` | extrachill-users |
| `GET /concert-tracking/user/{id}/shows` | `extrachill/get-user-shows` | extrachill-users |
| `GET /concert-tracking/user/{id}/stats` | `extrachill/get-user-concert-stats` | extrachill-users |

## What changed per handler

- **Before:** Route handler owned implementation (SQL queries, direct function calls, transform logic).
- **After:** Route handler invokes the matching ability via `wp_get_ability()` → `execute()` → `rest_ensure_response()`.

## What did NOT change

- Route registration blocks (URLs, args, `permission_callback`) — untouched
- Validation callbacks — untouched
- No custom redirects in this domain
- All `/extrachill/v1/*` URLs keep working with identical response shapes

## Gaps

**None.** All 12 route handlers in the events domain have a matching ability. Zero routes left as-is.

## Prerequisites

- [x] extrachill-events#69 (events abilities) — merged
- [x] extrachill-users#22 (concert tracking abilities) — merged

## Checklist

- [x] Every events-domain route handler with a matching ability uses the canonical 6-line invoke pattern
- [x] Permission callbacks unchanged
- [x] Args / validation unchanged
- [x] No custom redirects in this domain
- [x] PHP lint clean (`find inc -name '*.php' -exec php -l {} \;` — zero errors)
- [x] PR opened, NOT merged

Closes #26 (events batch).