### PR TITLE
refactor: enforce Turnstile on /event-submissions route (extrachill-events#84)

### DIFF
--- a/inc/routes/events/event-submissions.php
+++ b/inc/routes/events/event-submissions.php
@@ -12,10 +12,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_event_submission_route' );
 
 function extrachill_api_register_event_submission_route() {
+	// Captcha (Cloudflare Turnstile) is enforced here, at the human-facing
+	// boundary. The underlying extrachill/submit-event ability is captcha-
+	// free so it can be called from CLI, admin forms, or scheduled reruns
+	// without fabricating a token.
+	$turnstile_callback = function_exists( 'ec_turnstile_permission_callback' )
+		? ec_turnstile_permission_callback()
+		: '__return_true';
+
 	register_rest_route( 'extrachill/v1', '/event-submissions', array(
 		'methods'             => WP_REST_Server::CREATABLE,
 		'callback'            => 'extrachill_api_handle_event_submission',
-		'permission_callback' => '__return_true',
+		'permission_callback' => $turnstile_callback,
 		'args'                => array(
 			'turnstile_response' => array(
 				'required' => false,
@@ -46,7 +54,6 @@ function extrachill_api_handle_event_submission( WP_REST_Request $request ) {
 		'notes'              => sanitize_textarea_field( $request->get_param( 'notes' ) ),
 		'contact_name'       => sanitize_text_field( $request->get_param( 'contact_name' ) ),
 		'contact_email'      => sanitize_email( $request->get_param( 'contact_email' ) ),
-		'turnstile_response' => sanitize_text_field( $request->get_param( 'turnstile_response' ) ),
 		'system_prompt'      => sanitize_textarea_field( $request->get_param( 'system_prompt' ) ),
 	);
 


### PR DESCRIPTION
Coordinates with Extra-Chill/extrachill-events#84.

## Summary

Moves Cloudflare Turnstile enforcement for `POST /wp-json/extrachill/v1/event-submissions` from inside the `extrachill/submit-event` ability up to this route's `permission_callback`, using `ec_turnstile_permission_callback()` from extrachill-multisite v1.13.0 (already deployed).

This matches the pattern already in place for the newsletter route (see `inc/routes/newsletter/subscription.php`).

## Why

The captcha is a human-boundary concern that belongs at the REST surface, not inside business-logic primitives. After this PR + its pair in extrachill-events, the underlying `extrachill/submit-event` ability is captcha-free and can be invoked from CLI, admin forms, or scheduled re-runs of failed submissions without fabricating a Turnstile token.

## Changes

`inc/routes/events/event-submissions.php`:

- `permission_callback` changed from `'__return_true'` to `ec_turnstile_permission_callback()`, with a `function_exists()` guard that falls back to `'__return_true'` if extrachill-multisite is deactivated (avoids hard-failing the route)
- `turnstile_response` removed from the `$input` array passed to the ability (the ability no longer reads it)
- `turnstile_response` kept in the route's `args` block so the parameter is sanitized through REST and visible to the permission callback

Net diff: **+9 / -2 lines**.

## Coordinating PR

extrachill-events: https://github.com/Extra-Chill/extrachill-events/pull/85

These two PRs must ship together. The route starts checking Turnstile in this PR; the ability stops checking it in the events PR. Review as a pair.

## Smoke test checklist

- [ ] `php -l` clean (confirmed locally)
- [ ] Submit an event via the public form on events.extrachill.com after both PRs ship — confirm it goes through
- [ ] POST to `/event-submissions` with no `turnstile_response` returns 403 with a `turnstile_*` error code
- [ ] POST with a valid token still succeeds end-to-end

## Error-code drift (cosmetic only)

| Condition | Before (in ability) | After (in route permission_callback) |
|---|---|---|
| Helper unavailable | `turnstile_unavailable` (500) | `turnstile_missing` (500) |
| Empty token | `turnstile_failed` (403) | `turnstile_missing_token` (403) |
| Invalid token | `turnstile_failed` (403) | `turnstile_failed` (403) |

Frontend at `extrachill-events/blocks/event-submission/view.js` displays `error.message` verbatim; drift is cosmetic.

---

cc <@532385681268408341>