### PR TITLE
fix(newsletter): require Turnstile on public newsletter subscribe route

### DIFF
--- a/inc/routes/newsletter/subscription.php
+++ b/inc/routes/newsletter/subscription.php
@@ -16,38 +16,72 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_newsletter_subscription_route' );
 
 function extrachill_api_register_newsletter_subscription_route() {
+	// Admin-mode submissions (list_id present + manage_options/super-admin user) skip
+	// the Turnstile check; only public/anonymous context-based submissions need it.
+	// The closure handles that distinction without forking the route.
+	$permission_callback = function ( WP_REST_Request $request ) {
+		$list_id       = (string) $request->get_param( 'list_id' );
+		$is_admin_mode = '' !== $list_id;
+
+		if ( $is_admin_mode ) {
+			if ( ! is_super_admin() && ! current_user_can( 'manage_options' ) ) {
+				return new WP_Error(
+					'unauthorized',
+					'Admin capability required for direct list subscription',
+					array( 'status' => 403 )
+				);
+			}
+			return true;
+		}
+
+		if ( ! function_exists( 'ec_turnstile_check_request' ) ) {
+			return new WP_Error(
+				'turnstile_missing',
+				__( 'Security verification unavailable.', 'extrachill-api' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return ec_turnstile_check_request( $request );
+	};
+
 	register_rest_route(
 		'extrachill/v1',
 		'/newsletter/subscribe',
 		array(
 			'methods'             => WP_REST_Server::CREATABLE,
 			'callback'            => 'extrachill_api_newsletter_subscribe_handler',
-			'permission_callback' => '__return_true',
+			'permission_callback' => $permission_callback,
 			'args'                => array(
-				'emails'     => array(
+				'emails'             => array(
 					'required'          => true,
 					'type'              => 'array',
 					'validate_callback' => 'extrachill_api_validate_emails_array',
 				),
-				'context'    => array(
+				'context'            => array(
 					'required'          => false,
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 				),
-				'list_id'    => array(
+				'list_id'            => array(
 					'required'          => false,
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 				),
-				'source'     => array(
+				'source'             => array(
 					'required'          => false,
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 				),
-				'source_url' => array(
+				'source_url'         => array(
 					'required'          => false,
 					'type'              => 'string',
 					'sanitize_callback' => 'esc_url_raw',
+				),
+				'turnstile_response' => array(
+					'required'          => false,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
 				),
 			),
 		)
@@ -81,27 +115,17 @@ function extrachill_api_newsletter_subscribe_handler( $request ) {
 	$source     = $request->get_param( 'source' ) ?: '';
 	$source_url = $request->get_param( 'source_url' ) ?: '';
 
-	// Determine subscription mode: direct list_id (admin) or context lookup (public)
+	// Determine subscription mode: direct list_id (admin) or context lookup (public).
+	// Admin-mode capability and public-mode Turnstile checks are enforced in the
+	// permission_callback; this handler only needs to validate input shape.
 	$is_admin_mode = ! empty( $list_id );
 
-	if ( $is_admin_mode ) {
-		// Admin mode: requires super admin (multisite) or manage_options (single site)
-		if ( ! is_super_admin() && ! current_user_can( 'manage_options' ) ) {
-			return new WP_Error(
-				'unauthorized',
-				'Admin capability required for direct list subscription',
-				array( 'status' => 403 )
-			);
-		}
-	} else {
-		// Public mode: requires context
-		if ( empty( $context ) ) {
-			return new WP_Error(
-				'missing_context',
-				'Either list_id (admin) or context (public) is required',
-				array( 'status' => 400 )
-			);
-		}
+	if ( ! $is_admin_mode && empty( $context ) ) {
+		return new WP_Error(
+			'missing_context',
+			'Either list_id (admin) or context (public) is required',
+			array( 'status' => 400 )
+		);
 	}
 
 	// Use ability.


### PR DESCRIPTION
## Summary

Replace `permission_callback => '__return_true'` on `POST /wp-json/extrachill/v1/newsletter/subscribe` with a Turnstile check (for public submissions) and an admin-capability check (for admin submissions). Closes the bot-exploit hole that caused the 2026-04-30 spike of 176 signups in 18 minutes.

## Background

On 2026-04-30 17:00-17:18 UTC, a bot generated 176 newsletter signups (175 in a single hour, peaking 36 in a single second window). Investigation:

- All 176 carried identical `context: "archive"` and `list_id: "kJuiWi91hluwlihq9N7BQg"`
- All from `source_url: https://newsletter.extrachill.com/`
- All `user_id: NULL`
- No real human can solve a CAPTCHA-less form 36 times in a second

Real baseline is 1-2 signups/day. The "+1,035%" spike that surfaced in PROGRESS.md Session 24 was entirely this single-day bot event.

## Fix

Replace the trivial permission_callback with a closure that branches on submission mode:

- **Admin mode** (`list_id` present in body): require `super_admin` or `manage_options`. Skip Turnstile because authenticated admins shouldn't be CAPTCHA'd for legitimate bulk imports.
- **Public mode** (no `list_id`): call `ec_turnstile_check_request()` from extrachill-multisite. Reject with 403 if missing or invalid.

Also adds `turnstile_response` to the route's `args` so the parameter is sanitized through the standard REST pipeline.

## Handler simplification

The handler's old logic duplicated the permission decisions:

```php
if ( $is_admin_mode ) {
    if ( ! is_super_admin() && ! current_user_can( 'manage_options' ) ) {
        return new WP_Error( 'unauthorized', ... );
    }
} else {
    if ( empty( $context ) ) {
        return new WP_Error( 'missing_context', ... );
    }
}
```

The capability check moves to `permission_callback` (where REST permissions belong). The missing-context check stays in the handler because it's input-shape validation, not auth.

## Dependencies

- Requires the new `ec_turnstile_check_request()` helper from extrachill-multisite (companion PR).
- Newsletter forms need to render the Turnstile widget + send the token (companion PR in extrachill-newsletter).

All three should ship together. Deploy order: extrachill-multisite first, then extrachill-newsletter, then this PR last (so the new permission check has both the helper and the frontend wiring it needs).

## Verification after deploy

```bash
# Without a turnstile_response: should 403
curl -X POST https://extrachill.com/wp-json/extrachill/v1/newsletter/subscribe \
  -H 'Content-Type: application/json' \
  -d '{"emails":[{"email":"test@example.com"}],"context":"archive"}'

# With one from a real browser session: should subscribe
# (manual test via the actual form)
```

Also verify in 7 days:

```bash
wp datamachine analytics 404 patterns --days=7
wp extrachill analytics summary --days=7 --user=1
# newsletter_signup baseline should stay ~1-2/day; no more 100+/hr spikes
```

## References

- Investigation: extra-chill-bot PROGRESS.md Session 25
- Multisite PR (helper): Extra-Chill/extrachill-multisite#TBD
- Newsletter PR (frontend): Extra-Chill/extrachill-newsletter#TBD

🤖 Filed by Extra Chill agent