### PR TITLE
refactor(routes/seo): invoke abilities — round 2 (#26)

### DIFF
--- a/inc/routes/seo/audit.php
+++ b/inc/routes/seo/audit.php
@@ -57,25 +57,21 @@ function extrachill_api_seo_audit_permission_check() {
 /**
  * Runs a new SEO audit.
  *
+ * Wraps the extrachill/run-seo-audit ability from extrachill-seo.
+ *
  * @param WP_REST_Request $request The REST request object.
  * @return WP_REST_Response|WP_Error Response with audit results or error.
  */
 function extrachill_api_run_seo_audit( $request ) {
-	if ( ! function_exists( 'ec_seo_run_full_audit' ) ) {
-		return new WP_Error(
-			'dependency_missing',
-			'Extra Chill SEO plugin audit functions not available.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/run-seo-audit' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-seo plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$mode = $request->get_param( 'mode' );
-
-	if ( 'full' === $mode ) {
-		$results = ec_seo_run_full_audit();
-		return rest_ensure_response( $results );
+	$result = $ability->execute( array( 'mode' => $request->get_param( 'mode' ) ) );
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	$results = ec_seo_start_batch_audit();
-	return rest_ensure_response( $results );
+	return rest_ensure_response( $result );
 }

--- a/inc/routes/seo/config.php
+++ b/inc/routes/seo/config.php
@@ -64,51 +64,50 @@ function extrachill_api_seo_config_permission_check() {
 /**
  * Gets current SEO config.
  *
- * @return WP_REST_Response Config data.
+ * Wraps the extrachill/get-seo-config ability from extrachill-seo.
+ *
+ * @return WP_REST_Response|WP_Error Config data or error.
  */
 function extrachill_api_get_seo_config() {
-	$default_og_image_id = function_exists( 'ExtraChill\SEO\Core\ec_seo_get_default_og_image_id' )
-		? \ExtraChill\SEO\Core\ec_seo_get_default_og_image_id()
-		: 0;
+	$ability = wp_get_ability( 'extrachill/get-seo-config' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-seo plugin is required.', array( 'status' => 500 ) );
+	}
 
-	$indexnow_key = function_exists( 'ExtraChill\SEO\Core\ec_seo_get_indexnow_key' )
-		? \ExtraChill\SEO\Core\ec_seo_get_indexnow_key()
-		: '';
+	$result = $ability->execute( array() );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
 
-	$default_og_image_url = $default_og_image_id
-		? wp_get_attachment_image_url( $default_og_image_id, 'medium' )
-		: '';
-
-	return rest_ensure_response(
-		array(
-			'default_og_image_id'  => $default_og_image_id,
-			'default_og_image_url' => $default_og_image_url,
-			'indexnow_key'         => $indexnow_key,
-		)
-	);
+	return rest_ensure_response( $result );
 }
 
 /**
  * Updates SEO config.
  *
+ * Wraps the extrachill/update-seo-config ability from extrachill-seo.
+ *
  * @param WP_REST_Request $request The REST request object.
  * @return WP_REST_Response|WP_Error Updated config or error.
  */
 function extrachill_api_update_seo_config( $request ) {
-	$default_og_image_id = $request->get_param( 'default_og_image_id' );
-	$indexnow_key        = $request->get_param( 'indexnow_key' );
-
-	if ( null !== $default_og_image_id ) {
-		if ( function_exists( 'ExtraChill\SEO\Core\ec_seo_set_default_og_image_id' ) ) {
-			\ExtraChill\SEO\Core\ec_seo_set_default_og_image_id( $default_og_image_id );
-		}
+	$ability = wp_get_ability( 'extrachill/update-seo-config' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-seo plugin is required.', array( 'status' => 500 ) );
 	}
 
-	if ( null !== $indexnow_key ) {
-		if ( function_exists( 'ExtraChill\SEO\Core\ec_seo_set_indexnow_key' ) ) {
-			\ExtraChill\SEO\Core\ec_seo_set_indexnow_key( $indexnow_key );
-		}
+	$params = array();
+	if ( null !== $request->get_param( 'default_og_image_id' ) ) {
+		$params['default_og_image_id'] = $request->get_param( 'default_og_image_id' );
+	}
+	if ( null !== $request->get_param( 'indexnow_key' ) ) {
+		$params['indexnow_key'] = $request->get_param( 'indexnow_key' );
 	}
 
-	return extrachill_api_get_seo_config();
+	$result = $ability->execute( $params );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }

--- a/inc/routes/seo/status.php
+++ b/inc/routes/seo/status.php
@@ -31,16 +31,20 @@ function extrachill_api_register_seo_audit_status_route() {
 /**
  * Gets current SEO audit status and results.
  *
+ * Wraps the extrachill/get-seo-results ability from extrachill-seo.
+ *
  * @return WP_REST_Response|WP_Error Response with audit status or error.
  */
 function extrachill_api_get_seo_audit_status() {
-	if ( ! function_exists( 'ec_seo_get_audit_results' ) ) {
-		return new WP_Error(
-			'dependency_missing',
-			'Extra Chill SEO plugin not available.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/get-seo-results' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-seo plugin is required.', array( 'status' => 500 ) );
 	}
 
-	return rest_ensure_response( ec_seo_get_audit_results() );
+	$result = $ability->execute( array() );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }


### PR DESCRIPTION
## Summary

Refactors the remaining SEO domain REST route handlers to invoke WordPress Abilities instead of calling plugin functions directly. This is the second round of the ability-invoke refactor for SEO routes (see #26).

### Handlers refactored (4)

| File | Handler | Ability |
|---|---|---|
| `audit.php` | `extrachill_api_run_seo_audit()` | `extrachill/run-seo-audit` |
| `config.php` | `extrachill_api_get_seo_config()` | `extrachill/get-seo-config` |
| `config.php` | `extrachill_api_update_seo_config()` | `extrachill/update-seo-config` |
| `status.php` | `extrachill_api_get_seo_audit_status()` | `extrachill/get-seo-results` |

### Handlers left as-is — no matching ability (2)

| File | Handler | Reason |
|---|---|---|
| `continue.php` | `extrachill_api_continue_seo_audit()` | No ability registered for batch-continue |
| `details.php` | `extrachill_api_get_seo_audit_details()` | No ability registered for paginated audit details |

These two handlers still call plugin functions directly. They need corresponding abilities registered in `extrachill-seo` before they can be refactored.

### What was NOT changed

- Route registration (paths, methods)
- Permission callbacks
- Args / validation callbacks
- CHANGELOG.md / version strings

### Verification

- `find inc -name '*.php' -exec php -l {} \;` — all clean, zero syntax errors.

Closes part of #26.