### PR TITLE
feat: REST handlers for editor abilities (community-multisite#33)

### DIFF
--- a/inc/routes/comments/editor.php
+++ b/inc/routes/comments/editor.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * REST routes: Comment editor
+ *
+ * Thin REST wrappers around comment editor abilities registered by
+ * extrachill-multisite. Each handler is wp_get_ability(...)->execute(...) and
+ * nothing else.
+ *
+ * Endpoints:
+ * - GET  /wp-json/extrachill/v1/comments/<id>/editor
+ * - POST /wp-json/extrachill/v1/comments/<id>/editor
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_comments_editor_routes' );
+
+function extrachill_api_register_comments_editor_routes() {
+
+	register_rest_route(
+		'extrachill/v1',
+		'/comments/(?P<id>[\d]+)/editor',
+		array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_comments_editor_get_handler',
+				'permission_callback' => 'extrachill_api_comments_editor_read_permission',
+				'args'                => array(
+					'blog_id' => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => 'extrachill_api_comments_editor_update_handler',
+				'permission_callback' => 'extrachill_api_comments_editor_write_permission',
+				'args'                => array(
+					'content' => array(
+						'required' => true,
+						'type'     => 'string',
+					),
+					'blog_id' => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			),
+		)
+	);
+}
+
+function extrachill_api_comments_editor_read_permission() {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error( 'rest_forbidden', 'You must be logged in to load comments for editing.', array( 'status' => 401 ) );
+	}
+	return true;
+}
+
+function extrachill_api_comments_editor_write_permission() {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error( 'rest_forbidden', 'You must be logged in to edit comments.', array( 'status' => 401 ) );
+	}
+	return true;
+}
+
+function extrachill_api_comments_editor_get_handler( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/comment-get-for-editor' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_missing', 'comment-get-for-editor ability not available.', array( 'status' => 503 ) );
+	}
+
+	$result = $ability->execute(
+		array(
+			'comment_id' => (int) $request->get_param( 'id' ),
+			'blog_id'    => (int) $request->get_param( 'blog_id' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}
+
+function extrachill_api_comments_editor_update_handler( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/comment-update' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_missing', 'comment-update ability not available.', array( 'status' => 503 ) );
+	}
+
+	$content = $request->get_param( 'content' );
+	$content = is_string( $content ) ? wp_unslash( $content ) : '';
+
+	$result = $ability->execute(
+		array(
+			'comment_id' => (int) $request->get_param( 'id' ),
+			'content'    => $content,
+			'blog_id'    => (int) $request->get_param( 'blog_id' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}

--- a/inc/routes/community/reply-editor.php
+++ b/inc/routes/community/reply-editor.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * REST routes: Community reply editor
+ *
+ * Thin REST wrappers around editor abilities registered by extrachill-community.
+ *
+ * Endpoints:
+ * - GET  /wp-json/extrachill/v1/community/replies/<id>/editor
+ * - POST /wp-json/extrachill/v1/community/replies/<id>/editor
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_community_reply_editor_routes' );
+
+function extrachill_api_register_community_reply_editor_routes() {
+
+	register_rest_route(
+		'extrachill/v1',
+		'/community/replies/(?P<id>[\d]+)/editor',
+		array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_community_reply_editor_get_handler',
+				'permission_callback' => 'extrachill_api_community_reply_editor_read_permission',
+				'args'                => array(
+					'blog_id' => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => 'extrachill_api_community_reply_editor_update_handler',
+				'permission_callback' => 'extrachill_api_community_reply_editor_write_permission',
+				'args'                => array(
+					'content' => array(
+						'required' => true,
+						'type'     => 'string',
+					),
+					'format' => array(
+						'required' => false,
+						'type'     => 'string',
+						'enum'     => array( 'html', 'markdown' ),
+						'default'  => 'html',
+					),
+					'blog_id' => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			),
+		)
+	);
+}
+
+function extrachill_api_community_reply_editor_read_permission() {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error( 'rest_forbidden', 'You must be logged in to load replies for editing.', array( 'status' => 401 ) );
+	}
+	return true;
+}
+
+function extrachill_api_community_reply_editor_write_permission() {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error( 'rest_forbidden', 'You must be logged in to edit replies.', array( 'status' => 401 ) );
+	}
+	return true;
+}
+
+function extrachill_api_community_reply_editor_get_handler( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/community-get-reply-for-editor' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_missing', 'community-get-reply-for-editor ability not available.', array( 'status' => 503 ) );
+	}
+
+	$result = $ability->execute(
+		array(
+			'reply_id' => (int) $request->get_param( 'id' ),
+			'blog_id'  => (int) $request->get_param( 'blog_id' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}
+
+function extrachill_api_community_reply_editor_update_handler( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/community-update-reply' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_missing', 'community-update-reply ability not available.', array( 'status' => 503 ) );
+	}
+
+	$content = $request->get_param( 'content' );
+	$content = is_string( $content ) ? wp_unslash( $content ) : '';
+
+	$result = $ability->execute(
+		array(
+			'reply_id' => (int) $request->get_param( 'id' ),
+			'content'  => $content,
+			'format'   => (string) $request->get_param( 'format' ),
+			'blog_id'  => (int) $request->get_param( 'blog_id' ),
+			'user_id'  => get_current_user_id(),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}

--- a/inc/routes/community/topic-editor.php
+++ b/inc/routes/community/topic-editor.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * REST routes: Community topic editor
+ *
+ * Thin REST wrappers around editor abilities registered by extrachill-community.
+ * Each handler is wp_get_ability(...)->execute(...) and nothing else — domain
+ * logic, permission checks, sanitization, and writes all live in the ability.
+ *
+ * Endpoints:
+ * - GET  /wp-json/extrachill/v1/community/topics/<id>/editor
+ * - POST /wp-json/extrachill/v1/community/topics/<id>/editor
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_community_topic_editor_routes' );
+
+function extrachill_api_register_community_topic_editor_routes() {
+
+	register_rest_route(
+		'extrachill/v1',
+		'/community/topics/(?P<id>[\d]+)/editor',
+		array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_community_topic_editor_get_handler',
+				'permission_callback' => 'extrachill_api_community_topic_editor_read_permission',
+				'args'                => array(
+					'blog_id' => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => 'extrachill_api_community_topic_editor_update_handler',
+				'permission_callback' => 'extrachill_api_community_topic_editor_write_permission',
+				'args'                => array(
+					'title' => array(
+						'required'          => false,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'content' => array(
+						'required' => true,
+						'type'     => 'string',
+					),
+					'format' => array(
+						'required' => false,
+						'type'     => 'string',
+						'enum'     => array( 'html', 'markdown' ),
+						'default'  => 'html',
+					),
+					'blog_id' => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			),
+		)
+	);
+}
+
+function extrachill_api_community_topic_editor_read_permission() {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error( 'rest_forbidden', 'You must be logged in to load topics for editing.', array( 'status' => 401 ) );
+	}
+	return true;
+}
+
+function extrachill_api_community_topic_editor_write_permission() {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error( 'rest_forbidden', 'You must be logged in to edit topics.', array( 'status' => 401 ) );
+	}
+	return true;
+}
+
+function extrachill_api_community_topic_editor_get_handler( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/community-get-topic-for-editor' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_missing', 'community-get-topic-for-editor ability not available.', array( 'status' => 503 ) );
+	}
+
+	$result = $ability->execute(
+		array(
+			'topic_id' => (int) $request->get_param( 'id' ),
+			'blog_id'  => (int) $request->get_param( 'blog_id' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}
+
+function extrachill_api_community_topic_editor_update_handler( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/community-update-topic' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_missing', 'community-update-topic ability not available.', array( 'status' => 503 ) );
+	}
+
+	$content = $request->get_param( 'content' );
+	$content = is_string( $content ) ? wp_unslash( $content ) : '';
+
+	$input = array(
+		'topic_id' => (int) $request->get_param( 'id' ),
+		'content'  => $content,
+		'format'   => (string) $request->get_param( 'format' ),
+		'blog_id'  => (int) $request->get_param( 'blog_id' ),
+		'user_id'  => get_current_user_id(),
+	);
+
+	$title = $request->get_param( 'title' );
+	if ( null !== $title ) {
+		$input['title'] = is_string( $title ) ? wp_unslash( $title ) : '';
+	}
+
+	$result = $ability->execute( $input );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}


### PR DESCRIPTION
## Summary

Thin REST wrappers around the new editor abilities. Implements the **REST surface** portion of Extra-Chill/extrachill-multisite#33.

Each handler is `wp_get_ability(...)->execute(...)` and nothing else — domain logic, permission checks, sanitization, and writes all live in the ability. Matches the existing pattern in `inc/routes/community/topics.php` / `replies.php` / `drafts.php`.

## New endpoints

| Endpoint | Ability |
|---|---|
| `GET /extrachill/v1/community/topics/<id>/editor` | `extrachill/community-get-topic-for-editor` |
| `POST /extrachill/v1/community/topics/<id>/editor` | `extrachill/community-update-topic` |
| `GET /extrachill/v1/community/replies/<id>/editor` | `extrachill/community-get-reply-for-editor` |
| `POST /extrachill/v1/community/replies/<id>/editor` | `extrachill/community-update-reply` |
| `GET /extrachill/v1/comments/<id>/editor` | `extrachill/comment-get-for-editor` |
| `POST /extrachill/v1/comments/<id>/editor` | `extrachill/comment-update` |

Route files auto-load via the existing `RecursiveIteratorIterator` in `ExtraChill_API_Plugin::load_route_files()` — no bootstrap changes required.

## Routing

- **Forum routes** rely on the existing route-affinity middleware (`inc/middleware/route-affinity.php`) to forward `extrachill/v1/*` requests to the home subsite.
- **Comment routes** accept an optional `blog_id` input that the ability uses to `switch_to_blog()` for cross-subsite comments.

## Permission boundary

REST `permission_callback`s only verify `is_user_logged_in()`. Per-object cap checks (`edit_topic`, `edit_reply`, `edit_comment`, `bbp_past_edit_lock`) live in the ability `permission_callback` so the ability stays self-defending regardless of caller (REST, CLI, chat, MCP).

## Paired PRs

- **extrachill-community** — forum topic/reply editor abilities — https://github.com/Extra-Chill/extrachill-community/pull/34
- **extrachill-multisite** — comment editor abilities + shared `inc/Editor/` helpers — https://github.com/Extra-Chill/extrachill-multisite/pull/34
- **extrachill-api (this PR)** — thin REST wrappers

## Validation

See validation block in the community PR (Extra-Chill/extrachill-community#34) — all 6 abilities register cleanly with schemas matching the contracts in extrachill-multisite#33 verbatim.

## Notes

- No release / no deploy from this PR.
- Conventional commit; no changelog or version bump (homeboy owns both).

Design issue: https://github.com/Extra-Chill/extrachill-multisite/issues/33