### PR TITLE
refactor(routes/analytics): invoke abilities — round 2 (#26)

### DIFF
--- a/inc/routes/analytics/events.php
+++ b/inc/routes/analytics/events.php
@@ -142,23 +142,28 @@ function extrachill_api_analytics_events_handler( WP_REST_Request $request ) {
 /**
  * Handle events summary request.
  *
+ * Wraps the extrachill/get-analytics-summary ability from extrachill-analytics.
+ *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_analytics_events_summary_handler( WP_REST_Request $request ) {
-	if ( ! function_exists( 'extrachill_get_analytics_event_stats' ) ) {
-		return new WP_Error(
-			'function_missing',
-			'Analytics stats function not available.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/get-analytics-summary' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-analytics plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$event_type = $request->get_param( 'event_type' );
-	$days       = $request->get_param( 'days' );
-	$blog_id    = $request->get_param( 'blog_id' );
+	$result = $ability->execute(
+		array(
+			'event_type' => $request->get_param( 'event_type' ),
+			'days'       => $request->get_param( 'days' ),
+			'blog_id'    => $request->get_param( 'blog_id' ),
+		)
+	);
 
-	$stats = extrachill_get_analytics_event_stats( $event_type, $days, $blog_id );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
 
-	return rest_ensure_response( $stats );
+	return rest_ensure_response( $result );
 }


### PR DESCRIPTION
## Summary

Second pass of the analytics route refactor for #26. Converts the remaining route handler with a matching ability to the canonical 6-line invoke pattern.

### Refactored

- **`inc/routes/analytics/events.php`** → `extrachill_api_analytics_events_summary_handler` now invokes `extrachill/get-analytics-summary` ability instead of calling `extrachill_get_analytics_event_stats()` directly.

### Server-side gaps (no matching ability — left as-is)

| Handler | File | Notes |
|---|---|---|
| `extrachill_api_analytics_events_handler` | `events.php` | Queries raw events with pagination. No `extrachill/query-analytics-events` or equivalent ability registered. |
| `extrachill_api_analytics_meta_handler` | `meta.php` | Returns filter options (event types, blogs). No `extrachill/get-analytics-meta` ability registered. |

These handlers retain their original direct-query implementations. They need corresponding abilities registered in `extrachill-analytics` before they can be converted.

### Unchanged

- Route registration, args, and permission callbacks are untouched.
- PHP lint clean across all files.