### PR TITLE
fix(markdown-export): consume data-machine-events public integration API

### DIFF
--- a/inc/routes/tools/markdown-export.php
+++ b/inc/routes/tools/markdown-export.php
@@ -270,14 +270,20 @@ function extrachill_api_build_topic_replies_markdown( WP_Post $topic ) {
 /**
  * Gets event metadata lines for markdown header.
  *
+ * Uses the data-machine-events public integration API
+ * (`data_machine_events_parse_event_data()`, `datamachine_get_event_dates()`)
+ * to extract event metadata, falling back to the event_dates table + the
+ * venue taxonomy when block-attribute data is missing. See data-machine-events
+ * `docs/integration-api.md` for the contract.
+ *
  * @param WP_Post $post Post object.
  * @return array
  */
 function extrachill_api_get_event_markdown_meta_lines( WP_Post $post ) {
 	$meta_lines = array();
 
-	if ( class_exists( '\\DataMachineEvents\\Blocks\\Calendar\\Calendar_Query' ) ) {
-		$event_data = \DataMachineEvents\Blocks\Calendar\Calendar_Query::parse_event_data( $post );
+	if ( function_exists( 'data_machine_events_parse_event_data' ) ) {
+		$event_data = data_machine_events_parse_event_data( $post );
 		if ( is_array( $event_data ) ) {
 			if ( ! empty( $event_data['startDate'] ) ) {
 				$date = sanitize_text_field( $event_data['startDate'] );
@@ -296,11 +302,10 @@ function extrachill_api_get_event_markdown_meta_lines( WP_Post $post ) {
 	}
 
 	if ( empty( $meta_lines ) ) {
-		if ( class_exists( '\DataMachineEvents\Core\EventDatesTable' ) ) {
-			$dates = \DataMachineEvents\Core\EventDatesTable::get( $post->ID );
-			$event_datetime = $dates ? $dates->start_datetime : '';
-		} else {
-			$event_datetime = '';
+		$event_datetime = '';
+		if ( function_exists( 'datamachine_get_event_dates' ) ) {
+			$dates = datamachine_get_event_dates( $post->ID );
+			$event_datetime = $dates && ! empty( $dates->start_datetime ) ? $dates->start_datetime : '';
 		}
 		if ( $event_datetime ) {
 			$dt           = new DateTime( $event_datetime, wp_timezone() );


### PR DESCRIPTION
## Summary

Closes #41.

Replaces two stale `class_exists()` guards in the markdown-export REST tool with calls into data-machine-events' public integration API (introduced in DM-events 0.32.0, Extra-Chill/data-machine-events#245).

## What was broken

`\DataMachineEvents\Blocks\Calendar\Calendar_Query` was deleted from DM-events some time ago and replaced internally by `EventHydrator`. The `class_exists()` guard at line 279 has been early-returning silently ever since — no fatal, no admin notice. The markdown export of any event post has been falling through to the degraded fallback path with **no parsed `startDate` / `startTime` / `venue` data** for an unknown amount of time.

The fallback path (lines 298–313) was getting some data from the `event_dates` table + raw venue terms, so the output wasn't completely empty — it just missed the parsed `startTime` (so no `at HH:MM` suffix) and used the raw venue term name instead of the block-attribute venue string.

## Changes

| Before | After |
|---|---|
| `class_exists('\DataMachineEvents\Blocks\Calendar\Calendar_Query')` + `Calendar_Query::parse_event_data()` (broken — class deleted upstream) | `function_exists('data_machine_events_parse_event_data')` + `data_machine_events_parse_event_data()` (wraps current `EventHydrator` internally; future-proof) |
| `class_exists('\DataMachineEvents\Core\EventDatesTable')` + `EventDatesTable::get()` | `function_exists('datamachine_get_event_dates')` + `datamachine_get_event_dates()` (existing pre-public global helper) |

The venue-term fallback (`get_the_terms()`) is unchanged — it's WP core, not DM-events internal.

## Verification

- `php -l` clean.
- After deploy, exporting an event post via the markdown-export REST tool returns `**Date:** YYYY-MM-DD at HH:MM` and `**Venue:** Foo Bar` header lines populated from block-attribute data (currently degraded due to the broken `Calendar_Query` reference).

## Compatibility

Requires data-machine-events ≥ 0.32.0 (already deployed to extrachill.com production at v0.32.1).

## Related

- DM-events public API contract: `data-machine-events/docs/integration-api.md`.
- Reference consumer migration: Extra-Chill/extrachill-events#72 (deployed as v0.19.1).
- Outstanding follow-ups: Extra-Chill/extrachill-seo#10, Extra-Chill/extrachill-multisite#14.