### PR TITLE
refactor: contact/submit — use ec_turnstile_permission_callback() instead of inline check

### DIFF
--- a/inc/routes/contact/submit.php
+++ b/inc/routes/contact/submit.php
@@ -16,7 +16,7 @@ function extrachill_api_register_contact_submit_route() {
 	register_rest_route( 'extrachill/v1', '/contact/submit', array(
 		'methods'             => WP_REST_Server::CREATABLE,
 		'callback'            => 'extrachill_api_handle_contact_submit',
-		'permission_callback' => '__return_true',
+		'permission_callback' => ec_turnstile_permission_callback(),
 		'args'                => array(
 			'name' => array(
 				'required'          => true,
@@ -48,26 +48,6 @@ function extrachill_api_register_contact_submit_route() {
 }
 
 function extrachill_api_handle_contact_submit( WP_REST_Request $request ) {
-	if ( ! function_exists( 'ec_verify_turnstile_response' ) ) {
-		return new WP_Error(
-			'turnstile_missing',
-			__( 'Security verification unavailable.', 'extrachill-api' ),
-			array( 'status' => 500 )
-		);
-	}
-
-	$is_local_environment = defined( 'WP_ENVIRONMENT_TYPE' ) && WP_ENVIRONMENT_TYPE === 'local';
-	$turnstile_bypass     = $is_local_environment || (bool) apply_filters( 'extrachill_bypass_turnstile_verification', false );
-
-	$turnstile_response = $request->get_param( 'turnstile_response' );
-	if ( ! $turnstile_bypass && ( empty( $turnstile_response ) || ! ec_verify_turnstile_response( $turnstile_response ) ) ) {
-		return new WP_Error(
-			'turnstile_failed',
-			__( 'Security verification failed. Please try again.', 'extrachill-api' ),
-			array( 'status' => 403 )
-		);
-	}
-
 	$name    = $request->get_param( 'name' );
 	$email   = $request->get_param( 'email' );
 	$subject = $request->get_param( 'subject' );


### PR DESCRIPTION
Closes #46

## Summary

Replaces the inline 17-line Turnstile verification block in `inc/routes/contact/submit.php` with the shared `ec_turnstile_permission_callback()` factory from extrachill-multisite v1.13.0 (already deployed in production). The Turnstile check now runs at the `permission_callback` layer; the handler body starts directly with input extraction.

Mirrors the pattern established by the newsletter route retrofit (PR #45), which has been live in production. Second consumer of the helper.

## Diff

**Net change: -21 / +1 lines** (one file touched)

- `permission_callback` switched from `'__return_true'` to `ec_turnstile_permission_callback()` (factory invocation — returns a closure)
- Removed: `function_exists( 'ec_verify_turnstile_response' )` guard, local-env bypass logic, manual `ec_verify_turnstile_response()` call, two `WP_Error` returns
- Handler body now begins immediately at `\$name = \$request->get_param( 'name' );`

The dev-bypass paths (`WP_ENVIRONMENT_TYPE === 'local'` and `extrachill_bypass_turnstile_verification` filter) are preserved inside the shared helper, so behavior is unchanged on local environments.

## Error-code drift

| Condition | Before | After |
|---|---|---|
| `ec_verify_turnstile_response` unavailable | `turnstile_missing` (500) | `turnstile_missing` (500) — same |
| Empty token | `turnstile_failed` (403) | `turnstile_missing_token` (403) |
| Invalid token | `turnstile_failed` (403) | `turnstile_failed` (403) — same |

The contact form frontend (`extrachill-contact/blocks/contact-form/view.js`) displays `error.message` verbatim and does not branch on error code strings. Drift is cosmetic in the response body only.

## Manual smoke-test checklist (from issue #46 acceptance criteria)

- [ ] `permission_callback` uses the new helper ✅ (in diff)
- [ ] Manual Turnstile block removed from handler body ✅ (in diff)
- [ ] Submit the contact form end-to-end on a configured environment, confirm it goes through
- [ ] POST with empty `turnstile_response` returns 403
- [ ] POST with garbage `turnstile_response` returns 403
- [ ] No regression in dev-bypass behavior (`WP_ENVIRONMENT_TYPE === 'local'` or `extrachill_bypass_turnstile_verification` filter)

## Verification

- `php -l inc/routes/contact/submit.php` → no syntax errors
- No installed test harness in this checkout (`composer test` requires `vendor/bin/phpunit` which is absent); no automated tests touch this route

---

mention <@532385681268408341> when complete and ready for review