### PR TITLE
refactor: remove raw SQL from analytics/meta REST handler (refs #69)

### DIFF
--- a/inc/routes/analytics/meta.php
+++ b/inc/routes/analytics/meta.php
@@ -33,37 +33,21 @@ function extrachill_api_register_analytics_meta_routes() {
 /**
  * Handle analytics meta request.
  *
+ * Wraps the extrachill/get-analytics-meta ability from extrachill-analytics.
+ *
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_analytics_meta_handler() {
-	global $wpdb;
-
-	$table_name = extrachill_analytics_events_table();
-
-	// Get distinct event types.
-	$event_types = $wpdb->get_col(
-		"SELECT DISTINCT event_type FROM {$table_name} ORDER BY event_type ASC"
-	);
-
-	// Get blogs that have events.
-	$blog_ids = $wpdb->get_col(
-		"SELECT DISTINCT blog_id FROM {$table_name} ORDER BY blog_id ASC"
-	);
-
-	$blogs = array();
-	foreach ( $blog_ids as $blog_id ) {
-		$blog_id   = absint( $blog_id );
-		$blog_name = get_blog_option( $blog_id, 'blogname' );
-		$blogs[]   = array(
-			'id'   => $blog_id,
-			'name' => $blog_name ? $blog_name : "Blog {$blog_id}",
-		);
+	$ability = wp_get_ability( 'extrachill/get-analytics-meta' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-analytics plugin is required.', array( 'status' => 500 ) );
 	}
 
-	return rest_ensure_response(
-		array(
-			'event_types' => $event_types,
-			'blogs'       => $blogs,
-		)
-	);
+	$result = $ability->execute( array() );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }


### PR DESCRIPTION
## Summary

Fixes the layering violation in **#69**: `extrachill_api_analytics_meta_handler` ran raw `$wpdb->get_col("SELECT DISTINCT ...")` queries directly in the REST handler. It's now a thin delegation to the `extrachill/get-analytics-meta` ability in `extrachill-analytics`.

## What changed

`inc/routes/analytics/meta.php` — the handler now:

```php
$ability = wp_get_ability( 'extrachill/get-analytics-meta' );
if ( ! $ability ) {
    return new WP_Error( 'ability_not_found', 'extrachill-analytics plugin is required.', array( 'status' => 500 ) );
}
$result = $ability->execute( array() );
```

This mirrors the existing `extrachill_api_analytics_events_summary_handler` in the sibling `analytics/events.php`, which already wraps `extrachill/get-analytics-summary`. No raw `$wpdb` remains in the handler. Response shape is unchanged: `{ event_types: [...], blogs: [{id, name}] }`.

## Why an ability (not inline data functions)

The sibling `analytics/events.php` uses **both** patterns — the events handler calls data functions directly, the summary handler calls an ability. The issue explicitly asks for the ability pattern (parallel to `get-analytics-summary`), so this handler delegates to the ability. The ability itself delegates to new data functions in `extrachill-analytics/inc/core/events.php`, so the data-access layer is correct end-to-end.

## ⚠️ Paired PR required — merge order matters

This depends on **Extra-Chill/extrachill-analytics#23**, which adds the `extrachill/get-analytics-meta` ability. **The analytics PR must merge first (or simultaneously)** — merging this alone would make the endpoint resolve a non-existent ability and return a 500. Using `refs #69` (not `closes`) because #69's acceptance criteria span both repos; close #69 once both merge.

## Verification

- `php -l` clean on the changed file.
- No `wpdb` references remain in `inc/routes/analytics/meta.php`.
- Data-function SQL (now in the analytics ability) verified against the live network table: same `event_types` + `blogs` shape as before.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)