### PR TITLE
refactor(events): route /event-submissions directly to extrachill/submit-event

### DIFF
--- a/inc/routes/events/event-submissions.php
+++ b/inc/routes/events/event-submissions.php
@@ -2,6 +2,10 @@
 /**
  * Event submission endpoint — thin REST wrapper for extrachill/submit-event ability.
  *
+ * Calls the underlying extrachill/submit-event ability directly. The legacy
+ * extrachill/events-submit wrapper was a pure pass-through and has been
+ * removed (see Extra-Chill/extrachill-events#104).
+ *
  * @package ExtraChillAPI
  */
 
@@ -38,7 +42,7 @@ function extrachill_api_register_event_submission_route() {
 }
 
 function extrachill_api_handle_event_submission( WP_REST_Request $request ) {
-	$ability = wp_get_ability( 'extrachill/events-submit' );
+	$ability = wp_get_ability( 'extrachill/submit-event' );
 	if ( ! $ability ) {
 		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
 	}


### PR DESCRIPTION
## Summary

The `extrachill/events-submit` ability in `extrachill-events` is a pure pass-through wrapper around `extrachill/submit-event` — same input keys, same output shape, no transformation between layers. The 3-layer indirection (REST → `extrachill/events-submit` → `extrachill/submit-event`) collapses to 2 (REST → `extrachill/submit-event`).

Refs Extra-Chill/extrachill-events#104.

## Audit of `extrachill-events/inc/abilities/*.php`

Every lowercase wrapper in `extrachill-events/inc/abilities/` was read end-to-end and classified:

| Wrapper | Classification | Justification |
|---|---|---|
| `events-submit` | **PURE_PASS_THROUGH** | execute_callback forwards `$input` unchanged to `extrachill/submit-event`, returns result unchanged. Input schemas match. |
| `events-calendar` | HAS_REAL_TRANSFORM | Renames `page → paged`, builds `tax_filter` from slugs, packs geo into `geo_lat/geo_lng/geo_radius`, reshapes `paged_date_groups` envelope into `dates/total/page/has_more`. Out of scope per issue. |
| `events-filters` | HAS_REAL_TRANSFORM | Flattens hierarchical `taxonomies.{venue,promoter,location}` envelope into top-level `venues/promoters/locations`, normalizes `term_id`/`event_count` → `id`/`count`. |
| `events-geocode` | HAS_REAL_TRANSFORM | Renames `q → query`, forces `countrycodes=us`, reshapes Nominatim `{results: [...]}` envelope into flat `[{lat, lon, display_name}, ...]`. |
| `events-get-venue` | HAS_REAL_TRANSFORM | Does NOT delegate to `data-machine-events/get-venue`; reads venue terms + meta directly, parses `coordinates` string into `latitude`/`longitude` floats. Different contract. |
| `events-list-venues` | HAS_REAL_TRANSFORM | Packs `sw_lat/sw_lng/ne_lat/ne_lng` → CSV `bounds`, resolves `location` slug → `taxonomy`+`term_id`, reshapes venue records via `extrachill_events_transform_venue`. |
| `events-check-venue-duplicate` | HAS_REAL_TRANSFORM | Does NOT delegate to `data-machine-events/check-duplicate-venue` (which returns boolean `is_duplicate`); implements `get_terms` `name__like` lookup and returns array of matches via `extrachill_events_transform_venue_detail`. Different semantic contract. |
| `events-upcoming-counts` | HAS_REAL_TRANSFORM | Bulk caching (6hr transient), single-term-by-slug lookup, `location_slug` scoping with extra JOIN, `limit` slicing — none of which exist in `data-machine-events/get-upcoming-counts`. Output shape also differs (flat array vs. `{success, taxonomy, terms, total}`). |

**Conclusion:** only `events-submit` qualifies as a pure pass-through. The other seven wrappers do real work that belongs in the EC layer and stay registered as-is.

## Change

Single-line slug swap in `inc/routes/events/event-submissions.php`:

```diff
-$ability = wp_get_ability( 'extrachill/events-submit' );
+$ability = wp_get_ability( 'extrachill/submit-event' );
```

The REST contract (route URL, method, args, request shape, response shape) is identical. Captcha enforcement still happens at the route's `permission_callback`. The underlying `extrachill/submit-event` ability owns the canonical DM workflow logic.

## Coordination

This is **part 1 of 2**. Merge order:

1. ✅ **Merge this PR first** (extrachill-api). After this lands, the API stops calling the wrapper, so it becomes safe to delete.
2. ⏳ Then merge Extra-Chill/extrachill-events#TBD which deletes `inc/abilities/events-submit.php` and removes the `require_once` from `inc/abilities/register.php`.

Reversing the order would 500 the live `/event-submissions` endpoint between merges.

## Validation

- `php -l` clean on the edited file.
- `grep -r 'extrachill/events-submit'` across `extrachill-api` and `extrachill-events` shows no remaining call sites in this repo or in the (about-to-be-deleted) wrapper file.
- No `CHANGELOG.md` edits. No version-string bumps. Homeboy owns both.

## Out of scope

- The other seven wrappers (all classified HAS_REAL_TRANSFORM above) are untouched.
- The capitalized `inc/Abilities/*.php` directory (real abilities) is untouched.