### PR TITLE
refactor(routes/events): invoke abilities — round 2 (#26)

### DIFF
--- a/inc/routes/events/concert-tracking.php
+++ b/inc/routes/events/concert-tracking.php
@@ -188,16 +188,10 @@ function extrachill_api_handle_concert_tracking_toggle( WP_REST_Request $request
 		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$input = array(
+	$result = $ability->execute( array(
 		'event_id' => (int) $request->get_param( 'event_id' ),
-	);
-
-	$blog_id = (int) $request->get_param( 'blog_id' );
-	if ( $blog_id ) {
-		$input['blog_id'] = $blog_id;
-	}
-
-	$result = $ability->execute( $input );
+		'blog_id'  => (int) $request->get_param( 'blog_id' ),
+	) );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -219,16 +213,11 @@ function extrachill_api_handle_concert_tracking_event( WP_REST_Request $request 
 		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$input = array(
-		'event_id' => (int) $request->get_param( 'event_id' ),
-	);
-
-	if ( $request->get_param( 'include_attendees' ) ) {
-		$input['include_attendees'] = true;
-		$input['limit']             = (int) $request->get_param( 'limit' );
-	}
-
-	$result = $ability->execute( $input );
+	$result = $ability->execute( array(
+		'event_id'          => (int) $request->get_param( 'event_id' ),
+		'include_attendees' => (bool) $request->get_param( 'include_attendees' ),
+		'limit'             => (int) $request->get_param( 'limit' ),
+	) );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}

--- a/inc/routes/events/upcoming-counts.php
+++ b/inc/routes/events/upcoming-counts.php
@@ -70,21 +70,11 @@ function extrachill_api_events_upcoming_counts_handler( WP_REST_Request $request
 		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$input = array(
+	$result = $ability->execute( array(
 		'taxonomy' => $request->get_param( 'taxonomy' ),
-	);
-
-	$slug = $request->get_param( 'slug' );
-	if ( ! empty( $slug ) ) {
-		$input['slug'] = $slug;
-	}
-
-	$limit = (int) $request->get_param( 'limit' );
-	if ( $limit > 0 ) {
-		$input['limit'] = $limit;
-	}
-
-	$result = $ability->execute( $input );
+		'slug'     => $request->get_param( 'slug' ),
+		'limit'    => (int) $request->get_param( 'limit' ),
+	) );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}


### PR DESCRIPTION
## Summary

Normalises the remaining event-domain route handlers to the canonical 6-line ability invoke pattern (get ability → fail predictably → execute → unwrap → return). Removes conditional input assembly logic from three handlers that were partially refactored in round 1.

Closes the events portion of #26.

## Changes

### `inc/routes/events/concert-tracking.php`
- **`extrachill_api_handle_concert_tracking_toggle`** — removed conditional `blog_id` assembly; now passes `blog_id` unconditionally (ability handles `0` default)
- **`extrachill_api_handle_concert_tracking_event`** — removed conditional `include_attendees`/`limit` assembly; now passes all three params directly

### `inc/routes/events/upcoming-counts.php`
- **`extrachill_api_events_upcoming_counts_handler`** — removed conditional `slug` and `limit` assembly; now passes all params directly

### Unchanged (already canonical)
- `extrachill_api_handle_concert_tracking_user_shows` — was already clean
- `extrachill_api_handle_concert_tracking_user_stats` — was already clean

## Server-side gap

- **`extrachill/events-upcoming-counts`** ability is **not yet registered** — `wp_get_ability()` returns `null`. The route already referenced this ability before this refactor (the handler shape was correct, only the input assembly was normalised). The ability needs to be registered in `extrachill-events` for this endpoint to function.

## Checklist
- [x] Every route handler with a matching ability uses the canonical pattern
- [x] Permission callbacks unchanged
- [x] Args / validation unchanged  
- [x] PHP lint clean (`find inc -name '*.php' -exec php -l {} \;` — all pass)
- [x] PR opened, NOT merged