### PR TITLE
refactor(routes/users): invoke abilities (#26)

### DIFF
--- a/inc/routes/users/artist-access-request.php
+++ b/inc/routes/users/artist-access-request.php
@@ -57,7 +57,7 @@ function extrachill_api_user_artist_access_request( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/request-artist-access' );
 
 	if ( ! $ability ) {
-		return new WP_Error( 'service_unavailable', 'Artist access request service not available.', array( 'status' => 503 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute(

--- a/inc/routes/users/onboarding.php
+++ b/inc/routes/users/onboarding.php
@@ -74,11 +74,7 @@ function extrachill_api_onboarding_get_handler( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/get-onboarding-status' );
 
 	if ( ! $ability ) {
-		return new WP_Error(
-			'service_unavailable',
-			__( 'Onboarding service not available.', 'extrachill-api' ),
-			array( 'status' => 503 )
-		);
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute( array( 'user_id' => get_current_user_id() ) );
@@ -97,11 +93,7 @@ function extrachill_api_onboarding_post_handler( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/complete-onboarding' );
 
 	if ( ! $ability ) {
-		return new WP_Error(
-			'service_unavailable',
-			__( 'Onboarding service not available.', 'extrachill-api' ),
-			array( 'status' => 503 )
-		);
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute(

--- a/inc/routes/users/profile.php
+++ b/inc/routes/users/profile.php
@@ -96,7 +96,7 @@ function extrachill_api_user_profile_get( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/get-user-profile' );
 
 	if ( ! $ability ) {
-		return new WP_Error( 'service_unavailable', 'User profile service not available.', array( 'status' => 503 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute( array( 'user_id' => get_current_user_id() ) );
@@ -115,7 +115,7 @@ function extrachill_api_user_profile_update( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/update-user-profile' );
 
 	if ( ! $ability ) {
-		return new WP_Error( 'service_unavailable', 'User profile service not available.', array( 'status' => 503 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$input = array( 'user_id' => get_current_user_id() );
@@ -146,7 +146,7 @@ function extrachill_api_user_links_update( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/update-user-links' );
 
 	if ( ! $ability ) {
-		return new WP_Error( 'service_unavailable', 'User links service not available.', array( 'status' => 503 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute(

--- a/inc/routes/users/settings.php
+++ b/inc/routes/users/settings.php
@@ -116,7 +116,7 @@ function extrachill_api_user_settings_get( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/get-user-settings' );
 
 	if ( ! $ability ) {
-		return new WP_Error( 'service_unavailable', 'User settings service not available.', array( 'status' => 503 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute( array( 'user_id' => get_current_user_id() ) );
@@ -135,7 +135,7 @@ function extrachill_api_user_settings_update( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/update-user-settings' );
 
 	if ( ! $ability ) {
-		return new WP_Error( 'service_unavailable', 'User settings service not available.', array( 'status' => 503 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$input = array( 'user_id' => get_current_user_id() );
@@ -166,7 +166,7 @@ function extrachill_api_user_email_change( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/change-user-email' );
 
 	if ( ! $ability ) {
-		return new WP_Error( 'service_unavailable', 'Email change service not available.', array( 'status' => 503 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute(
@@ -190,7 +190,7 @@ function extrachill_api_user_password_change( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/change-user-password' );
 
 	if ( ! $ability ) {
-		return new WP_Error( 'service_unavailable', 'Password change service not available.', array( 'status' => 503 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute(

--- a/inc/routes/users/subscriptions.php
+++ b/inc/routes/users/subscriptions.php
@@ -63,7 +63,7 @@ function extrachill_api_user_subscriptions_get( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/get-subscriptions' );
 
 	if ( ! $ability ) {
-		return new WP_Error( 'service_unavailable', 'Subscriptions service not available.', array( 'status' => 503 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute( array( 'user_id' => get_current_user_id() ) );
@@ -82,7 +82,7 @@ function extrachill_api_user_subscriptions_update( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/update-subscriptions' );
 
 	if ( ! $ability ) {
-		return new WP_Error( 'service_unavailable', 'Subscriptions service not available.', array( 'status' => 503 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$result = $ability->execute(


### PR DESCRIPTION
## Summary

Normalizes all users-domain route handlers to follow the **exact canonical pattern** from `inc/routes/admin/artist-access.php` (the reference shape defined in #26).

- **Error code:** `ability_not_found` (was `service_unavailable`)
- **HTTP status:** `500` (was `503`)
- **Error message:** `"extrachill-users plugin is required."` (consistent across all handlers)
- **Removed** i18n wrappers (`__()`) on ability-missing errors to match canonical

## Files changed (5 files, 12 handlers)

| File | Handlers | Abilities |
|---|---|---|
| `profile.php` | GET profile, POST profile, POST links | `get-user-profile`, `update-user-profile`, `update-user-links` |
| `settings.php` | GET settings, POST settings, POST email, POST password | `get-user-settings`, `update-user-settings`, `change-user-email`, `change-user-password` |
| `subscriptions.php` | GET subscriptions, POST subscriptions | `get-subscriptions`, `update-subscriptions` |
| `onboarding.php` | GET onboarding, POST onboarding | `get-onboarding-status`, `complete-onboarding` |
| `artist-access-request.php` | POST artist-access | `request-artist-access` |

## Skipped — no matching ability registered

These routes still own their implementation because no ability exists in extrachill-users (or any other feature plugin) to delegate to:

| File | Route | Gap |
|---|---|---|
| `users.php` | `GET /users/{id}` | No `extrachill/get-user` ability |
| `artists.php` | `GET/POST/DELETE /users/{id}/artists` | No `extrachill/list-user-artists`, `add-user-artist`, `remove-user-artist` abilities |
| `search.php` | `GET /users/search` | No `extrachill/search-users` ability |
| `leaderboard.php` | `GET /users/leaderboard` | No `extrachill/get-leaderboard` ability |

## What's NOT changed
- ✅ Permission callbacks unchanged
- ✅ Args / validation unchanged
- ✅ Custom redirects unchanged (none in this domain)
- ✅ Route registration blocks untouched
- ✅ `php -l` passes on all files

## Checklist
- [x] Every users-domain route handler with a matching ability uses the canonical 6-line invoke pattern
- [x] Permission callbacks unchanged
- [x] Args / validation unchanged
- [x] Custom redirects unchanged
- [x] PHP lint clean
- [x] PR opened, NOT merged