### PR TITLE
refactor: point leaderboard route at canonical users-leaderboard ability (closes #63)

### DIFF
--- a/inc/routes/users/leaderboard.php
+++ b/inc/routes/users/leaderboard.php
@@ -36,9 +36,9 @@ function extrachill_api_register_users_leaderboard_routes() {
 }
 
 function extrachill_api_users_leaderboard_get_handler( WP_REST_Request $request ) {
-	$ability = wp_get_ability( 'extrachill/community-get-leaderboard' );
+	$ability = wp_get_ability( 'extrachill/users-leaderboard' );
 	if ( ! $ability ) {
-		return new WP_Error( 'ability_not_found', 'extrachill-community plugin is required.', array( 'status' => 500 ) );
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
 	$page     = max( 1, (int) $request->get_param( 'page' ) );
@@ -46,8 +46,8 @@ function extrachill_api_users_leaderboard_get_handler( WP_REST_Request $request 
 	$per_page = max( 1, min( 100, $per_page ) );
 
 	$result = $ability->execute( array(
-		'limit'  => $per_page,
-		'offset' => ( $page - 1 ) * $per_page,
+		'page'     => $page,
+		'per_page' => $per_page,
 	) );
 	if ( is_wp_error( $result ) ) {
 		return $result;


### PR DESCRIPTION
## Summary
Repoints the public REST route `GET /wp-json/extrachill/v1/users/leaderboard` at the canonical `extrachill/users-leaderboard` ability (extrachill-users) instead of the duplicate `extrachill/community-get-leaderboard` (extrachill-community). Resolves Extra-Chill/extrachill-api#63.

## The duplication finding
Two abilities ran nearly the same `WP_User_Query` over user meta `extrachill_total_points`:
- **CANONICAL** `extrachill/users-leaderboard` (extrachill-users) — modern shape `{ items:[{id, display_name, username, slug, avatar_url, profile_url, registered, points, rank, badges[], position}], pagination:{page, per_page, total, total_pages} }`, input `{ page, per_page }`.
- **DUPLICATE** `extrachill/community-get-leaderboard` (extrachill-community) — legacy shape `{ total, users:[{rank, user_id, user_login, display_name, total_points, rank_name}] }`, input `{ limit, offset }`.

The broken link: this route proxied the **duplicate**, but the SDK (`@extrachill/api-client` `LeaderboardResponse`) and the leaderboard block (`extrachill-community/src/blocks/leaderboard/view.tsx`) already expect the **canonical** shape. So the route was returning the wrong shape today — repointing it FIXES the block AND retires the duplicate.

## What this route now returns
The canonical ability's output verbatim via `rest_ensure_response`:
```
{ items: [ { id, display_name, username, slug, avatar_url, profile_url, registered, points, rank, badges[], position } ],
  pagination: { page, per_page, total, total_pages } }
```
No reshaping in the route.

## Changes
- `wp_get_ability('extrachill/community-get-leaderboard')` → `wp_get_ability('extrachill/users-leaderboard')`.
- Pass `page`/`per_page` straight through (removed the page→offset translation; the canonical ability paginates by page/per_page).
- Updated the not-found error message: now depends on **extrachill-users** (Network: true, always loaded), not extrachill-community.

## Request flow (before → after)
```
block (view.tsx) → SDK client.users.leaderboard(page, perPage)
  → GET /wp-json/extrachill/v1/users/leaderboard
  → BEFORE: extrachill/community-get-leaderboard  (legacy {total,users} — WRONG shape for block)
  → AFTER:  extrachill/users-leaderboard          (modern {items,pagination} — matches SDK + block)
```

## Grep proof
After this change, the live tree's only remaining `community-get-leaderboard` callers are the CLI command and the registration — both handled by the cross-linked PRs below. Across the three feature branches there are **zero** remaining references.

## Point calculation stays in community (deliberate non-consolidation)
Per #63, point CALCULATION (`extrachill_get_user_total_points`, increment, recalc queue — earned from bbPress activity) intentionally stays in extrachill-community. This change only unifies READ/leaderboard surfacing, not point earning.

## Coordinated PRs (land together)
- Community (retire duplicate ability): Extra-Chill/extrachill-community `unify-leaderboard-block`
- CLI (migrate `wp extrachill community leaderboard` to canonical ability): Extra-Chill/extrachill-cli `unify-leaderboard-ability`

**Ordering:** This API PR (and the CLI PR) must merge **before or simultaneously with** the community PR, because the community PR removes the `community-get-leaderboard` ability that both consumers used to call. Merging community first (alone) would briefly break both this route and the CLI command.