### PR TITLE
fix: route events-upcoming-counts to events site to stop off-site ability lookup spam

### DIFF
--- a/inc/middleware/route-affinity.php
+++ b/inc/middleware/route-affinity.php
@@ -103,7 +103,30 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		$args['user_id'] = $current_user_id;
 	}
 
+	// Force HTTP loopback for affinity forwarding.
+	//
+	// A route only has site affinity because its handler depends on the
+	// target site's plugin stack — e.g. /events/* handlers call abilities
+	// registered by extrachill-events, which is active ONLY on the events
+	// site. The default in-process cross-site path (switch_to_blog() +
+	// rest_do_request()) swaps DB/options context but does NOT bootstrap the
+	// target site's per-site plugins, so those abilities are never registered
+	// in the source process. The forwarded request then runs the handler with
+	// the ability missing → WP_Abilities_Registry logs a "not found" notice on
+	// every call and the route returns a 500.
+	//
+	// HTTP loopback spins up a fresh PHP-FPM worker that bootstraps the target
+	// site's full plugin stack, so the per-site ability is registered and the
+	// handler resolves correctly. This is precisely the documented use case for
+	// the loopback path. See Extra-Chill/extrachill-events#141.
+	$force_http_loopback = static function () {
+		return true;
+	};
+	add_filter( 'ec_cross_site_use_http_loopback', $force_http_loopback, 10, 0 );
+
 	$response = ec_cross_site_rest_request( $target_site, $method, $path, $args );
+
+	remove_filter( 'ec_cross_site_use_http_loopback', $force_http_loopback, 10 );
 
 	if ( is_wp_error( $response ) ) {
 		$status = $response->get_error_data()['status'] ?? 500;


### PR DESCRIPTION
## Root cause (verified live, not just traced)

`wp_get_ability('extrachill/events-upcoming-counts')` was being looked up on the **main site**, where the `extrachill-events` plugin that registers it is not active — producing **6,000+** `Ability "extrachill/events-upcoming-counts" not found` notices in production `debug.log` and returning a 500 on the upcoming-counts route.

The surprising part: the route-affinity middleware **was** firing and **was** forwarding the request to the events site. The forwarding just didn't help. Here's why:

```
Main site (blog 1) PHP process — extrachill-events NOT active
                                  → ability never registered in this process
   │ rest_do_request('/extrachill/v1/events/upcoming-counts')
   ▼
[pre_dispatch pass 1]  affinity middleware fires → forwards to 'events'
   │   ec_cross_site_rest_request('events', ...)   [DEFAULT = in-process]
   │     → switch_to_blog(7)   ← swaps DB/options ONLY; does NOT bootstrap
   │                             the events site's per-site plugins.
   ▼
[pre_dispatch pass 2]  X-EC-Forwarded='1' → handle locally
   ▼
handler: wp_get_ability('extrachill/events-upcoming-counts')
   → registry empty (plugin never loaded) → NOTICE + 500
```

`switch_to_blog()` swaps the database/options context but does **not** load another site's plugin code. Abilities registered by a **per-site** plugin (`extrachill-events`) at `wp_abilities_api_init` only exist in a process where that plugin is active. The in-process cross-site path can therefore only resolve **network-active** abilities — not per-site ones. The middleware comment claiming affinity "ensures this runs on the events site" was false for the default path.

### Reproduced + proved on production

| Dispatch path | Result |
|---|---|
| In-process (default, what affinity used) | `WP_Error: ability_not_found` + the notice |
| HTTP loopback | correct 8 location terms, **no notice** |

HTTP loopback routes through `127.0.0.1` with the events host header, so the events site bootstraps its **full** plugin stack in a fresh worker — the ability is registered and the handler resolves.

## The fix

In the route-affinity middleware, force the `ec_cross_site_use_http_loopback` filter to `true` for the duration of the forwarded request. A route only **has** site affinity because its handler depends on the target site's plugin stack — which is exactly the documented use case for the loopback path.

- **Where it lives:** `extrachill-api/inc/middleware/route-affinity.php` (this repo). The fix belongs here, not in `extrachill-blog`/`extrachill-multisite` callers — they correctly call `rest_do_request()` and rely on affinity to route. The bug was that affinity routed via a path incapable of loading per-site abilities.
- **Scope:** only affinity-forwarded cross-site requests are affected. In-process dispatch remains the default for network-shared routes called directly (auth, `wp/v2/*`, roadie, etc.).
- Filter is added immediately before the forward and removed immediately after, so it never leaks to unrelated dispatches.

## Verification

- Forwarded `/events/upcoming-counts` now returns the correct 8 location terms with **no** `ability not found` notice — confirmed via `wp eval` on production for both **authenticated** and **anonymous** (homepage-visitor) callers.
- Root cause fixed (routing now lands where the ability is registered), not the notice silenced.
- `php -l` clean. `homeboy lint --changed-since HEAD` reports only one **pre-existing** phpstan false-positive on line 41 (`str_starts_with`, a PHP 8 builtin) untouched by this diff; the added code produces no findings.

## Systemic note / follow-up (not blocking)

This was latent for **every** events/wire/shop/community/artists route in extrachill-api — they all depend on per-site plugin abilities and would fail identically when forwarded cross-site. `events-upcoming-counts` was the only one spamming because it's called cross-site from the main site on the homepage path (blog homepage queries + badge-count warmer). This fix covers **all** affinity-forwarded routes, so the latent breakage is closed too.

Perf: these forwarded calls are cache-warmed (6hr transients) — the homepage reads the warmed transient; loopback only fires on cold cache / the cron warmer, so the extra-FPM-worker cost (see #11) is bounded. A deeper future option would be to make in-process dispatch able to load the target site's plugin stack, eliminating loopback entirely — out of scope here.

closes Extra-Chill/extrachill-events#141