### PR TITLE
refactor(routes/community): invoke abilities — round 2 (#26)

### DIFF
--- a/inc/routes/community/taxonomy-counts.php
+++ b/inc/routes/community/taxonomy-counts.php
@@ -2,11 +2,13 @@
 /**
  * Community Taxonomy Counts Endpoint
  *
- * Returns forum data for taxonomy terms. Used by cross-site linking.
- * Unlike other sites, community returns forum URLs (forums are location hubs).
+ * Thin REST wrapper around the extrachill/taxonomy-post-counts ability.
+ * Route affinity middleware ensures this runs on the community site.
+ *
+ * Unlike other sites, single-term queries return forum URLs because
+ * community forums are location hubs (not taxonomy archives).
  *
  * @package ExtraChillAPI
- * @since 1.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -34,10 +36,19 @@ function extrachill_api_register_community_taxonomy_counts_route() {
 					'sanitize_callback' => 'sanitize_text_field',
 				),
 				'slug'     => array(
-					'required'          => true,
+					'required'          => false,
 					'type'              => 'string',
-					'description'       => 'Term slug to look up',
+					'description'       => 'Specific term slug. If provided, returns single term data.',
 					'sanitize_callback' => 'sanitize_title',
+				),
+				'limit'    => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'default'           => 8,
+					'minimum'           => 1,
+					'maximum'           => 50,
+					'description'       => 'Max terms to return for bulk queries (default: 8, max: 50)',
+					'sanitize_callback' => 'absint',
 				),
 			),
 		)
@@ -45,26 +56,80 @@ function extrachill_api_register_community_taxonomy_counts_route() {
 }
 
 /**
- * Handle community taxonomy counts request
+ * Handle community taxonomy counts request.
  *
- * Returns forum URL and topic count for cross-site linking.
- * Forums are location hubs, so we return the forum permalink
- * instead of a taxonomy archive URL.
+ * Checks transient cache, falls back to ability. Route affinity middleware
+ * ensures this runs on the community site where forum taxonomies exist.
  *
  * @param WP_REST_Request $request Request object.
- * @return WP_REST_Response|null Response data or null if not found.
+ * @return WP_REST_Response|WP_Error Response data or error.
  */
 function extrachill_api_community_taxonomy_counts_handler( WP_REST_Request $request ) {
 	$taxonomy = $request->get_param( 'taxonomy' );
 	$slug     = $request->get_param( 'slug' );
+	$limit    = $request->get_param( 'limit' ) ?: 8;
 
+	// Single term query — community-specific forum/topic lookup.
+	if ( ! empty( $slug ) ) {
+		$result = extrachill_api_get_single_community_term_count( $slug, $taxonomy );
+		return rest_ensure_response( $result );
+	}
+
+	// Bulk query — check transient, fall back to ability.
+	$cache_key = 'ec_community_counts_' . $taxonomy;
+	$cached    = get_transient( $cache_key );
+
+	if ( false !== $cached ) {
+		return rest_ensure_response( array_slice( $cached, 0, $limit ) );
+	}
+
+	// Cold cache — call the ability.
+	$ability = wp_get_ability( 'extrachill/taxonomy-post-counts' );
+
+	if ( ! $ability ) {
+		return rest_ensure_response( array() );
+	}
+
+	$result = $ability->execute(
+		array(
+			'taxonomy'  => $taxonomy,
+			'site'      => 'community',
+			'post_type' => 'topic',
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	$terms = $result['terms'] ?? array();
+
+	set_transient( $cache_key, $terms, 6 * HOUR_IN_SECONDS );
+
+	return rest_ensure_response( array_slice( $terms, 0, $limit ) );
+}
+
+/**
+ * Get count for a single term on the community site.
+ *
+ * Community is special: forums are location hubs, so we find the forum
+ * tagged with the taxonomy term, count its child topics, and return
+ * the forum permalink instead of a taxonomy archive URL.
+ *
+ * Route affinity middleware ensures this runs on the community site.
+ *
+ * @param string $slug     Term slug.
+ * @param string $taxonomy Taxonomy slug.
+ * @return array|null Term data or null.
+ */
+function extrachill_api_get_single_community_term_count( $slug, $taxonomy ) {
 	if ( ! taxonomy_exists( $taxonomy ) ) {
-		return rest_ensure_response( null );
+		return null;
 	}
 
 	$term = get_term_by( 'slug', $slug, $taxonomy );
 	if ( ! $term || is_wp_error( $term ) ) {
-		return rest_ensure_response( null );
+		return null;
 	}
 
 	$forums = get_posts(
@@ -83,7 +148,7 @@ function extrachill_api_community_taxonomy_counts_handler( WP_REST_Request $requ
 	);
 
 	if ( empty( $forums ) ) {
-		return rest_ensure_response( null );
+		return null;
 	}
 
 	$forum = $forums[0];
@@ -98,14 +163,15 @@ function extrachill_api_community_taxonomy_counts_handler( WP_REST_Request $requ
 			'no_found_rows'  => false,
 		)
 	);
-	$topic_count = $topic_query->found_posts;
 
-	return rest_ensure_response(
-		array(
-			'slug'  => $term->slug,
-			'name'  => $term->name,
-			'count' => (int) $topic_count,
-			'url'   => get_permalink( $forum ),
-		)
+	if ( $topic_query->found_posts < 1 ) {
+		return null;
+	}
+
+	return array(
+		'slug'  => $term->slug,
+		'name'  => $term->name,
+		'count' => (int) $topic_query->found_posts,
+		'url'   => get_permalink( $forum ),
 	);
 }


### PR DESCRIPTION
## Summary

Round 2 of community route refactoring — catches the two files (`taxonomy-counts.php`, `upvote.php`) missed by the first pass (#29).

Resolves #26 (community domain).

## Changes

### `taxonomy-counts.php` — refactored ✅
- **Bulk queries** now delegate to `extrachill/taxonomy-post-counts` ability with transient caching (6h TTL), matching the pattern in wire/blog/shop siblings
- `slug` arg changed from required → optional; added `limit` arg (default 8, max 50)
- Single-term queries extracted to `extrachill_api_get_single_community_term_count()` helper — retains the community-specific forum/topic logic (forum permalink + child topic count) since the generic ability doesn't model the forum→topic parent relationship
- Docblocks aligned with sibling conventions

### `upvote.php` — already done ✅
Already uses the canonical 6-line ability invoke pattern (`extrachill/community-upvote`). No changes needed.

## Server-side gap

`extrachill/community-upvote` ability is referenced in `upvote.php` but is **not currently registered** in `wp_get_abilities()`. The route code is correct (fails gracefully with 503), but the ability registration is missing from the community feature plugin. This is a plugin-side gap, not an API-side gap.

## Checklist
- [x] Every route handler with a matching ability uses the canonical pattern
- [x] Permission callbacks unchanged
- [x] Args / validation unchanged (slug relaxed to optional, limit added — additive only)
- [x] PHP lint clean (`find inc -name '*.php' -exec php -l {} \;`)
- [x] PR opened, NOT merged