### PR TITLE
fix: only pass slug to events upcoming-counts ability when set

### DIFF
--- a/inc/routes/events/upcoming-counts.php
+++ b/inc/routes/events/upcoming-counts.php
@@ -70,11 +70,17 @@ function extrachill_api_events_upcoming_counts_handler( WP_REST_Request $request
 		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$result = $ability->execute( array(
+	$input = array(
 		'taxonomy' => $request->get_param( 'taxonomy' ),
-		'slug'     => $request->get_param( 'slug' ),
 		'limit'    => (int) $request->get_param( 'limit' ),
-	) );
+	);
+
+	$slug = $request->get_param( 'slug' );
+	if ( is_string( $slug ) && '' !== $slug ) {
+		$input['slug'] = $slug;
+	}
+
+	$result = $ability->execute( $input );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}


### PR DESCRIPTION
## Summary
- REST handler at `/extrachill/v1/events/upcoming-counts` was unconditionally forwarding `slug => null` to the `extrachill/events-upcoming-counts` ability.
- Stricter Abilities API input validation now rejects null for a string-typed field, returning `ability_invalid_input`.
- This silently broke the location badge cloud on events.extrachill.com (rendered by `extrachill-events/inc/home/location-badges.php`) and the network cron badge warmer in extrachill-multisite.

## Fix
Only forward `slug` to the ability when the request actually included a non-empty string. Bulk queries omit `slug` entirely.

## Companion fix
Extra-Chill/extrachill-events also gets a schema relaxation so this can't regress from the ability side: https://github.com/Extra-Chill/extrachill-events/pull/new/fix-upcoming-counts-nullable-slug

## Verification
Before:
\`\`\`
curl -s 'https://events.extrachill.com/wp-json/extrachill/v1/events/upcoming-counts?taxonomy=location'
{"code":"ability_invalid_input","message":"Ability \"extrachill/events-upcoming-counts\" has invalid input. Reason: input[slug] is not of type string."}
\`\`\`
After deploy: badge cloud renders, endpoint returns the term array.