### PR TITLE
refactor(routes/artists): invoke abilities — round 2 (#26)

### DIFF
--- a/inc/routes/artists/analytics.php
+++ b/inc/routes/artists/analytics.php
@@ -4,8 +4,8 @@
  *
  * GET /wp-json/extrachill/v1/artists/{id}/analytics - Retrieve link page analytics
  *
- * Replaces legacy /analytics/link-page endpoint with artist-centric routing.
- * Automatically resolves link page from artist ID.
+ * Delegates to ability:
+ * - extrachill/artist-get-analytics
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -77,49 +77,25 @@ function extrachill_api_artist_analytics_permission_check( WP_REST_Request $requ
 }
 
 /**
- * GET handler - retrieve artist link page analytics
+ * GET handler - retrieve artist link page analytics via ability.
  */
 function extrachill_api_artist_analytics_handler( WP_REST_Request $request ) {
-	$artist_id  = $request->get_param( 'id' );
+	$ability = wp_get_ability( 'extrachill/artist-get-analytics' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
+	}
+
+	$input = array( 'id' => $request->get_param( 'id' ) );
+
 	$date_range = $request->get_param( 'date_range' );
-
-	if ( ! function_exists( 'ec_get_link_page_for_artist' ) ) {
-		return new WP_Error(
-			'dependency_missing',
-			'Artist platform not active.',
-			array( 'status' => 500 )
-		);
+	if ( $date_range !== null ) {
+		$input['date_range'] = $date_range;
 	}
 
-	$link_page_id = ec_get_link_page_for_artist( $artist_id );
-
-	if ( ! $link_page_id ) {
-		return new WP_Error(
-			'no_link_page',
-			'No link page exists for this artist.',
-			array( 'status' => 404 )
-		);
-	}
-
-	/**
-	 * Retrieve link page analytics via filter hook.
-	 *
-	 * @param mixed $result       Previous filter result (null if no handler).
-	 * @param int   $link_page_id The link page post ID.
-	 * @param int   $date_range   Number of days to query.
-	 */
-	$result = apply_filters( 'extrachill_get_link_page_analytics', null, $link_page_id, $date_range );
+	$result = $ability->execute( $input );
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
-	}
-
-	if ( ! is_array( $result ) ) {
-		return new WP_Error(
-			'analytics_unavailable',
-			'Analytics data could not be retrieved.',
-			array( 'status' => 500 )
-		);
 	}
 
 	return rest_ensure_response( $result );

--- a/inc/routes/artists/permissions.php
+++ b/inc/routes/artists/permissions.php
@@ -5,6 +5,9 @@
  * Registers the /extrachill/v1/artists/{id}/permissions endpoint to check if the current user
  * has permission to edit a specific artist profile. Used by extrachill.link for the
  * client-side edit button.
+ *
+ * Delegates to ability:
+ * - extrachill/artist-get-permissions
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -33,10 +36,13 @@ function extrachill_api_register_artist_permissions_route() {
 }
 
 /**
- * Check artist permissions
+ * Check artist permissions via ability.
+ *
+ * CORS headers for extrachill.link remain a transport-specific concern
+ * owned by this route handler.
  *
  * @param WP_REST_Request $request The request object.
- * @return WP_REST_Response The response object.
+ * @return WP_REST_Response|WP_Error The response object.
  */
 function ec_api_check_artist_permissions( WP_REST_Request $request ) {
 	// Handle CORS for extrachill.link
@@ -47,21 +53,16 @@ function ec_api_check_artist_permissions( WP_REST_Request $request ) {
 		header( 'Vary: Origin' );
 	}
 
-	$artist_id       = $request->get_param( 'id' );
-	$current_user_id = get_current_user_id();
-	$can_edit        = false;
-	$manage_url      = '';
-
-	if ( $artist_id && $current_user_id && function_exists( 'ec_can_manage_artist' ) && ec_can_manage_artist( $current_user_id, $artist_id ) ) {
-		$can_edit   = true;
-		$manage_url = home_url( '/manage-link-page/' );
+	$ability = wp_get_ability( 'extrachill/artist-get-permissions' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 	}
 
-	return rest_ensure_response(
-		array(
-			'can_edit'   => $can_edit,
-			'manage_url' => $manage_url,
-			'user_id'    => $current_user_id,
-		)
-	);
+	$result = $ability->execute( array( 'id' => $request->get_param( 'id' ) ) );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }

--- a/inc/routes/artists/roster.php
+++ b/inc/routes/artists/roster.php
@@ -6,6 +6,14 @@
  * POST   /artists/{id}/roster                      - Invite member by email
  * DELETE /artists/{id}/roster/{user_id}            - Remove roster member
  * DELETE /artists/{id}/roster/invites/{invite_id}  - Cancel pending invite
+ *
+ * Delegates to abilities:
+ * - extrachill/artist-get-roster (GET list)
+ *
+ * Handlers without matching abilities (server-side gap):
+ * - POST   invite member
+ * - DELETE remove member
+ * - DELETE cancel invite
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -139,72 +147,24 @@ function extrachill_api_artist_roster_invite_handler( WP_REST_Request $request )
 }
 
 /**
- * Lists linked members and pending invites for an artist.
+ * Lists linked members and pending invites for an artist via ability.
  *
  * @param WP_REST_Request $request The request object.
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_artist_roster_list_handler( WP_REST_Request $request ) {
-	$artist_id = $request->get_param( 'id' );
-
-	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
-		return new WP_Error(
-			'invalid_artist',
-			__( 'Invalid artist specified.', 'extrachill-api' ),
-			array( 'status' => 400 )
-		);
+	$ability = wp_get_ability( 'extrachill/artist-get-roster' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 	}
 
-	if ( ! function_exists( 'ec_can_manage_artist' ) || ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
-		return new WP_Error(
-			'permission_denied',
-			__( 'You do not have permission to view the roster for this artist.', 'extrachill-api' ),
-			array( 'status' => 403 )
-		);
+	$result = $ability->execute( array( 'id' => $request->get_param( 'id' ) ) );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	$members = array();
-	if ( function_exists( 'ec_get_linked_members' ) ) {
-		$linked_members = ec_get_linked_members( $artist_id );
-		if ( is_array( $linked_members ) ) {
-			foreach ( $linked_members as $member ) {
-				$user_info = get_userdata( $member->ID );
-				if ( $user_info ) {
-					$members[] = array(
-						'id'           => (int) $user_info->ID,
-						'display_name' => $user_info->display_name,
-						'username'     => $user_info->user_login,
-						'email'        => $user_info->user_email,
-						'avatar_url'   => get_avatar_url( $user_info->ID, array( 'size' => 60 ) ),
-						'profile_url'  => function_exists( 'extrachill_get_user_profile_url' ) ? extrachill_get_user_profile_url( $user_info->ID, $user_info->user_email ) : '',
-					);
-				}
-			}
-		}
-	}
-
-	$invites = array();
-	if ( function_exists( 'ec_get_pending_invitations' ) ) {
-		$pending = ec_get_pending_invitations( $artist_id );
-		if ( is_array( $pending ) ) {
-			foreach ( $pending as $invite ) {
-				$invited_on = isset( $invite['invited_on'] ) ? (int) $invite['invited_on'] : 0;
-				$invites[]  = array(
-					'id'                   => isset( $invite['id'] ) ? $invite['id'] : '',
-					'email'                => isset( $invite['email'] ) ? $invite['email'] : '',
-					'of_existing_user'     => email_exists( isset( $invite['email'] ) ? $invite['email'] : '' ) ? true : false,
-					'status'               => isset( $invite['status'] ) ? $invite['status'] : '',
-					'invited_on'           => $invited_on,
-					'invited_on_formatted' => $invited_on ? date_i18n( get_option( 'date_format' ), $invited_on ) : '',
-				);
-			}
-		}
-	}
-
-	return rest_ensure_response( array(
-		'members' => $members,
-		'invites' => $invites,
-	) );
+	return rest_ensure_response( $result );
 }
 
 /**

--- a/inc/routes/artists/subscribe.php
+++ b/inc/routes/artists/subscribe.php
@@ -3,7 +3,9 @@
  * REST route: POST /wp-json/extrachill/v1/artists/{id}/subscribe
  *
  * Public endpoint for subscribing to artist updates.
- * Validates input and fires action hook for subscription handling.
+ *
+ * Delegates to ability:
+ * - extrachill/artist-subscribe
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -33,48 +35,27 @@ function extrachill_api_register_artist_subscribe_route() {
 }
 
 /**
- * Handles artist subscription requests
+ * Handles artist subscription requests via ability.
  *
  * @param WP_REST_Request $request The request object.
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_artist_subscribe_handler( $request ) {
-	$artist_id = $request->get_param( 'id' );
-	$email     = $request->get_param( 'email' );
-
-	// Validate email format
-	if ( ! is_email( $email ) ) {
-		return new WP_Error(
-			'invalid_email',
-			__( 'Please enter a valid email address.', 'extrachill-api' ),
-			array( 'status' => 400 )
-		);
+	$ability = wp_get_ability( 'extrachill/artist-subscribe' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 	}
 
-	// Validate artist exists and is correct post type
-	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
-		return new WP_Error(
-			'invalid_artist',
-			__( 'Invalid artist specified.', 'extrachill-api' ),
-			array( 'status' => 400 )
-		);
-	}
-
-	/**
-	 * Fires when a subscription request is received.
-	 *
-	 * Handlers should return WP_Error on failure, or true/null on success.
-	 *
-	 * @param int    $artist_id The artist profile post ID.
-	 * @param string $email     The subscriber's email address.
-	 */
-	$result = apply_filters( 'extrachill_artist_subscribe', null, $artist_id, $email );
+	$result = $ability->execute(
+		array(
+			'id'    => $request->get_param( 'id' ),
+			'email' => $request->get_param( 'email' ),
+		)
+	);
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
 
-	return rest_ensure_response( array(
-		'message' => __( 'Thank you for subscribing!', 'extrachill-api' ),
-	) );
+	return rest_ensure_response( $result );
 }

--- a/inc/routes/artists/subscribers.php
+++ b/inc/routes/artists/subscribers.php
@@ -4,6 +4,10 @@
  *
  * GET /wp-json/extrachill/v1/artists/{id}/subscribers - Fetch paginated subscribers
  * GET /wp-json/extrachill/v1/artists/{id}/subscribers/export - Fetch all subscribers for CSV export
+ *
+ * Delegates to abilities:
+ * - extrachill/artist-list-subscribers
+ * - extrachill/artist-export-subscribers
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -60,109 +64,61 @@ function extrachill_api_register_artist_subscribers_routes() {
 }
 
 /**
- * Handles fetching paginated artist subscribers
+ * Handles fetching paginated artist subscribers via ability.
  *
  * @param WP_REST_Request $request The request object.
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_get_artist_subscribers_handler( WP_REST_Request $request ) {
-	$artist_id = $request->get_param( 'id' );
-	$page      = max( 1, $request->get_param( 'page' ) );
-	$per_page  = max( 1, min( 100, $request->get_param( 'per_page' ) ) );
-
-	// Validate artist exists and is correct post type
-	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
-		return new WP_Error(
-			'invalid_artist',
-			__( 'Invalid artist specified.', 'extrachill-api' ),
-			array( 'status' => 400 )
-		);
+	$ability = wp_get_ability( 'extrachill/artist-list-subscribers' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
 	}
 
-	// Check permission
-	if ( ! function_exists( 'ec_can_manage_artist' ) || ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
-		return new WP_Error(
-			'permission_denied',
-			__( 'You do not have permission to view subscribers for this artist.', 'extrachill-api' ),
-			array( 'status' => 403 )
-		);
+	$input = array( 'id' => $request->get_param( 'id' ) );
+
+	$page = $request->get_param( 'page' );
+	if ( $page !== null ) {
+		$input['page'] = $page;
 	}
 
-	/**
-	 * Fetch subscribers via filter hook
-	 *
-	 * @param mixed $result    Previous filter result (null if no handler has run).
-	 * @param int   $artist_id The artist profile post ID.
-	 * @param array $args      Query arguments (page, per_page).
-	 */
-	$args = array(
-		'page'     => $page,
-		'per_page' => $per_page,
-	);
-	$result = apply_filters( 'extrachill_get_artist_subscribers', null, $artist_id, $args );
+	$per_page = $request->get_param( 'per_page' );
+	if ( $per_page !== null ) {
+		$input['per_page'] = $per_page;
+	}
+
+	$result = $ability->execute( $input );
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
-	}
-
-	if ( ! is_array( $result ) || ! isset( $result['subscribers'] ) ) {
-		return new WP_Error(
-			'fetch_failed',
-			__( 'Could not fetch subscriber data.', 'extrachill-api' ),
-			array( 'status' => 500 )
-		);
 	}
 
 	return rest_ensure_response( $result );
 }
 
 /**
- * Handles exporting all artist subscribers for CSV generation
+ * Handles exporting all artist subscribers for CSV generation via ability.
  *
  * @param WP_REST_Request $request The request object.
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_export_artist_subscribers_handler( WP_REST_Request $request ) {
-	$artist_id        = $request->get_param( 'id' );
+	$ability = wp_get_ability( 'extrachill/artist-export-subscribers' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-artist-platform plugin is required.', array( 'status' => 500 ) );
+	}
+
+	$input = array( 'id' => $request->get_param( 'id' ) );
+
 	$include_exported = $request->get_param( 'include_exported' );
-
-	// Validate artist exists and is correct post type
-	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
-		return new WP_Error(
-			'invalid_artist',
-			__( 'Invalid artist specified.', 'extrachill-api' ),
-			array( 'status' => 400 )
-		);
+	if ( $include_exported !== null ) {
+		$input['include_exported'] = $include_exported;
 	}
 
-	// Check permission
-	if ( ! function_exists( 'ec_can_manage_artist' ) || ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
-		return new WP_Error(
-			'permission_denied',
-			__( 'You do not have permission to export subscribers for this artist.', 'extrachill-api' ),
-			array( 'status' => 403 )
-		);
-	}
-
-	/**
-	 * Export subscribers via filter hook
-	 *
-	 * @param mixed $result           Previous filter result (null if no handler has run).
-	 * @param int   $artist_id        The artist profile post ID.
-	 * @param bool  $include_exported Whether to include already exported subscribers.
-	 */
-	$result = apply_filters( 'extrachill_export_artist_subscribers', null, $artist_id, $include_exported );
+	$result = $ability->execute( $input );
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
-	}
-
-	if ( ! is_array( $result ) || ! isset( $result['subscribers'] ) ) {
-		return new WP_Error(
-			'export_failed',
-			__( 'Could not export subscriber data.', 'extrachill-api' ),
-			array( 'status' => 500 )
-		);
 	}
 
 	return rest_ensure_response( $result );


### PR DESCRIPTION
## Summary

Round 2 refactor of remaining artists-domain REST route handlers to invoke abilities instead of owning logic directly. Per #26.

## Handlers refactored (7 total)

| File | Handler | Ability |
|------|---------|---------|
| `analytics.php` | `extrachill_api_artist_analytics_handler` | `extrachill/artist-get-analytics` |
| `permissions.php` | `ec_api_check_artist_permissions` | `extrachill/artist-get-permissions` |
| `roster.php` | `extrachill_api_artist_roster_list_handler` | `extrachill/artist-get-roster` |
| `subscribe.php` | `extrachill_api_artist_subscribe_handler` | `extrachill/artist-subscribe` |
| `subscribers.php` | `extrachill_api_get_artist_subscribers_handler` | `extrachill/artist-list-subscribers` |
| `subscribers.php` | `extrachill_api_export_artist_subscribers_handler` | `extrachill/artist-export-subscribers` |

## Server-side gaps (no matching ability — left as-is)

| File | Handler | Notes |
|------|---------|-------|
| `roster.php` | `extrachill_api_artist_roster_invite_handler` | POST invite member |
| `roster.php` | `extrachill_api_artist_roster_remove_member_handler` | DELETE remove member |
| `roster.php` | `extrachill_api_artist_roster_cancel_invite_handler` | DELETE cancel invite |

These three roster mutation handlers have no matching ability registered in `extrachill-artist-platform`. They retain their original implementation.

## What's unchanged

- All route URLs, args, and `permission_callback` functions
- CORS headers in `permissions.php` (transport-specific, stays in route handler)
- PHP lint clean (`find inc -name '*.php' -exec php -l {} \;` — zero errors)

Closes #26 (partially — round 2 of artists domain).