### PR TITLE
fix(auth): require Turnstile on /auth/login REST route

### DIFF
--- a/inc/routes/auth/login.php
+++ b/inc/routes/auth/login.php
@@ -17,45 +17,73 @@ add_action( 'extrachill_api_register_routes', 'extrachill_api_register_auth_logi
  * Registers the auth login route.
  */
 function extrachill_api_register_auth_login_route() {
+	// Web clients must pass a Turnstile challenge; native app clients opt out
+	// by sending the HTTP_EXTRACHILL_CLIENT: app header (same policy as the
+	// registration route). Captcha runs BEFORE password validation and 2FA,
+	// so no 2FA-specific code change is needed.
+	$permission_callback = function ( WP_REST_Request $request ) {
+		$is_app_client = isset( $_SERVER['HTTP_EXTRACHILL_CLIENT'] )
+			&& 'app' === sanitize_text_field( wp_unslash( $_SERVER['HTTP_EXTRACHILL_CLIENT'] ) );
+
+		if ( $is_app_client ) {
+			return true;
+		}
+
+		if ( ! function_exists( 'ec_turnstile_check_request' ) ) {
+			return new WP_Error(
+				'turnstile_missing',
+				__( 'Security verification unavailable.', 'extrachill-api' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return ec_turnstile_check_request( $request );
+	};
+
 	register_rest_route(
 		'extrachill/v1',
 		'/auth/login',
 		array(
 			'methods'             => WP_REST_Server::CREATABLE,
 			'callback'            => 'extrachill_api_auth_login_handler',
-			'permission_callback' => '__return_true',
+			'permission_callback' => $permission_callback,
 			'args'                => array(
-				'identifier'  => array(
+				'identifier'         => array(
 					'required'          => true,
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 				),
-				'password'    => array(
+				'password'           => array(
 					'required' => true,
 					'type'     => 'string',
 				),
-				'device_id'   => array(
+				'device_id'          => array(
 					'required'          => true,
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 				),
-				'device_name' => array(
+				'device_name'        => array(
 					'required'          => false,
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 				),
-				'remember'    => array(
+				'remember'           => array(
 					'required' => false,
 					'type'     => 'boolean',
 				),
-				'set_cookie'  => array(
+				'set_cookie'         => array(
 					'required' => false,
 					'type'     => 'boolean',
 				),
-				'redirect_to' => array(
+				'redirect_to'        => array(
 					'required'          => false,
 					'type'              => 'string',
 					'sanitize_callback' => 'esc_url_raw',
+				),
+				'turnstile_response' => array(
+					'required'          => false,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
 				),
 			),
 		)


### PR DESCRIPTION
Closes #47

## ⚠️ Behavior-changing — read before merging

**This PR closes a real security gap by adding a Cloudflare Turnstile (captcha) check to `POST /wp-json/extrachill/v1/auth/login`.**

After this ships, web clients calling `/auth/login` without a valid `turnstile_response` will get a **403** from the permission_callback. Native app clients are **exempt** via the existing `HTTP_EXTRACHILL_CLIENT: app` header opt-out (same policy as the registration route).

**The web login form needs frontend wiring to render the Turnstile widget and pass the token.** That wiring is tracked in a follow-up issue: **Extra-Chill/extrachill-users#39**. Until that frontend PR is also ready to ship, **do not deploy this backend PR to production — web logins will break network-wide.**

Recommended deploy order:

1. Land + stage extrachill-users#39 frontend wiring (do not deploy yet)
2. Land this PR (do not deploy yet)
3. Deploy both in the same release window

## What changed

`inc/routes/auth/login.php`:

- `permission_callback` switched from `'__return_true'` to a closure that:
  - Returns `true` immediately if `HTTP_EXTRACHILL_CLIENT: app` header is present (app opt-out)
  - Returns a `turnstile_missing` 500 `WP_Error` if `ec_turnstile_check_request()` isn't loaded (extrachill-multisite v1.13.0+ provides it; live in production)
  - Otherwise delegates to `ec_turnstile_check_request( \$request )`
- Added `turnstile_response` to the route's `args` (sanitized via `sanitize_text_field`)
- Inline comment documenting the app opt-out policy and the 2FA ordering note

The closure pattern is copied from `inc/routes/newsletter/subscription.php`, which has been running this exact shape against the live `ec_turnstile_check_request()` helper since #45.

## 2FA note

Captcha runs in `permission_callback`, which fires **before** the handler ever calls `extrachill_users_login_with_tokens()`. That means the new flow is:

> captcha → password validation → 2FA challenge (if enabled)

No 2FA-specific code change is required. Users with Two-Factor enabled will see the captcha first, then their password prompt, then their 2FA challenge — same order as before, just with one extra (usually-invisible) step at the front.

## Proposed release-note copy

> **Login security improvement.** The Extra Chill web login now runs a silent Cloudflare Turnstile check to protect against automated credential-stuffing attacks. Most users will see no change — the challenge resolves invisibly in the background. If you're prompted to verify you're human, complete the challenge and log in normally. Native app clients are unaffected.

## Acceptance criteria (from #47)

- [x] `/auth/login` route requires `turnstile_response` for non-app-client requests (enforced via closure permission_callback)
- [x] App-client opt-out works (`HTTP_EXTRACHILL_CLIENT: app` header bypasses the check)
- [ ] Login form renders the Turnstile widget and passes the token in the POST body — **tracked in Extra-Chill/extrachill-users#39**
- [ ] Manual smoke test: log in via the web form with a real captcha challenge — succeeds → **blocked on #39**
- [ ] Manual smoke test: POST to `/auth/login` without `turnstile_response` from a non-app client — 403 → ready to test after merge
- [ ] Manual smoke test: POST to `/auth/login` with `HTTP_EXTRACHILL_CLIENT: app` and no captcha — succeeds (still subject to `wp_authenticate`) → ready to test after merge
- [x] 2FA flow unaffected for users with Two-Factor enabled (captcha is added in front of the existing flow; no service-layer change)
- [x] Release notes prepared for the user-facing UX change (see "Proposed release-note copy" above)

## Verification performed in this branch

- `php -l inc/routes/auth/login.php` → clean
- Existing integration tests in `tests/integration/test-auth-routes.php` call the handler function directly, bypassing `permission_callback`, so they continue to pass without modification
- Diff is small and self-contained (1 file, +36/-8)

## Risks & caveats

- **Hard dependency on extrachill-multisite v1.13.0+** being active network-wide (it already is — confirmed in production). If `ec_turnstile_check_request()` somehow goes missing, the route fails closed with a 500 rather than silently allowing unauthenticated traffic.
- **Frontend follow-up (extrachill-users#39) is mandatory before deploying.** Without it, every web login gets a 403.
- **No change to `/auth/google` OAuth route.** OAuth flows have their own anti-abuse measures (Google's). Flagged in #47 as out of scope for this fix — file separately if we want extra defense in depth.

## Related

- Surfaced during audit: Extra-Chill/extrachill-multisite#25
- Network 404 firehose context: Extra-Chill/extrachill-multisite#23
- Helper introduced in: Extra-Chill/extrachill-multisite#24
- Same closure pattern: Extra-Chill/extrachill-api#45 (newsletter)
- Frontend follow-up: Extra-Chill/extrachill-users#39

---

<@532385681268408341> ready for review.