### PR TITLE
refactor(routes/users): invoke abilities — round 2 (#26)

### DIFF
--- a/inc/routes/users/leaderboard.php
+++ b/inc/routes/users/leaderboard.php
@@ -36,68 +36,22 @@ function extrachill_api_register_users_leaderboard_routes() {
 }
 
 function extrachill_api_users_leaderboard_get_handler( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/community-get-leaderboard' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-community plugin is required.', array( 'status' => 500 ) );
+	}
+
 	$page     = max( 1, (int) $request->get_param( 'page' ) );
 	$per_page = (int) $request->get_param( 'per_page' );
 	$per_page = max( 1, min( 100, $per_page ) );
 
-	$offset = ( $page - 1 ) * $per_page;
-
-	$query = new WP_User_Query( array(
-		'fields'   => 'all',
-		'orderby'  => 'meta_value_num',
-		'order'    => 'DESC',
-		'number'   => $per_page,
-		'offset'   => $offset,
-		'meta_key' => 'extrachill_total_points',
+	$result = $ability->execute( array(
+		'limit'  => $per_page,
+		'offset' => ( $page - 1 ) * $per_page,
 	) );
-
-	$total_query = new WP_User_Query( array(
-		'fields'   => 'ID',
-		'orderby'  => 'meta_value_num',
-		'order'    => 'DESC',
-		'meta_key' => 'extrachill_total_points',
-	) );
-
-	$total       = (int) $total_query->get_total();
-	$total_pages = $per_page ? (int) ceil( $total / $per_page ) : 1;
-
-	$items = array();
-	$index = 0;
-
-	foreach ( $query->get_results() as $user ) {
-		$user_id = (int) $user->ID;
-		$points  = (float) get_user_meta( $user_id, 'extrachill_total_points', true );
-		$rank    = function_exists( 'ec_get_rank_for_points' ) ? ec_get_rank_for_points( $points ) : '';
-		$badges  = function_exists( 'ec_get_user_badges' ) ? ec_get_user_badges( $user_id ) : array();
-
-		$profile_url = function_exists( 'extrachill_get_user_profile_url' )
-			? extrachill_get_user_profile_url( $user_id, $user->user_email )
-			: get_author_posts_url( $user_id );
-
-		$items[] = array(
-			'id'           => $user_id,
-			'display_name' => $user->display_name,
-			'username'     => $user->user_login,
-			'slug'         => $user->user_nicename,
-			'avatar_url'   => get_avatar_url( $user_id, array( 'size' => 96 ) ),
-			'profile_url'  => $profile_url,
-			'registered'   => mysql2date( 'c', $user->user_registered ),
-			'points'       => $points,
-			'rank'         => $rank,
-			'badges'       => $badges,
-			'position'     => $offset + $index + 1,
-		);
-
-		$index++;
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	return rest_ensure_response( array(
-		'items'      => $items,
-		'pagination' => array(
-			'page'        => $page,
-			'per_page'    => $per_page,
-			'total'       => $total,
-			'total_pages' => $total_pages,
-		),
-	) );
+	return rest_ensure_response( $result );
 }


### PR DESCRIPTION
## Summary

Second pass on users-domain route handlers — refactors routes that were skipped in PR #33 because their matching abilities didn't exist yet.

- **`leaderboard.php`** — replaced inline `WP_User_Query` + points/rank/badge assembly with `extrachill/community-get-leaderboard` ability invocation. Route-level `page`/`per_page` → ability `limit`/`offset` translation kept in the handler (transport-specific concern).

## Skipped — no matching ability registered

These route handlers still own their implementation because no ability exists to delegate to:

| File | Routes | Gap |
|---|---|---|
| `artists.php` | `GET /users/{id}/artists`, `POST /users/{id}/artists`, `DELETE /users/{id}/artists/{artist_id}` | No `extrachill/list-user-artists`, `extrachill/add-user-artist`, `extrachill/remove-user-artist` abilities |
| `search.php` | `GET /users/search` (mentions, admin, artist-capable contexts) | No `extrachill/search-users` ability |

## What's NOT changed

- ✅ Permission callbacks unchanged
- ✅ Args / validation unchanged
- ✅ Route registration untouched
- ✅ `php -l` passes on all files

## Checklist

- [x] Every users-domain route handler with a matching ability uses the canonical 6-line invoke pattern
- [x] Routes without a matching ability stay as-is (gap documented above)
- [x] Permission callbacks unchanged
- [x] Args / validation unchanged
- [x] PHP lint clean (`find inc -name '*.php' -exec php -l {} \;`)
- [x] PR opened, NOT merged

Part of #26 (users domain, round 2).