### PR TITLE
fix: orphan cleanup desyncs artist-user relationship

### DIFF
--- a/inc/routes/admin/artist-relationships.php
+++ b/inc/routes/admin/artist-relationships.php
@@ -353,18 +353,15 @@ function extrachill_api_get_orphaned_relationships() {
  * @return WP_REST_Response
  */
 function extrachill_api_cleanup_orphan( $request ) {
-	$user_id   = $request->get_param( 'user_id' );
-	$artist_id = $request->get_param( 'artist_id' );
+	$user_id   = (int) $request->get_param( 'user_id' );
+	$artist_id = (int) $request->get_param( 'artist_id' );
 
-	$artist_ids = get_user_meta( $user_id, '_artist_profile_ids', true );
-	if ( is_array( $artist_ids ) ) {
-		$artist_ids = array_filter(
-			$artist_ids,
-			function ( $id ) use ( $artist_id ) {
-				return (int) $id !== (int) $artist_id;
-			}
-		);
-		update_user_meta( $user_id, '_artist_profile_ids', array_values( $artist_ids ) );
+	// Route through the canonical two-sided remover so both sides of the
+	// relationship stay in sync: _artist_profile_ids (user meta) AND
+	// _artist_member_ids (artist post meta). Editing only the user side
+	// here would leave a stale link on the artist roster — a new orphan.
+	if ( function_exists( 'ec_remove_artist_membership' ) ) {
+		ec_remove_artist_membership( $user_id, $artist_id );
 	}
 
 	return rest_ensure_response( array( 'success' => true ) );


### PR DESCRIPTION
## Root cause

The `extrachill_api_cleanup_orphan()` REST endpoint (in `inc/routes/admin/artist-relationships.php`) edited only **one side** of a two-sided meta contract. It did a raw `update_user_meta( $user_id, '_artist_profile_ids', ... )` that removed the orphan from the user side only.

The artist↔user membership is bidirectional:
- `_artist_profile_ids` — **user meta**, the artists a user belongs to
- `_artist_member_ids` — **artist post meta**, the artist's roster (lives on the artist blog)

Cleaning up an orphan on the user side while leaving `_artist_member_ids` untouched **creates a new orphan on the opposite side** — the stale link just moves from one meta key to the other.

## Fix

Route the cleanup through the canonical mutator `ec_remove_artist_membership( $user_id, $artist_id )`, which removes **both** sides of the relationship. A `function_exists()` guard is kept as a safety net.

## Verification

Confirmed against the canonical remover in `extrachill-artist-platform/inc/artist-profiles/admin/user-linking.php`:
- **Step 1** removes the artist ID from `_artist_profile_ids` (user meta).
- **Step 2** `switch_to_blog( ec_get_blog_id( 'artist' ) )` and removes the user ID from `_artist_member_ids` (artist post meta), then `restore_current_blog()`.
- Signature is `ec_remove_artist_membership( $user_id, $artist_id )` — matches the endpoint's params.

`php -l` passes on the changed file.

Closes #65.