### PR TITLE
fix: pass location_slug param to events-upcoming-counts ability

### DIFF
--- a/inc/routes/events/upcoming-counts.php
+++ b/inc/routes/events/upcoming-counts.php
@@ -29,20 +29,26 @@ function extrachill_api_register_events_upcoming_counts_route() {
 			'callback'            => 'extrachill_api_events_upcoming_counts_handler',
 			'permission_callback' => '__return_true',
 			'args'                => array(
-				'taxonomy' => array(
+				'taxonomy'      => array(
 					'required'          => true,
 					'type'              => 'string',
 					'enum'              => array( 'venue', 'location', 'artist', 'festival' ),
 					'description'       => 'Taxonomy to query: venue, location, artist, or festival',
 					'sanitize_callback' => 'sanitize_text_field',
 				),
-				'slug'     => array(
+				'slug'          => array(
 					'required'          => false,
 					'type'              => 'string',
 					'description'       => 'Specific term slug. If provided, returns single term data.',
 					'sanitize_callback' => 'sanitize_title',
 				),
-				'limit'    => array(
+				'location_slug' => array(
+					'required'          => false,
+					'type'              => 'string',
+					'description'       => 'Optional location term slug to scope bulk venue counts to a single city. Only applied when taxonomy is "venue".',
+					'sanitize_callback' => 'sanitize_title',
+				),
+				'limit'         => array(
 					'required'          => false,
 					'type'              => 'integer',
 					'default'           => 0,
@@ -78,6 +84,11 @@ function extrachill_api_events_upcoming_counts_handler( WP_REST_Request $request
 	$slug = $request->get_param( 'slug' );
 	if ( is_string( $slug ) && '' !== $slug ) {
 		$input['slug'] = $slug;
+	}
+
+	$location_slug = $request->get_param( 'location_slug' );
+	if ( is_string( $location_slug ) && '' !== $location_slug ) {
+		$input['location_slug'] = $location_slug;
 	}
 
 	$result = $ability->execute( $input );


### PR DESCRIPTION
## Summary

The `/extrachill/v1/events/upcoming-counts` REST route was silently dropping the `location_slug` query parameter when forwarding to the `extrachill/events-upcoming-counts` ability. With the ability change shipped in `extrachill-events` v0.22.0 (PR Extra-Chill/extrachill-events#88), callers using the location scope were falling through to the **unscoped global cache** and getting top venues across the whole country instead of venues in the requested city.

## Bug discovered in production

After deploying v0.22.0, the Charleston location archive at https://events.extrachill.com/location/usa/south-carolina/charleston/ rendered venue badges for **Spotted Cat Music Club (New Orleans), Red Rocks (Colorado), Grand Ole Opry (Nashville)** etc. — clearly not Charleston venues.

Direct ability invocation worked correctly:

```
wp eval 'wp_get_ability("extrachill/events-upcoming-counts")->execute([
    "taxonomy" => "venue",
    "location_slug" => "charleston",
])'
```

returned the correct Charleston-scoped venues (The Dinghy, Starlight Motor Inn, Charleston Tin Roof, etc.). The bug was confined to the REST route handler.

## Fix

- Register `location_slug` as a known route arg with `sanitize_title` sanitization
- Forward `location_slug` to the ability when non-empty, matching the existing pattern for `slug`

## Verification

After deploy, the Charleston location archive should render Charleston-only venue badges. The scoped transient `ec_upcoming_counts_venue_loc_charleston` already exists with correct data (populated by direct ability test); only the REST path needed wiring.

## Related

- Extra-Chill/extrachill-events#86 (parent issue)
- Extra-Chill/extrachill-events#88 (ability extension, already deployed)