### PR TITLE
refactor(routes/admin): invoke abilities — round 2 (#26)

### DIFF
--- a/inc/routes/admin/lifetime-membership.php
+++ b/inc/routes/admin/lifetime-membership.php
@@ -149,102 +149,53 @@ function extrachill_api_get_lifetime_memberships( $request ) {
 /**
  * Grants a lifetime membership to a user.
  *
+ * Wraps the extrachill/grant-lifetime-membership ability.
+ *
  * @param WP_REST_Request $request The REST request object.
  * @return WP_REST_Response|WP_Error Response with grant confirmation or error.
  */
 function extrachill_api_grant_lifetime_membership( $request ) {
-	$identifier = $request->get_param( 'user_identifier' );
-
-	if ( empty( $identifier ) ) {
-		return new WP_Error(
-			'missing_identifier',
-			'User identifier is required.',
-			array( 'status' => 400 )
-		);
+	$ability = wp_get_ability( 'extrachill/grant-lifetime-membership' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'Lifetime membership ability is not available.', array( 'status' => 500 ) );
 	}
 
-	$user = get_user_by( 'login', $identifier );
-	if ( ! $user ) {
-		$user = get_user_by( 'email', $identifier );
-	}
-
-	if ( ! $user ) {
-		return new WP_Error(
-			'user_not_found',
-			'User not found.',
-			array( 'status' => 404 )
-		);
-	}
-
-	$existing = get_user_meta( $user->ID, 'extrachill_lifetime_membership', true );
-	if ( $existing ) {
-		return new WP_Error(
-			'membership_exists',
-			'User already has a lifetime membership.',
-			array( 'status' => 409 )
-		);
-	}
-
-	$membership_data = array(
-		'purchased' => current_time( 'mysql' ),
-		'order_id'  => null,
-		'username'  => $user->user_login,
-	);
-
-	update_user_meta( $user->ID, 'extrachill_lifetime_membership', $membership_data );
-
-	return rest_ensure_response(
+	$result = $ability->execute(
 		array(
-			'message'  => "Lifetime membership granted to {$user->user_login}",
-			'user_id'  => $user->ID,
-			'username' => $user->user_login,
-			'email'    => $user->user_email,
+			'user_identifier' => $request->get_param( 'user_identifier' ),
 		)
 	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }
 
 /**
  * Revokes a lifetime membership from a user.
  *
+ * Wraps the extrachill/revoke-lifetime-membership ability.
+ *
  * @param WP_REST_Request $request The REST request object.
  * @return WP_REST_Response|WP_Error Response with revoke confirmation or error.
  */
 function extrachill_api_revoke_lifetime_membership( $request ) {
-	$user_id = $request->get_param( 'user_id' );
-
-	if ( ! $user_id ) {
-		return new WP_Error(
-			'missing_user_id',
-			'User ID is required.',
-			array( 'status' => 400 )
-		);
+	$ability = wp_get_ability( 'extrachill/revoke-lifetime-membership' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'Lifetime membership ability is not available.', array( 'status' => 500 ) );
 	}
 
-	$user = get_userdata( $user_id );
-	if ( ! $user ) {
-		return new WP_Error(
-			'user_not_found',
-			'User not found.',
-			array( 'status' => 404 )
-		);
-	}
-
-	$existing = get_user_meta( $user_id, 'extrachill_lifetime_membership', true );
-	if ( ! $existing ) {
-		return new WP_Error(
-			'no_membership',
-			'User does not have a lifetime membership.',
-			array( 'status' => 404 )
-		);
-	}
-
-	delete_user_meta( $user_id, 'extrachill_lifetime_membership' );
-
-	return rest_ensure_response(
+	$result = $ability->execute(
 		array(
-			'message'  => "Lifetime membership revoked for {$user->user_login}",
-			'user_id'  => $user_id,
-			'username' => $user->user_login,
+			'user_id' => absint( $request->get_param( 'user_id' ) ),
 		)
 	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }

--- a/inc/routes/admin/taxonomy-sync.php
+++ b/inc/routes/admin/taxonomy-sync.php
@@ -85,198 +85,31 @@ function extrachill_api_taxonomy_sync_sanitize_taxonomies( $value ) {
     return array_values( array_unique( $taxonomies ) );
 }
 
+/**
+ * Syncs shared taxonomies from the main site to target sites.
+ *
+ * Wraps the extrachill/sync-taxonomies ability.
+ *
+ * @param WP_REST_Request $request The REST request object.
+ * @return WP_REST_Response|WP_Error Response with sync report or error.
+ */
 function extrachill_api_taxonomy_sync( WP_REST_Request $request ) {
-    if ( ! function_exists( 'ec_get_blog_id' ) ) {
-        return new WP_Error(
-            'dependency_missing',
-            'Required function ec_get_blog_id() not available.',
-            array( 'status' => 500 )
-        );
+    $ability = wp_get_ability( 'extrachill/sync-taxonomies' );
+    if ( ! $ability ) {
+        return new WP_Error( 'ability_not_found', 'Taxonomy sync ability is not available.', array( 'status' => 500 ) );
     }
 
-    $target_sites = $request->get_param( 'target_sites' );
-    $taxonomies   = $request->get_param( 'taxonomies' );
-
-    if ( empty( $target_sites ) || empty( $taxonomies ) ) {
-        return new WP_Error(
-            'invalid_params',
-            'Please select at least one target site and one taxonomy.',
-            array( 'status' => 400 )
-        );
-    }
-
-    $target_blog_ids = array();
-
-    foreach ( $target_sites as $site_slug ) {
-        $blog_id = ec_get_blog_id( $site_slug );
-        if ( $blog_id ) {
-            $target_blog_ids[] = absint( $blog_id );
-        }
-    }
-
-    if ( empty( $target_blog_ids ) ) {
-        return new WP_Error(
-            'invalid_params',
-            'No valid target sites selected.',
-            array( 'status' => 400 )
-        );
-    }
-
-    $report = extrachill_api_perform_taxonomy_sync( $target_blog_ids, $taxonomies );
-
-    return rest_ensure_response( $report );
-}
-
-function extrachill_api_organize_terms_by_parent( $terms ) {
-    $hierarchy = array();
-
-    foreach ( $terms as $term ) {
-        $parent_id = (int) $term->parent;
-
-        if ( ! isset( $hierarchy[ $parent_id ] ) ) {
-            $hierarchy[ $parent_id ] = array();
-        }
-
-        $hierarchy[ $parent_id ][] = $term;
-    }
-
-    return $hierarchy;
-}
-
-function extrachill_api_sync_term_recursive( $term, $taxonomy, $hierarchy, $parent_id_on_target, &$site_report, &$report ) {
-    $report['total_terms_processed']++;
-
-    $existing_term = term_exists( $term->slug, $taxonomy );
-    if ( $existing_term ) {
-        $site_report['skipped']++;
-        $report['total_terms_skipped']++;
-        $synced_term_id = is_array( $existing_term ) ? $existing_term['term_id'] : $existing_term;
-    } else {
-        $term_args = array(
-            'slug'        => $term->slug,
-            'description' => $term->description,
-        );
-
-        if ( $parent_id_on_target > 0 ) {
-            $term_args['parent'] = $parent_id_on_target;
-        }
-
-        $result = wp_insert_term( $term->name, $taxonomy, $term_args );
-
-        if ( is_wp_error( $result ) ) {
-            $site_report['failed']++;
-            return;
-        }
-
-        $site_report['created']++;
-        $report['total_terms_created']++;
-        $synced_term_id = $result['term_id'];
-    }
-
-    if ( isset( $hierarchy[ $term->term_id ] ) ) {
-        foreach ( $hierarchy[ $term->term_id ] as $child_term ) {
-            extrachill_api_sync_term_recursive( $child_term, $taxonomy, $hierarchy, $synced_term_id, $site_report, $report );
-        }
-    }
-}
-
-function extrachill_api_perform_taxonomy_sync( $target_blog_ids, $taxonomies ) {
-    $source_blog_id = ec_get_blog_id( 'main' );
-
-    if ( ! $source_blog_id ) {
-        return array(
-            'total_terms_processed' => 0,
-            'total_terms_created'   => 0,
-            'total_terms_skipped'   => 0,
-            'breakdown'             => array(),
-        );
-    }
-
-    $report = array(
-        'total_terms_processed' => 0,
-        'total_terms_created'   => 0,
-        'total_terms_skipped'   => 0,
-        'breakdown'             => array(),
+    $result = $ability->execute(
+        array(
+            'target_sites' => $request->get_param( 'target_sites' ),
+            'taxonomies'   => $request->get_param( 'taxonomies' ),
+        )
     );
 
-    foreach ( $taxonomies as $taxonomy ) {
-        $source_terms = array();
-
-        try {
-            switch_to_blog( $source_blog_id );
-            $source_terms = get_terms(
-                array(
-                    'taxonomy'   => $taxonomy,
-                    'hide_empty' => false,
-                )
-            );
-        } finally {
-            restore_current_blog();
-        }
-
-        if ( is_wp_error( $source_terms ) || empty( $source_terms ) ) {
-            continue;
-        }
-
-        $report['breakdown'][ $taxonomy ] = array(
-            'source_terms' => count( $source_terms ),
-            'sites'        => array(),
-        );
-
-        $is_hierarchical = is_taxonomy_hierarchical( $taxonomy );
-
-        foreach ( $target_blog_ids as $target_blog_id ) {
-            $site_report = array(
-                'created' => 0,
-                'skipped' => 0,
-                'failed'  => 0,
-            );
-
-            try {
-                switch_to_blog( $target_blog_id );
-
-                if ( $is_hierarchical ) {
-                    $hierarchy = extrachill_api_organize_terms_by_parent( $source_terms );
-
-                    if ( isset( $hierarchy[0] ) ) {
-                        foreach ( $hierarchy[0] as $root_term ) {
-                            extrachill_api_sync_term_recursive( $root_term, $taxonomy, $hierarchy, 0, $site_report, $report );
-                        }
-                    }
-                } else {
-                    foreach ( $source_terms as $term ) {
-                        $report['total_terms_processed']++;
-
-                        $existing_term = term_exists( $term->slug, $taxonomy );
-                        if ( $existing_term ) {
-                            $site_report['skipped']++;
-                            $report['total_terms_skipped']++;
-                            continue;
-                        }
-
-                        $term_args = array(
-                            'slug'        => $term->slug,
-                            'description' => $term->description,
-                        );
-
-                        $result = wp_insert_term( $term->name, $taxonomy, $term_args );
-
-                        if ( is_wp_error( $result ) ) {
-                            $site_report['failed']++;
-                            continue;
-                        }
-
-                        $site_report['created']++;
-                        $report['total_terms_created']++;
-                    }
-                }
-            } finally {
-                restore_current_blog();
-            }
-
-            $report['breakdown'][ $taxonomy ]['sites'][ (string) $target_blog_id ] = $site_report;
-        }
+    if ( is_wp_error( $result ) ) {
+        return $result;
     }
 
-    return $report;
+    return rest_ensure_response( $result );
 }
+

--- a/inc/routes/admin/team-members.php
+++ b/inc/routes/admin/team-members.php
@@ -159,126 +159,50 @@ function extrachill_api_get_team_members( $request ) {
 /**
  * Syncs team member status for all network users.
  *
+ * Wraps the extrachill/sync-team-members ability.
+ *
  * @param WP_REST_Request $request The REST request object.
  * @return WP_REST_Response|WP_Error Response with sync report or error.
  */
 function extrachill_api_sync_team_members( $request ) {
-	if ( ! function_exists( 'ec_has_main_site_account' ) ) {
-		return new WP_Error(
-			'dependency_missing',
-			'Required function ec_has_main_site_account() not available.',
-			array( 'status' => 500 )
-		);
+	$ability = wp_get_ability( 'extrachill/sync-team-members' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'Team members ability is not available.', array( 'status' => 500 ) );
 	}
 
-	$report = array(
-		'total_users'                   => 0,
-		'users_updated'                 => 0,
-		'users_skipped_override'        => 0,
-		'users_with_main_site_account'  => 0,
-	);
+	$result = $ability->execute( array() );
 
-	$users = get_users(
-		array(
-			'blog_id' => 0,
-			'fields'  => 'ID',
-		)
-	);
-
-	$report['total_users'] = count( $users );
-
-	foreach ( $users as $user_id ) {
-		$manual_override = get_user_meta( $user_id, 'extrachill_team_manual_override', true );
-
-		if ( 'add' === $manual_override || 'remove' === $manual_override ) {
-			$report['users_skipped_override']++;
-			continue;
-		}
-
-		$has_main_account = ec_has_main_site_account( $user_id );
-
-		if ( $has_main_account ) {
-			$report['users_with_main_site_account']++;
-
-			$current_status = get_user_meta( $user_id, 'extrachill_team', true );
-			if ( 1 != $current_status ) {
-				update_user_meta( $user_id, 'extrachill_team', 1 );
-				$report['users_updated']++;
-			}
-		} else {
-			$current_status = get_user_meta( $user_id, 'extrachill_team', true );
-			if ( 1 == $current_status ) {
-				update_user_meta( $user_id, 'extrachill_team', 0 );
-				$report['users_updated']++;
-			}
-		}
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	return rest_ensure_response( $report );
+	return rest_ensure_response( $result );
 }
 
 /**
  * Manages team member status for a single user.
  *
+ * Wraps the extrachill/manage-team-member ability.
+ *
  * @param WP_REST_Request $request The REST request object.
  * @return WP_REST_Response|WP_Error Response with result or error.
  */
 function extrachill_api_manage_team_member( $request ) {
-	$user_id = $request->get_param( 'user_id' );
-	$action  = $request->get_param( 'action' );
-
-	$user = get_userdata( $user_id );
-	if ( ! $user ) {
-		return new WP_Error(
-			'user_not_found',
-			'User not found.',
-			array( 'status' => 404 )
-		);
+	$ability = wp_get_ability( 'extrachill/manage-team-member' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'Team members ability is not available.', array( 'status' => 500 ) );
 	}
 
-	switch ( $action ) {
-		case 'force_add':
-			update_user_meta( $user_id, 'extrachill_team_manual_override', 'add' );
-			update_user_meta( $user_id, 'extrachill_team', 1 );
-			return rest_ensure_response(
-				array(
-					'message'        => 'User forced to team member.',
-					'user_id'        => $user_id,
-					'is_team_member' => true,
-					'source'         => 'Manual: Add',
-				)
-			);
+	$result = $ability->execute(
+		array(
+			'user_id' => absint( $request->get_param( 'user_id' ) ),
+			'action'  => $request->get_param( 'action' ),
+		)
+	);
 
-		case 'force_remove':
-			update_user_meta( $user_id, 'extrachill_team_manual_override', 'remove' );
-			update_user_meta( $user_id, 'extrachill_team', 0 );
-			return rest_ensure_response(
-				array(
-					'message'        => 'User forced to non-team member.',
-					'user_id'        => $user_id,
-					'is_team_member' => false,
-					'source'         => 'Manual: Remove',
-				)
-			);
-
-		case 'reset_auto':
-			delete_user_meta( $user_id, 'extrachill_team_manual_override' );
-			$has_main_account = function_exists( 'ec_has_main_site_account' ) ? ec_has_main_site_account( $user_id ) : false;
-			update_user_meta( $user_id, 'extrachill_team', $has_main_account ? 1 : 0 );
-			return rest_ensure_response(
-				array(
-					'message'        => 'User reset to auto sync.',
-					'user_id'        => $user_id,
-					'is_team_member' => $has_main_account,
-					'source'         => 'Auto',
-				)
-			);
-
-		default:
-			return new WP_Error(
-				'invalid_action',
-				'Invalid action specified.',
-				array( 'status' => 400 )
-			);
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
+
+	return rest_ensure_response( $result );
 }


### PR DESCRIPTION
## Summary

Second refactor pass for admin-domain REST routes — replaces inline business logic with canonical ability invocations per [#26](https://github.com/Extra-Chill/extrachill-api/issues/26).

### Handlers refactored (5)

| File | Handler | Ability |
|---|---|---|
| `lifetime-membership.php` | `extrachill_api_grant_lifetime_membership` | `extrachill/grant-lifetime-membership` |
| `lifetime-membership.php` | `extrachill_api_revoke_lifetime_membership` | `extrachill/revoke-lifetime-membership` |
| `taxonomy-sync.php` | `extrachill_api_taxonomy_sync` | `extrachill/sync-taxonomies` |
| `team-members.php` | `extrachill_api_sync_team_members` | `extrachill/sync-team-members` |
| `team-members.php` | `extrachill_api_manage_team_member` | `extrachill/manage-team-member` |

### Server-side gaps (no matching ability — left as-is)

| File | Handler | Missing ability |
|---|---|---|
| `lifetime-membership.php` | `extrachill_api_get_lifetime_memberships` | `extrachill/list-lifetime-memberships` |
| `team-members.php` | `extrachill_api_get_team_members` | `extrachill/list-team-members` |

### What was NOT changed
- Route registration, args, and `permission_callback` — all unchanged
- Sanitize callbacks in `taxonomy-sync.php` — kept for REST arg validation
- `CHANGELOG.md` and version strings — untouched

### Verification
- `find inc -name '*.php' -exec php -l {} \;` — all clean