### PR TITLE
refactor: thin /users/search REST handler to extrachill/users-search ability

### DIFF
--- a/inc/routes/users/search.php
+++ b/inc/routes/users/search.php
@@ -4,6 +4,10 @@
  *
  * GET /wp-json/extrachill/v1/users/search - Search users by term
  *
+ * Thin wrapper around the extrachill/users-search ability. All search logic
+ * (column selection, context handling, artist-capable filtering) lives in
+ * the ability implementation in the extrachill-users plugin.
+ *
  * Contexts:
  * - mentions (default): Logged-in only, lightweight response for @mentions autocomplete
  * - admin: Admin-only, full user data for relationship management
@@ -17,226 +21,90 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_user_search_routes' );
 
 function extrachill_api_register_user_search_routes() {
-	register_rest_route( 'extrachill/v1', '/users/search', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_user_search_handler',
-		'permission_callback' => 'extrachill_api_user_search_permission_check',
-		'args'                => array(
-			'term'    => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
+	register_rest_route(
+		'extrachill/v1',
+		'/users/search',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_user_search_handler',
+			'permission_callback' => 'extrachill_api_user_search_permission_check',
+			'args'                => array(
+				'term'              => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'context'           => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => 'mentions',
+					'enum'              => array( 'mentions', 'admin', 'artist-capable' ),
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'exclude_artist_id' => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
 			),
-			'context' => array(
-				'required'          => false,
-				'type'              => 'string',
-				'default'           => 'mentions',
-				'enum'              => array( 'mentions', 'admin', 'artist-capable' ),
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-			'exclude_artist_id' => array(
-				'required'          => false,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
-			),
-		),
-	) );
+		)
+	);
 }
 
-	/**
-	 * Permission check for user search endpoint
-	 *
-	 * - mentions context: Requires logged-in user
-	 * - admin context: Requires manage_options capability
-	 * - artist-capable context: Requires logged-in user who can create artist profiles
-	 */
-	function extrachill_api_user_search_permission_check( WP_REST_Request $request ) {
-		$context = $request->get_param( 'context' );
-
-		if ( $context === 'mentions' && ! is_user_logged_in() ) {
-			return new WP_Error(
-				'rest_forbidden',
-				'Must be logged in.',
-				array( 'status' => 401 )
-			);
-		}
-
-		if ( $context === 'admin' ) {
-			if ( ! current_user_can( 'manage_options' ) ) {
-				return new WP_Error(
-					'rest_forbidden',
-					'Admin access required.',
-					array( 'status' => 403 )
-				);
-			}
-		}
-
-		if ( $context === 'artist-capable' ) {
-			if ( ! is_user_logged_in() ) {
-				return new WP_Error(
-					'rest_forbidden',
-					'Must be logged in.',
-					array( 'status' => 401 )
-				);
-			}
-
-			if ( ! function_exists( 'ec_can_create_artist_profiles' ) || ! ec_can_create_artist_profiles( get_current_user_id() ) ) {
-				return new WP_Error(
-					'rest_forbidden',
-					'Cannot manage artist profiles.',
-					array( 'status' => 403 )
-				);
-			}
-		}
-
-		return true;
+/**
+ * Permission check for user search endpoint.
+ *
+ * Gates at logged-in users. Context-specific permission checks
+ * (admin requires manage_options, artist-capable requires
+ * ec_can_create_artist_profiles) live in the ability's execute_callback
+ * which can read the sanitized input.
+ *
+ * @param WP_REST_Request $request The REST request object.
+ * @return bool|WP_Error True if authorized, WP_Error otherwise.
+ */
+function extrachill_api_user_search_permission_check( WP_REST_Request $request ) {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error(
+			'rest_forbidden',
+			'Must be logged in.',
+			array( 'status' => 401 )
+		);
 	}
 
+	return true;
+}
+
 /**
- * Search handler - find users by term
+ * Search handler - thin wrapper around extrachill/users-search ability.
+ *
+ * @param WP_REST_Request $request The REST request object.
+ * @return WP_REST_Response|WP_Error Response with user list or error.
  */
 function extrachill_api_user_search_handler( WP_REST_Request $request ) {
-	$term    = $request->get_param( 'term' );
-	$context = $request->get_param( 'context' );
-
-	if ( empty( $term ) ) {
+	$ability = wp_get_ability( 'extrachill/users-search' );
+	if ( ! $ability ) {
 		return new WP_Error(
-			'missing_search_term',
-			'Search term is required.',
-			array( 'status' => 400 )
+			'ability_not_found',
+			'Users search ability is not available.',
+			array( 'status' => 500 )
 		);
 	}
 
-	// Require minimum 2 characters for admin and artist-capable contexts
-	if ( in_array( $context, array( 'admin', 'artist-capable' ), true ) && strlen( $term ) < 2 ) {
-		return rest_ensure_response( array() );
-	}
+	$input = array(
+		'term'    => $request->get_param( 'term' ),
+		'context' => $request->get_param( 'context' ),
+	);
 
-	// Handle artist-capable context separately due to meta filtering
-	if ( $context === 'artist-capable' ) {
-		return extrachill_api_search_artist_capable_users( $request );
-	}
-
-	$search_columns = array( 'user_login', 'user_nicename' );
-	$number         = 10;
-
-	// Admin context searches more columns and returns more results
-	if ( $context === 'admin' ) {
-		$search_columns = array( 'user_login', 'user_email', 'display_name' );
-		$number         = 20;
-	}
-
-	$users_query = new WP_User_Query( array(
-		'search'         => '*' . esc_attr( $term ) . '*',
-		'search_columns' => $search_columns,
-		'number'         => $number,
-		'orderby'        => 'display_name',
-		'order'          => 'ASC',
-	) );
-
-	$users_data = array();
-
-	foreach ( $users_query->get_results() as $user ) {
-		if ( $context === 'admin' ) {
-			$users_data[] = array(
-				'id'           => $user->ID,
-				'display_name' => $user->display_name,
-				'username'     => $user->user_login,
-				'email'        => $user->user_email,
-				'avatar_url'   => get_avatar_url( $user->ID, array( 'size' => 32 ) ),
-			);
-		} else {
-			// Mentions context - lightweight response
-			$profile_url = function_exists( 'extrachill_get_user_profile_url' )
-				? extrachill_get_user_profile_url( $user->ID, $user->user_email )
-				: '';
-
-			$users_data[] = array(
-				'id'          => $user->ID,
-				'username'    => $user->user_login,
-				'slug'        => $user->user_nicename,
-				'avatar_url'  => get_avatar_url( $user->ID, array( 'size' => 32 ) ),
-				'profile_url' => $profile_url,
-			);
-		}
-	}
-
-	return rest_ensure_response( $users_data );
-}
-
-/**
- * Search for users who can create artist profiles
- *
- * Filters results to users with:
- * - user_is_artist meta = '1' OR
- * - user_is_professional meta = '1' OR
- * - Team member status (ec_is_team_member)
- *
- * Excludes users who are already roster members of the specified artist.
- */
-function extrachill_api_search_artist_capable_users( WP_REST_Request $request ) {
-	$term              = $request->get_param( 'term' );
 	$exclude_artist_id = $request->get_param( 'exclude_artist_id' );
-
-	// Get existing roster member IDs to exclude
-	$exclude_user_ids = array();
-	if ( $exclude_artist_id && function_exists( 'ec_get_linked_members' ) ) {
-		$linked_members = ec_get_linked_members( $exclude_artist_id );
-		if ( is_array( $linked_members ) ) {
-			foreach ( $linked_members as $member ) {
-				$exclude_user_ids[] = (int) $member->ID;
-			}
-		}
+	if ( ! empty( $exclude_artist_id ) ) {
+		$input['exclude_artist_id'] = absint( $exclude_artist_id );
 	}
 
-	// Search users by term
-	$users_query = new WP_User_Query( array(
-		'search'         => '*' . esc_attr( $term ) . '*',
-		'search_columns' => array( 'user_login', 'user_email', 'display_name' ),
-		'number'         => 50,
-		'orderby'        => 'display_name',
-		'order'          => 'ASC',
-	) );
+	$result = $ability->execute( $input );
 
-	$users_data = array();
-	$count      = 0;
-	$limit      = 10;
-
-	foreach ( $users_query->get_results() as $user ) {
-		if ( $count >= $limit ) {
-			break;
-		}
-
-		// Skip if already a roster member
-		if ( in_array( $user->ID, $exclude_user_ids, true ) ) {
-			continue;
-		}
-
-		// Check if user can create artist profiles
-		$is_artist       = get_user_meta( $user->ID, 'user_is_artist', true ) === '1';
-		$is_professional = get_user_meta( $user->ID, 'user_is_professional', true ) === '1';
-		$is_team_member  = function_exists( 'ec_is_team_member' ) && ec_is_team_member( $user->ID );
-
-		if ( ! $is_artist && ! $is_professional && ! $is_team_member ) {
-			continue;
-		}
-
-		// Build profile URL
-		$profile_url = function_exists( 'extrachill_get_user_profile_url' )
-			? extrachill_get_user_profile_url( $user->ID, $user->user_email )
-			: '';
-
-		$users_data[] = array(
-			'id'           => $user->ID,
-			'display_name' => $user->display_name,
-			'username'     => $user->user_login,
-			'email'        => $user->user_email,
-			'avatar_url'   => get_avatar_url( $user->ID, array( 'size' => 32 ) ),
-			'profile_url'  => $profile_url,
-		);
-
-		$count++;
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	return rest_ensure_response( $users_data );
+	return rest_ensure_response( $result );
 }


### PR DESCRIPTION
## Why

\`inc/routes/users/search.php\` reimplements ~200 lines of user-search logic that is **already implemented identically** as the canonical \`extrachill/users-search\` ability in extrachill-users. Per RULES.md:

> \`extrachill-api\` is a REST wrapper ONLY: abilities own logic/writes; REST handlers must be thin calls to \`wp_get_ability()->execute()\`.

The duplicated route is a layering bug. Same pattern as Extra-Chill/extrachill-api#4 (search routes) and the broader ability-delegation effort.

## What changes

- Replace the inline \`WP_User_Query\` + \`extrachill_api_search_artist_capable_users\` implementation with a single \`wp_get_ability( 'extrachill/users-search' )->execute( \$input )\` call.
- Permission callback gates at \`is_user_logged_in()\` only. Context-specific checks (\`admin\` requires \`manage_options\`, \`artist-capable\` requires \`ec_can_create_artist_profiles\`) live inside the ability's \`execute_callback\` — where they already exist — so they run regardless of whether the ability is invoked via REST, CLI, or chat tool.
- Route argument schema unchanged. Response shape unchanged.

## Verification

\`\`\`
wp eval '
  wp_set_current_user( 1 );
  \$ability = wp_get_ability( \"extrachill/users-search\" );
  \$result = \$ability->execute( array( \"term\" => \"chubes\", \"context\" => \"mentions\" ) );
  // returns 4 results, same shape as REST endpoint
'
\`\`\`

## Relation to other in-flight work

This PR is the REST-side mirror of the @mentions cleanup in:
- Extra-Chill/blocks-everywhere#7 (delete vendor-specific completer)
- Extra-Chill/extrachill-community#32 (re-home @mentions completer)

Both client PRs talk to \`/extrachill/v1/users/search\`. After this PR, that route delegates to the canonical ability instead of duplicating it. No client-visible change.