### PR TITLE
style: clear phpcs lint debt (release preflight)

### DIFF
--- a/extrachill-api.php
+++ b/extrachill-api.php
@@ -11,107 +11,107 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 // Load Composer autoloader for dependencies (Endroid QR Code)
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
-    require_once __DIR__ . '/vendor/autoload.php';
+	require_once __DIR__ . '/vendor/autoload.php';
 }
 
 if ( ! defined( 'EXTRACHILL_API_PATH' ) ) {
-    define( 'EXTRACHILL_API_PATH', plugin_dir_path( __FILE__ ) );
+	define( 'EXTRACHILL_API_PATH', plugin_dir_path( __FILE__ ) );
 }
 
 if ( ! defined( 'EXTRACHILL_API_URL' ) ) {
-    define( 'EXTRACHILL_API_URL', plugin_dir_url( __FILE__ ) );
+	define( 'EXTRACHILL_API_URL', plugin_dir_url( __FILE__ ) );
 }
 
 final class ExtraChill_API_Plugin {
-    /**
-     * Singleton instance storage.
-     *
-     * @var ExtraChill_API_Plugin|null
-     */
-    private static $instance = null;
+	/**
+	 * Singleton instance storage.
+	 *
+	 * @var ExtraChill_API_Plugin|null
+	 */
+	private static $instance = null;
 
-    /**
-     * Bootstraps plugin hooks.
-     */
-    private function __construct() {
-        $this->load_route_files();
-        $this->load_middleware();
-        add_action( 'plugins_loaded', array( $this, 'boot' ) );
-        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
-    }
+	/**
+	 * Bootstraps plugin hooks.
+	 */
+	private function __construct() {
+		$this->load_route_files();
+		$this->load_middleware();
+		add_action( 'plugins_loaded', array( $this, 'boot' ) );
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
 
-    /**
-     * Returns shared instance.
-     *
-     * @return ExtraChill_API_Plugin
-     */
-    public static function get_instance() {
-        if ( null === self::$instance ) {
-            self::$instance = new self();
-        }
+	/**
+	 * Returns shared instance.
+	 *
+	 * @return ExtraChill_API_Plugin
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
 
-        return self::$instance;
-    }
+		return self::$instance;
+	}
 
-    /**
-     * Placeholder bootstrap for future setup.
-     */
-    public function boot() {
-        require_once EXTRACHILL_API_PATH . 'inc/auth/extrachill-link-auth.php';
-        require_once EXTRACHILL_API_PATH . 'inc/utils/id-generator.php';
+	/**
+	 * Placeholder bootstrap for future setup.
+	 */
+	public function boot() {
+		require_once EXTRACHILL_API_PATH . 'inc/auth/extrachill-link-auth.php';
+		require_once EXTRACHILL_API_PATH . 'inc/utils/id-generator.php';
 
-        do_action( 'extrachill_api_bootstrap' );
-    }
+		do_action( 'extrachill_api_bootstrap' );
+	}
 
-    /**
-     * Loads all route files so each endpoint can self-register.
-     */
-    private function load_route_files() {
-        $routes_dir = EXTRACHILL_API_PATH . 'inc/routes/';
+	/**
+	 * Loads all route files so each endpoint can self-register.
+	 */
+	private function load_route_files() {
+		$routes_dir = EXTRACHILL_API_PATH . 'inc/routes/';
 
-        if ( ! is_dir( $routes_dir ) ) {
-            return;
-        }
+		if ( ! is_dir( $routes_dir ) ) {
+			return;
+		}
 
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator( $routes_dir, RecursiveDirectoryIterator::SKIP_DOTS )
-        );
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $routes_dir, RecursiveDirectoryIterator::SKIP_DOTS )
+		);
 
-        foreach ( $iterator as $file ) {
-            if ( 'php' !== $file->getExtension() ) {
-                continue;
-            }
+		foreach ( $iterator as $file ) {
+			if ( 'php' !== $file->getExtension() ) {
+				continue;
+			}
 
-            require_once $file->getRealPath();
-        }
-    }
+			require_once $file->getRealPath();
+		}
+	}
 
-    /**
-     * Loads middleware files for request interception.
-     */
-    private function load_middleware() {
-        $middleware_dir = EXTRACHILL_API_PATH . 'inc/middleware/';
+	/**
+	 * Loads middleware files for request interception.
+	 */
+	private function load_middleware() {
+		$middleware_dir = EXTRACHILL_API_PATH . 'inc/middleware/';
 
-        if ( ! is_dir( $middleware_dir ) ) {
-            return;
-        }
+		if ( ! is_dir( $middleware_dir ) ) {
+			return;
+		}
 
-        foreach ( glob( $middleware_dir . '*.php' ) as $file ) {
-            require_once $file;
-        }
-    }
+		foreach ( glob( $middleware_dir . '*.php' ) as $file ) {
+			require_once $file;
+		}
+	}
 
-    /**
-     * Registers REST routes. Will be populated as endpoints migrate into this plugin.
-     */
-    public function register_routes() {
-        do_action( 'extrachill_api_register_routes' );
-    }
+	/**
+	 * Registers REST routes. Will be populated as endpoints migrate into this plugin.
+	 */
+	public function register_routes() {
+		do_action( 'extrachill_api_register_routes' );
+	}
 }
 
 ExtraChill_API_Plugin::get_instance();

--- a/inc/controllers/class-docs-sync-controller.php
+++ b/inc/controllers/class-docs-sync-controller.php
@@ -18,7 +18,7 @@ class ExtraChill_Docs_Sync_Controller {
 			return new WP_Error(
 				'invalid_site',
 				'Documentation sync is only allowed on the docs site.',
-				[ 'status' => 400 ]
+				array( 'status' => 400 )
 			);
 		}
 
@@ -26,7 +26,7 @@ class ExtraChill_Docs_Sync_Controller {
 			return new WP_Error(
 				'missing_post_type',
 				'The ec_doc post type is not registered on this site.',
-				[ 'status' => 500 ]
+				array( 'status' => 500 )
 			);
 		}
 
@@ -61,11 +61,13 @@ class ExtraChill_Docs_Sync_Controller {
 			// Check if update is needed.
 			$stored_hash = get_post_meta( $existing_post->ID, '_sync_hash', true );
 			if ( ! $force && $stored_hash === $hash ) {
-				return new WP_REST_Response( [
-					'success' => true,
-					'action'  => 'skipped',
-					'id'      => $existing_post->ID,
-				] );
+				return new WP_REST_Response(
+					array(
+						'success' => true,
+						'action'  => 'skipped',
+						'id'      => $existing_post->ID,
+					)
+				);
 			}
 			$post_id = $existing_post->ID;
 			$action  = 'updated';
@@ -81,20 +83,20 @@ class ExtraChill_Docs_Sync_Controller {
 		}
 
 		// Insert/Update Post.
-		$post_data = [
+		$post_data = array(
 			'ID'           => $post_id,
 			'post_title'   => $title,
 			'post_content' => $html_content,
 			'post_name'    => $slug,
 			'post_status'  => 'publish',
 			'post_type'    => 'ec_doc',
-			'meta_input'   => [
+			'meta_input'   => array(
 				'_source_file'    => $source_file,
 				'_sync_hash'      => $hash,
 				'_sync_timestamp' => $timestamp,
 				'_sync_filesize'  => $filesize,
-			],
-		];
+			),
+		);
 
 		$id = wp_insert_post( $post_data, true );
 
@@ -103,30 +105,32 @@ class ExtraChill_Docs_Sync_Controller {
 		}
 
 		// 6. Set Terms.
-		wp_set_object_terms( $id, [ $term_id ], 'ec_doc_platform' );
+		wp_set_object_terms( $id, array( $term_id ), 'ec_doc_platform' );
 
-		return new WP_REST_Response( [
-			'success' => true,
-			'action'  => $action,
-			'id'      => $id,
-		] );
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'action'  => $action,
+				'id'      => $id,
+			)
+		);
 	}
 
 	/**
 	 * Helper to find post by source file meta.
 	 */
 	private static function get_post_by_source_file( $source_file ) {
-		$args = [
-			'post_type'   => 'ec_doc',
-			'post_status' => 'any',
-			'meta_query'  => [
-				[
+		$args  = array(
+			'post_type'      => 'ec_doc',
+			'post_status'    => 'any',
+			'meta_query'     => array(
+				array(
 					'key'   => '_source_file',
 					'value' => $source_file,
-				],
-			],
+				),
+			),
 			'posts_per_page' => 1,
-		];
+		);
 		$query = new WP_Query( $args );
 		return $query->have_posts() ? $query->posts[0] : null;
 	}
@@ -138,11 +142,11 @@ class ExtraChill_Docs_Sync_Controller {
 	 * @return string HTML with IDs added to headers.
 	 */
 	private static function add_header_ids( $html ) {
-		$used_ids = [];
+		$used_ids = array();
 
 		return preg_replace_callback(
 			'/<(h2)([^>]*)>(.*?)<\/h2>/i',
-			function( $matches ) use ( &$used_ids ) {
+			function ( $matches ) use ( &$used_ids ) {
 				$attrs = $matches[2];
 				$text  = $matches[3];
 
@@ -212,8 +216,8 @@ class ExtraChill_Docs_Sync_Controller {
 		}
 
 		// Create if not exists.
-		$name = ucwords( str_replace( '-', ' ', $slug ) );
-		$result = wp_insert_term( $name, 'ec_doc_platform', [ 'slug' => $slug ] );
+		$name   = ucwords( str_replace( '-', ' ', $slug ) );
+		$result = wp_insert_term( $name, 'ec_doc_platform', array( 'slug' => $slug ) );
 
 		if ( is_wp_error( $result ) ) {
 			return $result;

--- a/inc/routes/admin/lifetime-membership.php
+++ b/inc/routes/admin/lifetime-membership.php
@@ -98,8 +98,8 @@ function extrachill_api_lifetime_membership_admin_permission_check() {
  * @return WP_REST_Response|WP_Error Response with member list or error.
  */
 function extrachill_api_get_lifetime_memberships( $request ) {
-	$search = $request->get_param( 'search' );
-	$page   = $request->get_param( 'page' );
+	$search   = $request->get_param( 'search' );
+	$page     = $request->get_param( 'page' );
 	$per_page = 20;
 
 	$args = array(
@@ -129,11 +129,11 @@ function extrachill_api_get_lifetime_memberships( $request ) {
 		}
 
 		$formatted_members[] = array(
-			'ID'             => $user->ID,
-			'user_login'     => $user->user_login,
-			'user_email'     => $user->user_email,
-			'purchased'      => isset( $membership_data['purchased'] ) ? $membership_data['purchased'] : 'N/A',
-			'order_id'       => isset( $membership_data['order_id'] ) && $membership_data['order_id'] ? $membership_data['order_id'] : 'Manual',
+			'ID'         => $user->ID,
+			'user_login' => $user->user_login,
+			'user_email' => $user->user_email,
+			'purchased'  => isset( $membership_data['purchased'] ) ? $membership_data['purchased'] : 'N/A',
+			'order_id'   => isset( $membership_data['order_id'] ) && $membership_data['order_id'] ? $membership_data['order_id'] : 'Manual',
 		);
 	}
 

--- a/inc/routes/admin/taxonomy-sync.php
+++ b/inc/routes/admin/taxonomy-sync.php
@@ -9,80 +9,80 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_taxonomy_sync_routes' );
 
 function extrachill_api_register_taxonomy_sync_routes() {
-    register_rest_route(
-        'extrachill/v1',
-        '/admin/taxonomies/sync',
-        array(
-            'methods'             => WP_REST_Server::CREATABLE,
-            'callback'            => 'extrachill_api_taxonomy_sync',
-            'permission_callback' => 'extrachill_api_taxonomy_sync_permission_check',
-            'args'                => array(
-                'target_sites' => array(
-                    'required'          => true,
-                    'type'              => 'array',
-                    'sanitize_callback' => 'extrachill_api_taxonomy_sync_sanitize_site_slugs',
-                ),
-                'taxonomies'   => array(
-                    'required'          => true,
-                    'type'              => 'array',
-                    'sanitize_callback' => 'extrachill_api_taxonomy_sync_sanitize_taxonomies',
-                ),
-            ),
-        )
-    );
+	register_rest_route(
+		'extrachill/v1',
+		'/admin/taxonomies/sync',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_taxonomy_sync',
+			'permission_callback' => 'extrachill_api_taxonomy_sync_permission_check',
+			'args'                => array(
+				'target_sites' => array(
+					'required'          => true,
+					'type'              => 'array',
+					'sanitize_callback' => 'extrachill_api_taxonomy_sync_sanitize_site_slugs',
+				),
+				'taxonomies'   => array(
+					'required'          => true,
+					'type'              => 'array',
+					'sanitize_callback' => 'extrachill_api_taxonomy_sync_sanitize_taxonomies',
+				),
+			),
+		)
+	);
 }
 
 function extrachill_api_taxonomy_sync_permission_check() {
-    if ( ! current_user_can( 'manage_network_options' ) ) {
-        return new WP_Error(
-            'rest_forbidden',
-            'You do not have permission to sync taxonomies.',
-            array( 'status' => 403 )
-        );
-    }
+	if ( ! current_user_can( 'manage_network_options' ) ) {
+		return new WP_Error(
+			'rest_forbidden',
+			'You do not have permission to sync taxonomies.',
+			array( 'status' => 403 )
+		);
+	}
 
-    return true;
+	return true;
 }
 
 function extrachill_api_taxonomy_sync_sanitize_site_slugs( $value ) {
-    if ( ! is_array( $value ) ) {
-        return array();
-    }
+	if ( ! is_array( $value ) ) {
+		return array();
+	}
 
-    $site_slugs = array();
-    foreach ( $value as $site_slug ) {
-        $site_slug = sanitize_key( $site_slug );
-        if ( '' === $site_slug ) {
-            continue;
-        }
-        $site_slugs[] = $site_slug;
-    }
+	$site_slugs = array();
+	foreach ( $value as $site_slug ) {
+		$site_slug = sanitize_key( $site_slug );
+		if ( '' === $site_slug ) {
+			continue;
+		}
+		$site_slugs[] = $site_slug;
+	}
 
-    return array_values( array_unique( $site_slugs ) );
+	return array_values( array_unique( $site_slugs ) );
 }
 
 function extrachill_api_taxonomy_sync_sanitize_taxonomies( $value ) {
-    if ( ! is_array( $value ) ) {
-        return array();
-    }
+	if ( ! is_array( $value ) ) {
+		return array();
+	}
 
-    $valid_taxonomies = array( 'location', 'festival', 'artist', 'venue' );
+	$valid_taxonomies = array( 'location', 'festival', 'artist', 'venue' );
 
-    $taxonomies = array();
-    foreach ( $value as $taxonomy ) {
-        $taxonomy = sanitize_key( $taxonomy );
-        if ( in_array( $taxonomy, $valid_taxonomies, true ) ) {
-            $taxonomies[] = $taxonomy;
-        }
-    }
+	$taxonomies = array();
+	foreach ( $value as $taxonomy ) {
+		$taxonomy = sanitize_key( $taxonomy );
+		if ( in_array( $taxonomy, $valid_taxonomies, true ) ) {
+			$taxonomies[] = $taxonomy;
+		}
+	}
 
-    return array_values( array_unique( $taxonomies ) );
+	return array_values( array_unique( $taxonomies ) );
 }
 
 /**
@@ -94,22 +94,21 @@ function extrachill_api_taxonomy_sync_sanitize_taxonomies( $value ) {
  * @return WP_REST_Response|WP_Error Response with sync report or error.
  */
 function extrachill_api_taxonomy_sync( WP_REST_Request $request ) {
-    $ability = wp_get_ability( 'extrachill/sync-taxonomies' );
-    if ( ! $ability ) {
-        return new WP_Error( 'ability_not_found', 'Taxonomy sync ability is not available.', array( 'status' => 500 ) );
-    }
+	$ability = wp_get_ability( 'extrachill/sync-taxonomies' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'Taxonomy sync ability is not available.', array( 'status' => 500 ) );
+	}
 
-    $result = $ability->execute(
-        array(
-            'target_sites' => $request->get_param( 'target_sites' ),
-            'taxonomies'   => $request->get_param( 'taxonomies' ),
-        )
-    );
+	$result = $ability->execute(
+		array(
+			'target_sites' => $request->get_param( 'target_sites' ),
+			'taxonomies'   => $request->get_param( 'taxonomies' ),
+		)
+	);
 
-    if ( is_wp_error( $result ) ) {
-        return $result;
-    }
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
 
-    return rest_ensure_response( $result );
+	return rest_ensure_response( $result );
 }
-

--- a/inc/routes/admin/team-members.php
+++ b/inc/routes/admin/team-members.php
@@ -66,7 +66,7 @@ function extrachill_api_register_team_member_routes() {
 					'required'          => true,
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
-					'validate_callback' => function( $value ) {
+					'validate_callback' => function ( $value ) {
 						return in_array( $value, array( 'force_add', 'force_remove', 'reset_auto' ), true );
 					},
 				),
@@ -98,8 +98,8 @@ function extrachill_api_team_member_admin_permission_check() {
  * @return WP_REST_Response|WP_Error Response with user list or error.
  */
 function extrachill_api_get_team_members( $request ) {
-	$search = $request->get_param( 'search' );
-	$page   = $request->get_param( 'page' );
+	$search   = $request->get_param( 'search' );
+	$page     = $request->get_param( 'page' );
 	$per_page = 20;
 
 	$args = array(

--- a/inc/routes/analytics/link-page.php
+++ b/inc/routes/analytics/link-page.php
@@ -13,27 +13,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_link_page_analytics_route' );
 
 function extrachill_api_register_link_page_analytics_route() {
-	register_rest_route( 'extrachill/v1', '/analytics/link-page', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_link_page_analytics_handler',
-		'permission_callback' => 'is_user_logged_in',
-		'args'                => array(
-			'link_page_id' => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'validate_callback' => function ( $param ) {
-					return is_numeric( $param ) && $param > 0;
-				},
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/analytics/link-page',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_link_page_analytics_handler',
+			'permission_callback' => 'is_user_logged_in',
+			'args'                => array(
+				'link_page_id' => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'validate_callback' => function ( $param ) {
+						return is_numeric( $param ) && $param > 0;
+					},
+					'sanitize_callback' => 'absint',
+				),
+				'date_range'   => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'default'           => 30,
+					'sanitize_callback' => 'absint',
+				),
 			),
-			'date_range'   => array(
-				'required'          => false,
-				'type'              => 'integer',
-				'default'           => 30,
-				'sanitize_callback' => 'absint',
-			),
-		),
-	) );
+		)
+	);
 }
 
 /**

--- a/inc/routes/analytics/view-count.php
+++ b/inc/routes/analytics/view-count.php
@@ -6,47 +6,51 @@
  * to track post views without blocking page render.
  */
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-add_action('extrachill_api_register_routes', 'extrachill_api_register_view_count_route');
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_view_count_route' );
 
 function extrachill_api_register_view_count_route() {
-	register_rest_route('extrachill/v1', '/analytics/view', array(
-		'methods'             => WP_REST_Server::CREATABLE,
-		'callback'            => 'extrachill_api_view_count_handler',
-		'permission_callback' => '__return_true',
-		'args'                => array(
-			'post_id' => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'validate_callback' => function($param) {
-					return is_numeric($param) && $param > 0;
-				},
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/analytics/view',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_view_count_handler',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'post_id' => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'validate_callback' => function ( $param ) {
+						return is_numeric( $param ) && $param > 0;
+					},
+					'sanitize_callback' => 'absint',
+				),
 			),
-		),
-	));
+		)
+	);
 }
 
-function extrachill_api_view_count_handler($request) {
-	$post_id = $request->get_param('post_id');
+function extrachill_api_view_count_handler( $request ) {
+	$post_id = $request->get_param( 'post_id' );
 
-	if (!function_exists('ec_track_post_views')) {
+	if ( ! function_exists( 'ec_track_post_views' ) ) {
 		return new WP_Error(
 			'function_missing',
 			'View tracking function not available.',
-			array('status' => 500)
+			array( 'status' => 500 )
 		);
 	}
 
 	// Track all-time views (theme system)
-	ec_track_post_views($post_id);
+	ec_track_post_views( $post_id );
 
 	// For link pages, also fire action for 90-day daily table tracking
-	if (get_post_type($post_id) === 'artist_link_page') {
-		do_action('extrachill_link_page_view_recorded', $post_id);
+	if ( get_post_type( $post_id ) === 'artist_link_page' ) {
+		do_action( 'extrachill_link_page_view_recorded', $post_id );
 	}
 
 	return rest_ensure_response( array( 'recorded' => true ) );

--- a/inc/routes/artists/analytics.php
+++ b/inc/routes/artists/analytics.php
@@ -15,24 +15,28 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_artist_analytics_route' );
 
 function extrachill_api_register_artist_analytics_route() {
-	register_rest_route( 'extrachill/v1', '/artists/(?P<id>\d+)/analytics', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_artist_analytics_handler',
-		'permission_callback' => 'extrachill_api_artist_analytics_permission_check',
-		'args'                => array(
-			'id' => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/artists/(?P<id>\d+)/analytics',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_artist_analytics_handler',
+			'permission_callback' => 'extrachill_api_artist_analytics_permission_check',
+			'args'                => array(
+				'id'         => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'date_range' => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'default'           => 30,
+					'sanitize_callback' => 'absint',
+				),
 			),
-			'date_range' => array(
-				'required'          => false,
-				'type'              => 'integer',
-				'default'           => 30,
-				'sanitize_callback' => 'absint',
-			),
-		),
-	) );
+		)
+	);
 }
 
 /**

--- a/inc/routes/artists/artist.php
+++ b/inc/routes/artists/artist.php
@@ -19,62 +19,70 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_artist_routes' );
 
 function extrachill_api_register_artist_routes() {
-	register_rest_route( 'extrachill/v1', '/artists', array(
+	register_rest_route(
+		'extrachill/v1',
+		'/artists',
 		array(
-			'methods'             => WP_REST_Server::CREATABLE,
-			'callback'            => 'extrachill_api_artist_post_handler',
-			'permission_callback' => 'extrachill_api_artist_create_permission_check',
-			'args'                => array(
-				'name' => array(
-					'required'          => true,
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_text_field',
-				),
-				'bio' => array(
-					'required'          => false,
-					'type'              => 'string',
-					'sanitize_callback' => 'wp_kses_post',
-				),
-				'local_city' => array(
-					'required'          => false,
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_text_field',
-				),
-				'genre' => array(
-					'required'          => false,
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_text_field',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => 'extrachill_api_artist_post_handler',
+				'permission_callback' => 'extrachill_api_artist_create_permission_check',
+				'args'                => array(
+					'name'       => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'bio'        => array(
+						'required'          => false,
+						'type'              => 'string',
+						'sanitize_callback' => 'wp_kses_post',
+					),
+					'local_city' => array(
+						'required'          => false,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'genre'      => array(
+						'required'          => false,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
 				),
 			),
-		),
-	) );
+		)
+	);
 
-	register_rest_route( 'extrachill/v1', '/artists/(?P<id>\d+)', array(
+	register_rest_route(
+		'extrachill/v1',
+		'/artists/(?P<id>\d+)',
 		array(
-			'methods'             => WP_REST_Server::READABLE,
-			'callback'            => 'extrachill_api_artist_get_handler',
-			'permission_callback' => 'extrachill_api_artist_permission_check',
-			'args'                => array(
-				'id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_artist_get_handler',
+				'permission_callback' => 'extrachill_api_artist_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
-		array(
-			'methods'             => WP_REST_Server::EDITABLE,
-			'callback'            => 'extrachill_api_artist_put_handler',
-			'permission_callback' => 'extrachill_api_artist_permission_check',
-			'args'                => array(
-				'id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => 'extrachill_api_artist_put_handler',
+				'permission_callback' => 'extrachill_api_artist_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
-	) );
+		)
+	);
 }
 
 /**

--- a/inc/routes/artists/links.php
+++ b/inc/routes/artists/links.php
@@ -20,32 +20,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_artist_links_routes' );
 
 function extrachill_api_register_artist_links_routes() {
-	register_rest_route( 'extrachill/v1', '/artists/(?P<id>\d+)/links', array(
+	register_rest_route(
+		'extrachill/v1',
+		'/artists/(?P<id>\d+)/links',
 		array(
-			'methods'             => WP_REST_Server::READABLE,
-			'callback'            => 'extrachill_api_artist_links_get_handler',
-			'permission_callback' => 'extrachill_api_artist_links_permission_check',
-			'args'                => array(
-				'id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_artist_links_get_handler',
+				'permission_callback' => 'extrachill_api_artist_links_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
-		array(
-			'methods'             => WP_REST_Server::EDITABLE,
-			'callback'            => 'extrachill_api_artist_links_put_handler',
-			'permission_callback' => 'extrachill_api_artist_links_permission_check',
-			'args'                => array(
-				'id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => 'extrachill_api_artist_links_put_handler',
+				'permission_callback' => 'extrachill_api_artist_links_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
-	) );
+		)
+	);
 }
 
 /**
@@ -129,8 +133,8 @@ function extrachill_api_artist_links_put_handler( WP_REST_Request $request ) {
 	// The JS client wraps the full payload as {links: {links, settings, css_vars, ...}}.
 	// Unwrap nested compound object to top-level keys for backward compatibility.
 	if ( isset( $body['links'] ) && is_array( $body['links'] ) && isset( $body['links']['links'] ) ) {
-		$nested = $body['links'];
-		$body   = array_merge( $body, $nested );
+		$nested        = $body['links'];
+		$body          = array_merge( $body, $nested );
 		$body['links'] = $nested['links'];
 	}
 

--- a/inc/routes/artists/roster.php
+++ b/inc/routes/artists/roster.php
@@ -24,72 +24,88 @@ add_action( 'extrachill_api_register_routes', 'extrachill_api_register_artist_ro
 
 function extrachill_api_register_artist_roster_routes() {
 	// Roster endpoints under the artist resource
-	register_rest_route( 'extrachill/v1', '/artists/(?P<id>\d+)/roster', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_artist_roster_list_handler',
-		'permission_callback' => 'is_user_logged_in',
-		'args'                => array(
-			'id' => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/artists/(?P<id>\d+)/roster',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_artist_roster_list_handler',
+			'permission_callback' => 'is_user_logged_in',
+			'args'                => array(
+				'id' => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
 			),
-		),
-	) );
+		)
+	);
 
-	register_rest_route( 'extrachill/v1', '/artists/(?P<id>\d+)/roster', array(
-		'methods'             => WP_REST_Server::CREATABLE,
-		'callback'            => 'extrachill_api_artist_roster_invite_handler',
-		'permission_callback' => 'is_user_logged_in',
-		'args'                => array(
-			'id'    => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/artists/(?P<id>\d+)/roster',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_artist_roster_invite_handler',
+			'permission_callback' => 'is_user_logged_in',
+			'args'                => array(
+				'id'    => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'email' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_email',
+				),
 			),
-			'email' => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_email',
-			),
-		),
-	) );
+		)
+	);
 
-	register_rest_route( 'extrachill/v1', '/artists/(?P<id>\d+)/roster/(?P<user_id>\d+)', array(
-		'methods'             => WP_REST_Server::DELETABLE,
-		'callback'            => 'extrachill_api_artist_roster_remove_member_handler',
-		'permission_callback' => 'is_user_logged_in',
-		'args'                => array(
-			'id'      => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/artists/(?P<id>\d+)/roster/(?P<user_id>\d+)',
+		array(
+			'methods'             => WP_REST_Server::DELETABLE,
+			'callback'            => 'extrachill_api_artist_roster_remove_member_handler',
+			'permission_callback' => 'is_user_logged_in',
+			'args'                => array(
+				'id'      => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'user_id' => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
 			),
-			'user_id' => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
-			),
-		),
-	) );
+		)
+	);
 
-	register_rest_route( 'extrachill/v1', '/artists/(?P<id>\d+)/roster/invites/(?P<invite_id>[A-Za-z0-9_-]+)', array(
-		'methods'             => WP_REST_Server::DELETABLE,
-		'callback'            => 'extrachill_api_artist_roster_cancel_invite_handler',
-		'permission_callback' => 'is_user_logged_in',
-		'args'                => array(
-			'id'        => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/artists/(?P<id>\d+)/roster/invites/(?P<invite_id>[A-Za-z0-9_-]+)',
+		array(
+			'methods'             => WP_REST_Server::DELETABLE,
+			'callback'            => 'extrachill_api_artist_roster_cancel_invite_handler',
+			'permission_callback' => 'is_user_logged_in',
+			'args'                => array(
+				'id'        => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'invite_id' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
 			),
-			'invite_id' => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-		),
-	) );
+		)
+	);
 }
 
 /**
@@ -140,10 +156,12 @@ function extrachill_api_artist_roster_invite_handler( WP_REST_Request $request )
 		);
 	}
 
-	return rest_ensure_response( array(
-		'message'    => __( 'Invitation successfully sent.', 'extrachill-api' ),
-		'invitation' => $result,
-	) );
+	return rest_ensure_response(
+		array(
+			'message'    => __( 'Invitation successfully sent.', 'extrachill-api' ),
+			'invitation' => $result,
+		)
+	);
 }
 
 /**
@@ -211,11 +229,13 @@ function extrachill_api_artist_roster_remove_member_handler( WP_REST_Request $re
 		);
 	}
 
-	return rest_ensure_response( array(
-		'removed'  => true,
-		'user_id'  => (int) $user_id,
-		'artist_id'=> (int) $artist_id,
-	) );
+	return rest_ensure_response(
+		array(
+			'removed'   => true,
+			'user_id'   => (int) $user_id,
+			'artist_id' => (int) $artist_id,
+		)
+	);
 }
 
 /**
@@ -225,8 +245,8 @@ function extrachill_api_artist_roster_remove_member_handler( WP_REST_Request $re
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_artist_roster_cancel_invite_handler( WP_REST_Request $request ) {
-	$artist_id  = $request->get_param( 'id' );
-	$invite_id  = $request->get_param( 'invite_id' );
+	$artist_id = $request->get_param( 'id' );
+	$invite_id = $request->get_param( 'invite_id' );
 
 	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
 		return new WP_Error(
@@ -262,9 +282,11 @@ function extrachill_api_artist_roster_cancel_invite_handler( WP_REST_Request $re
 		);
 	}
 
-	return rest_ensure_response( array(
-		'cancelled' => true,
-		'invite_id' => $invite_id,
-		'artist_id' => (int) $artist_id,
-	) );
+	return rest_ensure_response(
+		array(
+			'cancelled' => true,
+			'invite_id' => $invite_id,
+			'artist_id' => (int) $artist_id,
+		)
+	);
 }

--- a/inc/routes/artists/socials.php
+++ b/inc/routes/artists/socials.php
@@ -16,32 +16,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_artist_socials_routes' );
 
 function extrachill_api_register_artist_socials_routes() {
-	register_rest_route( 'extrachill/v1', '/artists/(?P<id>\d+)/socials', array(
+	register_rest_route(
+		'extrachill/v1',
+		'/artists/(?P<id>\d+)/socials',
 		array(
-			'methods'             => WP_REST_Server::READABLE,
-			'callback'            => 'extrachill_api_artist_socials_get_handler',
-			'permission_callback' => 'extrachill_api_artist_socials_permission_check',
-			'args'                => array(
-				'id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_artist_socials_get_handler',
+				'permission_callback' => 'extrachill_api_artist_socials_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
-		array(
-			'methods'             => WP_REST_Server::EDITABLE,
-			'callback'            => 'extrachill_api_artist_socials_put_handler',
-			'permission_callback' => 'extrachill_api_artist_socials_permission_check',
-			'args'                => array(
-				'id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => 'extrachill_api_artist_socials_put_handler',
+				'permission_callback' => 'extrachill_api_artist_socials_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
-	) );
+		)
+	);
 }
 
 /**

--- a/inc/routes/artists/subscribe.php
+++ b/inc/routes/artists/subscribe.php
@@ -15,23 +15,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_artist_subscribe_route' );
 
 function extrachill_api_register_artist_subscribe_route() {
-	register_rest_route( 'extrachill/v1', '/artists/(?P<id>\d+)/subscribe', array(
-		'methods'             => WP_REST_Server::CREATABLE,
-		'callback'            => 'extrachill_api_artist_subscribe_handler',
-		'permission_callback' => '__return_true',
-		'args'                => array(
-			'id'    => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/artists/(?P<id>\d+)/subscribe',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_artist_subscribe_handler',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'id'    => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'email' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_email',
+				),
 			),
-			'email' => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_email',
-			),
-		),
-	) );
+		)
+	);
 }
 
 /**

--- a/inc/routes/artists/subscribers.php
+++ b/inc/routes/artists/subscribers.php
@@ -18,49 +18,57 @@ add_action( 'extrachill_api_register_routes', 'extrachill_api_register_artist_su
 
 function extrachill_api_register_artist_subscribers_routes() {
 	// Fetch paginated subscribers
-	register_rest_route( 'extrachill/v1', '/artists/(?P<id>\d+)/subscribers', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_get_artist_subscribers_handler',
-		'permission_callback' => 'is_user_logged_in',
-		'args'                => array(
-			'id'       => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/artists/(?P<id>\d+)/subscribers',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_get_artist_subscribers_handler',
+			'permission_callback' => 'is_user_logged_in',
+			'args'                => array(
+				'id'       => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'page'     => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'default'           => 1,
+					'sanitize_callback' => 'absint',
+				),
+				'per_page' => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'default'           => 20,
+					'sanitize_callback' => 'absint',
+				),
 			),
-			'page'     => array(
-				'required'          => false,
-				'type'              => 'integer',
-				'default'           => 1,
-				'sanitize_callback' => 'absint',
-			),
-			'per_page' => array(
-				'required'          => false,
-				'type'              => 'integer',
-				'default'           => 20,
-				'sanitize_callback' => 'absint',
-			),
-		),
-	) );
+		)
+	);
 
 	// Export all subscribers for CSV
-	register_rest_route( 'extrachill/v1', '/artists/(?P<id>\d+)/subscribers/export', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_export_artist_subscribers_handler',
-		'permission_callback' => 'is_user_logged_in',
-		'args'                => array(
-			'id'               => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/artists/(?P<id>\d+)/subscribers/export',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_export_artist_subscribers_handler',
+			'permission_callback' => 'is_user_logged_in',
+			'args'                => array(
+				'id'               => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'include_exported' => array(
+					'required' => false,
+					'type'     => 'boolean',
+					'default'  => false,
+				),
 			),
-			'include_exported' => array(
-				'required'          => false,
-				'type'              => 'boolean',
-				'default'           => false,
-			),
-		),
-	) );
+		)
+	);
 }
 
 /**

--- a/inc/routes/auth/browser-handoff.php
+++ b/inc/routes/auth/browser-handoff.php
@@ -67,7 +67,7 @@ function extrachill_api_auth_browser_handoff_handler( WP_REST_Request $request )
 
 	$handoff_url = add_query_arg(
 		array(
-			'action'            => 'extrachill_browser_handoff',
+			'action'             => 'extrachill_browser_handoff',
 			'ec_browser_handoff' => $token,
 		),
 		esc_url_raw( "https://{$redirect_host}/wp-admin/admin-post.php" )

--- a/inc/routes/auth/refresh.php
+++ b/inc/routes/auth/refresh.php
@@ -25,16 +25,16 @@ function extrachill_api_register_auth_refresh_route() {
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 				),
-				'device_id'      => array(
+				'device_id'     => array(
 					'required'          => true,
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 				),
-				'remember'       => array(
+				'remember'      => array(
 					'required' => false,
 					'type'     => 'boolean',
 				),
-				'set_cookie'     => array(
+				'set_cookie'    => array(
 					'required' => false,
 					'type'     => 'boolean',
 				),

--- a/inc/routes/auth/register.php
+++ b/inc/routes/auth/register.php
@@ -42,11 +42,11 @@ function extrachill_api_register_auth_register_route() {
 					'required' => true,
 					'type'     => 'string',
 				),
-			'turnstile_response'   => array(
-				'required'          => false,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
+				'turnstile_response'   => array(
+					'required'          => false,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
 				'device_id'            => array(
 					'required'          => true,
 					'type'              => 'string',

--- a/inc/routes/community/drafts.php
+++ b/inc/routes/community/drafts.php
@@ -11,135 +11,135 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_community_drafts_routes' );
 
 function extrachill_api_register_community_drafts_routes() {
-    register_rest_route(
-        'extrachill/v1',
-        '/community/drafts',
-        [
-            [
-                'methods'             => WP_REST_Server::READABLE,
-                'callback'            => 'extrachill_api_community_drafts_get_handler',
-                'permission_callback' => 'extrachill_api_community_drafts_permission',
-                'args'                => extrachill_api_community_drafts_context_args(),
-            ],
-            [
-                'methods'             => WP_REST_Server::CREATABLE,
-                'callback'            => 'extrachill_api_community_drafts_post_handler',
-                'permission_callback' => 'extrachill_api_community_drafts_permission',
-                'args'                => array_merge(
-                    extrachill_api_community_drafts_context_args(),
-                    [
-                        'title'   => [
-                            'required'          => false,
-                            'type'              => 'string',
-                            'sanitize_callback' => 'sanitize_text_field',
-                        ],
-                        'content' => [
-                            'required' => false,
-                            'type'     => 'string',
-                        ],
-                    ]
-                ),
-            ],
-            [
-                'methods'             => WP_REST_Server::DELETABLE,
-                'callback'            => 'extrachill_api_community_drafts_delete_handler',
-                'permission_callback' => 'extrachill_api_community_drafts_permission',
-                'args'                => extrachill_api_community_drafts_context_args(),
-            ],
-        ]
-    );
+	register_rest_route(
+		'extrachill/v1',
+		'/community/drafts',
+		array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_community_drafts_get_handler',
+				'permission_callback' => 'extrachill_api_community_drafts_permission',
+				'args'                => extrachill_api_community_drafts_context_args(),
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => 'extrachill_api_community_drafts_post_handler',
+				'permission_callback' => 'extrachill_api_community_drafts_permission',
+				'args'                => array_merge(
+					extrachill_api_community_drafts_context_args(),
+					array(
+						'title'   => array(
+							'required'          => false,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'content' => array(
+							'required' => false,
+							'type'     => 'string',
+						),
+					)
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => 'extrachill_api_community_drafts_delete_handler',
+				'permission_callback' => 'extrachill_api_community_drafts_permission',
+				'args'                => extrachill_api_community_drafts_context_args(),
+			),
+		)
+	);
 }
 
 function extrachill_api_community_drafts_permission() {
-    return is_user_logged_in();
+	return is_user_logged_in();
 }
 
 function extrachill_api_community_drafts_sanitize_int( $value, $request, $param ) {
-    return is_numeric( $value ) ? (int) $value : 0;
+	return is_numeric( $value ) ? (int) $value : 0;
 }
 
 function extrachill_api_community_drafts_context_args() {
-    return [
-        'type'    => [
-            'required'          => true,
-            'type'              => 'string',
-            'enum'              => [ 'topic', 'reply' ],
-            'sanitize_callback' => 'sanitize_text_field',
-        ],
-        'forum_id' => [
-            'required'          => false,
-            'type'              => 'integer',
-            'sanitize_callback' => 'extrachill_api_community_drafts_sanitize_int',
-            'validate_callback' => function( $param ) {
-                return is_numeric( $param ) && (int) $param >= 0;
-            },
-        ],
-        'topic_id' => [
-            'required'          => false,
-            'type'              => 'integer',
-            'sanitize_callback' => 'extrachill_api_community_drafts_sanitize_int',
-            'validate_callback' => function( $param ) {
-                return is_numeric( $param ) && (int) $param >= 0;
-            },
-        ],
-        'reply_to' => [
-            'required'          => false,
-            'type'              => 'integer',
-            'sanitize_callback' => 'extrachill_api_community_drafts_sanitize_int',
-            'validate_callback' => function( $param ) {
-                return is_numeric( $param ) && (int) $param >= 0;
-            },
-        ],
-        'prefer_unassigned' => [
-            'required'          => false,
-            'type'              => 'boolean',
-            'sanitize_callback' => 'rest_sanitize_boolean',
-        ],
-    ];
+	return array(
+		'type'              => array(
+			'required'          => true,
+			'type'              => 'string',
+			'enum'              => array( 'topic', 'reply' ),
+			'sanitize_callback' => 'sanitize_text_field',
+		),
+		'forum_id'          => array(
+			'required'          => false,
+			'type'              => 'integer',
+			'sanitize_callback' => 'extrachill_api_community_drafts_sanitize_int',
+			'validate_callback' => function ( $param ) {
+				return is_numeric( $param ) && (int) $param >= 0;
+			},
+		),
+		'topic_id'          => array(
+			'required'          => false,
+			'type'              => 'integer',
+			'sanitize_callback' => 'extrachill_api_community_drafts_sanitize_int',
+			'validate_callback' => function ( $param ) {
+				return is_numeric( $param ) && (int) $param >= 0;
+			},
+		),
+		'reply_to'          => array(
+			'required'          => false,
+			'type'              => 'integer',
+			'sanitize_callback' => 'extrachill_api_community_drafts_sanitize_int',
+			'validate_callback' => function ( $param ) {
+				return is_numeric( $param ) && (int) $param >= 0;
+			},
+		),
+		'prefer_unassigned' => array(
+			'required'          => false,
+			'type'              => 'boolean',
+			'sanitize_callback' => 'rest_sanitize_boolean',
+		),
+	);
 }
 
 function extrachill_api_community_drafts_validate_context( WP_REST_Request $request ) {
-    $type = $request->get_param( 'type' );
-    $forum_id = (int) $request->get_param( 'forum_id' );
-    $topic_id = (int) $request->get_param( 'topic_id' );
+	$type     = $request->get_param( 'type' );
+	$forum_id = (int) $request->get_param( 'forum_id' );
+	$topic_id = (int) $request->get_param( 'topic_id' );
 
-    if ( 'topic' === $type ) {
-        if ( ! $request->has_param( 'forum_id' ) ) {
-            return new WP_Error( 'missing_forum_id', 'forum_id is required for topic drafts.', [ 'status' => 400 ] );
-        }
+	if ( 'topic' === $type ) {
+		if ( ! $request->has_param( 'forum_id' ) ) {
+			return new WP_Error( 'missing_forum_id', 'forum_id is required for topic drafts.', array( 'status' => 400 ) );
+		}
 
-        if ( $forum_id < 0 ) {
-            return new WP_Error( 'invalid_forum_id', 'forum_id must be >= 0.', [ 'status' => 400 ] );
-        }
+		if ( $forum_id < 0 ) {
+			return new WP_Error( 'invalid_forum_id', 'forum_id must be >= 0.', array( 'status' => 400 ) );
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    if ( 'reply' === $type ) {
-        if ( $topic_id <= 0 ) {
-            return new WP_Error( 'invalid_topic_id', 'topic_id is required for reply drafts.', [ 'status' => 400 ] );
-        }
+	if ( 'reply' === $type ) {
+		if ( $topic_id <= 0 ) {
+			return new WP_Error( 'invalid_topic_id', 'topic_id is required for reply drafts.', array( 'status' => 400 ) );
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    return new WP_Error( 'invalid_type', 'Invalid type.', [ 'status' => 400 ] );
+	return new WP_Error( 'invalid_type', 'Invalid type.', array( 'status' => 400 ) );
 }
 
 function extrachill_api_community_drafts_get_context_from_request( WP_REST_Request $request ) {
-    return [
-        'type'    => (string) $request->get_param( 'type' ),
-        'blog_id' => (int) get_current_blog_id(),
-        'forum_id' => (int) $request->get_param( 'forum_id' ),
-        'topic_id' => (int) $request->get_param( 'topic_id' ),
-        'reply_to' => (int) $request->get_param( 'reply_to' ),
-    ];
+	return array(
+		'type'     => (string) $request->get_param( 'type' ),
+		'blog_id'  => (int) get_current_blog_id(),
+		'forum_id' => (int) $request->get_param( 'forum_id' ),
+		'topic_id' => (int) $request->get_param( 'topic_id' ),
+		'reply_to' => (int) $request->get_param( 'reply_to' ),
+	);
 }
 
 function extrachill_api_community_drafts_get_handler( WP_REST_Request $request ) {
@@ -150,10 +150,10 @@ function extrachill_api_community_drafts_get_handler( WP_REST_Request $request )
 
 	$ability = wp_get_ability( 'extrachill/get-bbpress-draft' );
 	if ( ! $ability ) {
-		return new WP_Error( 'missing_ability', 'Draft ability not available.', [ 'status' => 500 ] );
+		return new WP_Error( 'missing_ability', 'Draft ability not available.', array( 'status' => 500 ) );
 	}
 
-	$context = extrachill_api_community_drafts_get_context_from_request( $request );
+	$context                      = extrachill_api_community_drafts_get_context_from_request( $request );
 	$context['user_id']           = get_current_user_id();
 	$context['prefer_unassigned'] = (bool) $request->get_param( 'prefer_unassigned' );
 
@@ -163,35 +163,35 @@ function extrachill_api_community_drafts_get_handler( WP_REST_Request $request )
 		return $draft;
 	}
 
-	return rest_ensure_response( [ 'draft' => $draft ] );
+	return rest_ensure_response( array( 'draft' => $draft ) );
 }
 
 function extrachill_api_community_drafts_post_handler( WP_REST_Request $request ) {
-    $valid = extrachill_api_community_drafts_validate_context( $request );
-    if ( true !== $valid ) {
-        return $valid;
-    }
+	$valid = extrachill_api_community_drafts_validate_context( $request );
+	if ( true !== $valid ) {
+		return $valid;
+	}
 
 	$ability = wp_get_ability( 'extrachill/save-bbpress-draft' );
 	if ( ! $ability ) {
-		return new WP_Error( 'missing_ability', 'Draft ability not available.', [ 'status' => 500 ] );
+		return new WP_Error( 'missing_ability', 'Draft ability not available.', array( 'status' => 500 ) );
 	}
 
-    $context = extrachill_api_community_drafts_get_context_from_request( $request );
+	$context = extrachill_api_community_drafts_get_context_from_request( $request );
 
-    $title = (string) $request->get_param( 'title' );
-    $content = $request->get_param( 'content' );
-    $content = is_string( $content ) ? wp_unslash( $content ) : '';
+	$title   = (string) $request->get_param( 'title' );
+	$content = $request->get_param( 'content' );
+	$content = is_string( $content ) ? wp_unslash( $content ) : '';
 
-    $draft = [
-        'type'    => $context['type'],
-        'blog_id' => $context['blog_id'],
-        'forum_id' => $context['forum_id'],
-        'topic_id' => $context['topic_id'],
-        'reply_to' => $context['reply_to'],
-        'title'   => $title,
-        'content' => $content,
-    ];
+	$draft = array(
+		'type'     => $context['type'],
+		'blog_id'  => $context['blog_id'],
+		'forum_id' => $context['forum_id'],
+		'topic_id' => $context['topic_id'],
+		'reply_to' => $context['reply_to'],
+		'title'    => $title,
+		'content'  => $content,
+	);
 
 	$draft['user_id'] = get_current_user_id();
 
@@ -201,30 +201,32 @@ function extrachill_api_community_drafts_post_handler( WP_REST_Request $request 
 		return $saved;
 	}
 
-    return rest_ensure_response( [
-        'saved' => true,
-        'draft' => $saved,
-    ] );
+	return rest_ensure_response(
+		array(
+			'saved' => true,
+			'draft' => $saved,
+		)
+	);
 }
 
 function extrachill_api_community_drafts_delete_handler( WP_REST_Request $request ) {
-    $valid = extrachill_api_community_drafts_validate_context( $request );
-    if ( true !== $valid ) {
-        return $valid;
-    }
+	$valid = extrachill_api_community_drafts_validate_context( $request );
+	if ( true !== $valid ) {
+		return $valid;
+	}
 
 	$ability = wp_get_ability( 'extrachill/delete-bbpress-draft' );
 	if ( ! $ability ) {
-		return new WP_Error( 'missing_ability', 'Draft ability not available.', [ 'status' => 500 ] );
+		return new WP_Error( 'missing_ability', 'Draft ability not available.', array( 'status' => 500 ) );
 	}
 
-	$context = extrachill_api_community_drafts_get_context_from_request( $request );
+	$context            = extrachill_api_community_drafts_get_context_from_request( $request );
 	$context['user_id'] = get_current_user_id();
-	$deleted = $ability->execute( $context );
+	$deleted            = $ability->execute( $context );
 
 	if ( is_wp_error( $deleted ) ) {
 		return $deleted;
 	}
 
-	return rest_ensure_response( [ 'deleted' => (bool) $deleted ] );
+	return rest_ensure_response( array( 'deleted' => (bool) $deleted ) );
 }

--- a/inc/routes/community/notifications.php
+++ b/inc/routes/community/notifications.php
@@ -31,7 +31,7 @@ function extrachill_api_register_community_notifications_routes() {
 					'type'     => 'boolean',
 					'default'  => false,
 				),
-				'limit' => array(
+				'limit'  => array(
 					'required' => false,
 					'type'     => 'integer',
 					'default'  => 50,
@@ -93,9 +93,11 @@ function extrachill_api_community_notifications_mark_read_handler( WP_REST_Reque
 		return new WP_Error( 'ability_missing', 'community-mark-notifications-read ability not available.', array( 'status' => 503 ) );
 	}
 
-	$result = $ability->execute( array(
-		'user_id' => get_current_user_id(),
-	) );
+	$result = $ability->execute(
+		array(
+			'user_id' => get_current_user_id(),
+		)
+	);
 
 	if ( is_wp_error( $result ) ) {
 		return $result;

--- a/inc/routes/community/replies.php
+++ b/inc/routes/community/replies.php
@@ -36,7 +36,7 @@ function extrachill_api_register_community_replies_routes() {
 						'type'     => 'integer',
 						'default'  => 30,
 					),
-					'page' => array(
+					'page'     => array(
 						'required' => false,
 						'type'     => 'integer',
 						'default'  => 1,
@@ -53,7 +53,7 @@ function extrachill_api_register_community_replies_routes() {
 						'type'              => 'integer',
 						'sanitize_callback' => 'absint',
 					),
-					'content' => array(
+					'content'  => array(
 						'required' => true,
 						'type'     => 'string',
 					),

--- a/inc/routes/community/reply-editor.php
+++ b/inc/routes/community/reply-editor.php
@@ -44,7 +44,7 @@ function extrachill_api_register_community_reply_editor_routes() {
 						'required' => true,
 						'type'     => 'string',
 					),
-					'format' => array(
+					'format'  => array(
 						'required' => false,
 						'type'     => 'string',
 						'enum'     => array( 'html', 'markdown' ),

--- a/inc/routes/community/topic-editor.php
+++ b/inc/routes/community/topic-editor.php
@@ -42,7 +42,7 @@ function extrachill_api_register_community_topic_editor_routes() {
 				'callback'            => 'extrachill_api_community_topic_editor_update_handler',
 				'permission_callback' => 'extrachill_api_community_topic_editor_write_permission',
 				'args'                => array(
-					'title' => array(
+					'title'   => array(
 						'required'          => false,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
@@ -51,7 +51,7 @@ function extrachill_api_register_community_topic_editor_routes() {
 						'required' => true,
 						'type'     => 'string',
 					),
-					'format' => array(
+					'format'  => array(
 						'required' => false,
 						'type'     => 'string',
 						'enum'     => array( 'html', 'markdown' ),

--- a/inc/routes/community/topics.php
+++ b/inc/routes/community/topics.php
@@ -37,18 +37,18 @@ function extrachill_api_register_community_topics_routes() {
 						'type'     => 'integer',
 						'default'  => 20,
 					),
-					'page' => array(
+					'page'     => array(
 						'required' => false,
 						'type'     => 'integer',
 						'default'  => 1,
 					),
-					'orderby' => array(
+					'orderby'  => array(
 						'required' => false,
 						'type'     => 'string',
 						'default'  => 'date',
 						'enum'     => array( 'date', 'modified', 'title' ),
 					),
-					'order' => array(
+					'order'    => array(
 						'required' => false,
 						'type'     => 'string',
 						'default'  => 'DESC',
@@ -66,12 +66,12 @@ function extrachill_api_register_community_topics_routes() {
 						'type'              => 'integer',
 						'sanitize_callback' => 'absint',
 					),
-					'title' => array(
+					'title'    => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'content' => array(
+					'content'  => array(
 						'required' => true,
 						'type'     => 'string',
 					),
@@ -89,7 +89,7 @@ function extrachill_api_register_community_topics_routes() {
 			'callback'            => 'extrachill_api_community_topics_get_handler',
 			'permission_callback' => '__return_true',
 			'args'                => array(
-				'include_replies' => array(
+				'include_replies'  => array(
 					'required' => false,
 					'type'     => 'boolean',
 					'default'  => true,
@@ -99,7 +99,7 @@ function extrachill_api_register_community_topics_routes() {
 					'type'     => 'integer',
 					'default'  => 30,
 				),
-				'replies_page' => array(
+				'replies_page'     => array(
 					'required' => false,
 					'type'     => 'integer',
 					'default'  => 1,
@@ -147,10 +147,10 @@ function extrachill_api_community_topics_get_handler( WP_REST_Request $request )
 
 	$result = $ability->execute(
 		array(
-			'topic_id'        => (int) $request->get_param( 'id' ),
-			'include_replies' => (bool) $request->get_param( 'include_replies' ),
+			'topic_id'         => (int) $request->get_param( 'id' ),
+			'include_replies'  => (bool) $request->get_param( 'include_replies' ),
 			'replies_per_page' => (int) $request->get_param( 'replies_per_page' ),
-			'replies_page'    => (int) $request->get_param( 'replies_page' ),
+			'replies_page'     => (int) $request->get_param( 'replies_page' ),
 		)
 	);
 

--- a/inc/routes/community/upvote.php
+++ b/inc/routes/community/upvote.php
@@ -6,36 +6,40 @@
  * Delegates to business logic in extrachill-community plugin.
  */
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-add_action('extrachill_api_register_routes', 'extrachill_api_register_community_upvote_route');
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_community_upvote_route' );
 
 function extrachill_api_register_community_upvote_route() {
-	register_rest_route('extrachill/v1', '/community/upvote', array(
-		'methods'             => WP_REST_Server::CREATABLE,
-		'callback'            => 'extrachill_api_community_upvote_handler',
-		'permission_callback' => function() {
-			return is_user_logged_in();
-		},
-		'args'                => array(
-			'post_id' => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'validate_callback' => function($param) {
-					return is_numeric($param) && $param > 0;
-				},
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/community/upvote',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_community_upvote_handler',
+			'permission_callback' => function () {
+				return is_user_logged_in();
+			},
+			'args'                => array(
+				'post_id' => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'validate_callback' => function ( $param ) {
+						return is_numeric( $param ) && $param > 0;
+					},
+					'sanitize_callback' => 'absint',
+				),
+				'type'    => array(
+					'required'          => true,
+					'type'              => 'string',
+					'enum'              => array( 'topic', 'reply' ),
+					'sanitize_callback' => 'sanitize_text_field',
+				),
 			),
-			'type' => array(
-				'required'          => true,
-				'type'              => 'string',
-				'enum'              => array('topic', 'reply'),
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-		),
-	));
+		)
+	);
 }
 
 function extrachill_api_community_upvote_handler( $request ) {

--- a/inc/routes/contact/submit.php
+++ b/inc/routes/contact/submit.php
@@ -13,38 +13,42 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_contact_submit_route' );
 
 function extrachill_api_register_contact_submit_route() {
-	register_rest_route( 'extrachill/v1', '/contact/submit', array(
-		'methods'             => WP_REST_Server::CREATABLE,
-		'callback'            => 'extrachill_api_handle_contact_submit',
-		'permission_callback' => ec_turnstile_permission_callback(),
-		'args'                => array(
-			'name' => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
+	register_rest_route(
+		'extrachill/v1',
+		'/contact/submit',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_handle_contact_submit',
+			'permission_callback' => ec_turnstile_permission_callback(),
+			'args'                => array(
+				'name'               => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'email'              => array(
+					'required'          => true,
+					'type'              => 'string',
+					'validate_callback' => 'is_email',
+					'sanitize_callback' => 'sanitize_email',
+				),
+				'subject'            => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'message'            => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_textarea_field',
+				),
+				'turnstile_response' => array(
+					'required' => true,
+					'type'     => 'string',
+				),
 			),
-			'email' => array(
-				'required'          => true,
-				'type'              => 'string',
-				'validate_callback' => 'is_email',
-				'sanitize_callback' => 'sanitize_email',
-			),
-			'subject' => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-			'message' => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_textarea_field',
-			),
-			'turnstile_response' => array(
-				'required' => true,
-				'type'     => 'string',
-			),
-		),
-	) );
+		)
+	);
 }
 
 function extrachill_api_handle_contact_submit( WP_REST_Request $request ) {
@@ -65,8 +69,10 @@ function extrachill_api_handle_contact_submit( WP_REST_Request $request ) {
 	ec_contact_send_user_confirmation( $name, $email, $subject, $message );
 	ec_contact_sync_to_sendy( $email );
 
-	return rest_ensure_response( array(
-		'success' => true,
-		'message' => __( 'Your message has been sent successfully. We\'ll get back to you soon.', 'extrachill-api' ),
-	) );
+	return rest_ensure_response(
+		array(
+			'success' => true,
+			'message' => __( 'Your message has been sent successfully. We\'ll get back to you soon.', 'extrachill-api' ),
+		)
+	);
 }

--- a/inc/routes/content-blocks/band-name.php
+++ b/inc/routes/content-blocks/band-name.php
@@ -13,32 +13,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_content_blocks_band_name_route' );
 
 function extrachill_api_register_content_blocks_band_name_route() {
-	register_rest_route( 'extrachill/v1', '/content-blocks/band-name', array(
-		'methods'             => WP_REST_Server::CREATABLE,
-		'callback'            => 'extrachill_api_content_blocks_band_name_handler',
-		'permission_callback' => '__return_true',
-		'args'                => array(
-			'input'           => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
+	register_rest_route(
+		'extrachill/v1',
+		'/content-blocks/band-name',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_content_blocks_band_name_handler',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'input'           => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'genre'           => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'number_of_words' => array(
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'first_the'       => array(
+					'type' => 'boolean',
+				),
+				'and_the'         => array(
+					'type' => 'boolean',
+				),
 			),
-			'genre'           => array(
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-			'number_of_words' => array(
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
-			),
-			'first_the'       => array(
-				'type' => 'boolean',
-			),
-			'and_the'         => array(
-				'type' => 'boolean',
-			),
-		),
-	) );
+		)
+	);
 }
 
 function extrachill_api_content_blocks_band_name_handler( $request ) {
@@ -66,7 +70,9 @@ function extrachill_api_content_blocks_band_name_handler( $request ) {
 
 	$generated_name = extrachill_content_blocks_generate_band_name( $input, $genre, $number_of_words, $first_the, $and_the );
 
-	return rest_ensure_response( array(
-		'name' => $generated_name,
-	) );
+	return rest_ensure_response(
+		array(
+			'name' => $generated_name,
+		)
+	);
 }

--- a/inc/routes/content-blocks/image-voting-vote.php
+++ b/inc/routes/content-blocks/image-voting-vote.php
@@ -13,32 +13,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_content_blocks_image_voting_vote_route' );
 
 function extrachill_api_register_content_blocks_image_voting_vote_route() {
-	register_rest_route( 'extrachill/v1', '/content-blocks/image-voting/vote', array(
-		'methods'             => WP_REST_Server::CREATABLE,
-		'callback'            => 'extrachill_api_content_blocks_image_voting_vote_handler',
-		'permission_callback' => '__return_true',
-		'args'                => array(
-			'post_id'       => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'validate_callback' => function ( $param ) {
-					return is_numeric( $param ) && $param > 0;
-				},
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/content-blocks/image-voting/vote',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_content_blocks_image_voting_vote_handler',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'post_id'       => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'validate_callback' => function ( $param ) {
+						return is_numeric( $param ) && $param > 0;
+					},
+					'sanitize_callback' => 'absint',
+				),
+				'instance_id'   => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'email_address' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'validate_callback' => 'is_email',
+					'sanitize_callback' => 'sanitize_email',
+				),
 			),
-			'instance_id'   => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-			'email_address' => array(
-				'required'          => true,
-				'type'              => 'string',
-				'validate_callback' => 'is_email',
-				'sanitize_callback' => 'sanitize_email',
-			),
-		),
-	) );
+		)
+	);
 }
 
 function extrachill_api_content_blocks_image_voting_vote_handler( $request ) {
@@ -57,10 +61,12 @@ function extrachill_api_content_blocks_image_voting_vote_handler( $request ) {
 	$result = extrachill_content_blocks_process_image_vote( $post_id, $instance_id, $email_address );
 
 	if ( $result['success'] ) {
-		return rest_ensure_response( array(
-			'message'    => $result['message'],
-			'vote_count' => $result['vote_count'],
-		) );
+		return rest_ensure_response(
+			array(
+				'message'    => $result['message'],
+				'vote_count' => $result['vote_count'],
+			)
+		);
 	} else {
 		return new WP_Error(
 			isset( $result['code'] ) ? $result['code'] : 'vote_failed',

--- a/inc/routes/content-blocks/image-voting.php
+++ b/inc/routes/content-blocks/image-voting.php
@@ -12,23 +12,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_content_blocks_image_voting_route' );
 
 function extrachill_api_register_content_blocks_image_voting_route() {
-	register_rest_route( 'extrachill/v1', '/content-blocks/image-voting/vote-count/(?P<post_id>\d+)/(?P<instance_id>[a-zA-Z0-9\-]+)', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_content_blocks_image_voting_handler',
-		'permission_callback' => '__return_true',
-		'args'                => array(
-			'post_id'     => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/content-blocks/image-voting/vote-count/(?P<post_id>\d+)/(?P<instance_id>[a-zA-Z0-9\-]+)',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_content_blocks_image_voting_handler',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'post_id'     => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'instance_id' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
 			),
-			'instance_id' => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-		),
-	) );
+		)
+	);
 }
 
 function extrachill_api_content_blocks_image_voting_handler( $request ) {
@@ -57,7 +61,9 @@ function extrachill_api_content_blocks_image_voting_handler( $request ) {
 		}
 	}
 
-	return rest_ensure_response( array(
-		'vote_count' => $vote_count,
-	) );
+	return rest_ensure_response(
+		array(
+			'vote_count' => $vote_count,
+		)
+	);
 }

--- a/inc/routes/content-blocks/rapper-name.php
+++ b/inc/routes/content-blocks/rapper-name.php
@@ -13,30 +13,34 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_content_blocks_rapper_name_route' );
 
 function extrachill_api_register_content_blocks_rapper_name_route() {
-	register_rest_route( 'extrachill/v1', '/content-blocks/rapper-name', array(
-		'methods'             => WP_REST_Server::CREATABLE,
-		'callback'            => 'extrachill_api_content_blocks_rapper_name_handler',
-		'permission_callback' => '__return_true',
-		'args'                => array(
-			'input'           => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
+	register_rest_route(
+		'extrachill/v1',
+		'/content-blocks/rapper-name',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_content_blocks_rapper_name_handler',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'input'           => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'gender'          => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'style'           => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'number_of_words' => array(
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
 			),
-			'gender'          => array(
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-			'style'           => array(
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-			'number_of_words' => array(
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
-			),
-		),
-	) );
+		)
+	);
 }
 
 function extrachill_api_content_blocks_rapper_name_handler( $request ) {
@@ -63,7 +67,9 @@ function extrachill_api_content_blocks_rapper_name_handler( $request ) {
 
 	$generated_name = extrachill_content_blocks_generate_rapper_name( $input, $style, $gender, $number_of_words );
 
-	return rest_ensure_response( array(
-		'name' => $generated_name,
-	) );
+	return rest_ensure_response(
+		array(
+			'name' => $generated_name,
+		)
+	);
 }

--- a/inc/routes/docs/docs-info.php
+++ b/inc/routes/docs/docs-info.php
@@ -4,7 +4,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_docs_info_routes' );
@@ -13,15 +13,15 @@ add_action( 'extrachill_api_register_routes', 'extrachill_api_register_docs_info
  * Registers docs-info route.
  */
 function extrachill_api_register_docs_info_routes() {
-    register_rest_route(
-        'extrachill/v1',
-        '/docs-info',
-        array(
-            'methods'             => WP_REST_Server::READABLE,
-            'callback'            => 'extrachill_api_docs_info_handler',
-            'permission_callback' => '__return_true',
-        )
-    );
+	register_rest_route(
+		'extrachill/v1',
+		'/docs-info',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_docs_info_handler',
+			'permission_callback' => '__return_true',
+		)
+	);
 }
 
 /**
@@ -30,7 +30,7 @@ function extrachill_api_register_docs_info_routes() {
  * @return WP_REST_Response
  */
 function extrachill_api_docs_info_handler() {
-    $site = get_site();
+	$site = get_site();
 
 	$post_types = extrachill_api_docs_info_collect_post_types();
 	$pages      = extrachill_api_docs_info_collect_pages();
@@ -43,7 +43,7 @@ function extrachill_api_docs_info_handler() {
 
 	return rest_ensure_response(
 		array(
-			'site'        => array(
+			'site'         => array(
 				'blog_id' => get_current_blog_id(),
 				'domain'  => isset( $site->domain ) ? $site->domain : '',
 				'path'    => isset( $site->path ) ? $site->path : '/',
@@ -64,30 +64,30 @@ function extrachill_api_docs_info_handler() {
  * @return array|WP_Error
  */
 function extrachill_api_docs_info_collect_about() {
-    $main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
-    if ( ! $main_blog_id ) {
-        return new WP_Error( 'about_not_found', 'Main site blog ID not available.', array( 'status' => 500 ) );
-    }
+	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+	if ( ! $main_blog_id ) {
+		return new WP_Error( 'about_not_found', 'Main site blog ID not available.', array( 'status' => 500 ) );
+	}
 
-    try {
-        switch_to_blog( $main_blog_id );
+	try {
+		switch_to_blog( $main_blog_id );
 
-        $about = get_page_by_path( 'about' );
+		$about = get_page_by_path( 'about' );
 
-        if ( ! $about || 'publish' !== $about->post_status ) {
-            return new WP_Error( 'about_not_found', 'About page not found on main site.', array( 'status' => 500 ) );
-        }
+		if ( ! $about || 'publish' !== $about->post_status ) {
+			return new WP_Error( 'about_not_found', 'About page not found on main site.', array( 'status' => 500 ) );
+		}
 
-        return array(
-            'id'      => (int) $about->ID,
-            'slug'    => 'about',
-            'title'   => get_the_title( $about ),
-            'url'     => get_permalink( $about ),
-            'content' => apply_filters( 'the_content', $about->post_content ),
-        );
-    } finally {
-        restore_current_blog();
-    }
+		return array(
+			'id'      => (int) $about->ID,
+			'slug'    => 'about',
+			'title'   => get_the_title( $about ),
+			'url'     => get_permalink( $about ),
+			'content' => apply_filters( 'the_content', $about->post_content ),
+		);
+	} finally {
+		restore_current_blog();
+	}
 }
 
 /**
@@ -124,29 +124,29 @@ function extrachill_api_docs_info_collect_pages() {
  * @return array
  */
 function extrachill_api_docs_info_collect_post_types() {
-    $public_post_types = get_post_types( array( 'public' => true ), 'objects' );
-    $data              = array();
+	$public_post_types = get_post_types( array( 'public' => true ), 'objects' );
+	$data              = array();
 
-    global $wpdb;
+	global $wpdb;
 
-    foreach ( $public_post_types as $post_type => $object ) {
-        $counts = wp_count_posts( $post_type );
-        $published_count = isset( $counts->publish ) ? (int) $counts->publish : 0;
+	foreach ( $public_post_types as $post_type => $object ) {
+		$counts          = wp_count_posts( $post_type );
+		$published_count = isset( $counts->publish ) ? (int) $counts->publish : 0;
 
-        $tax_data   = array();
-        $taxonomies = get_object_taxonomies( $post_type, 'objects' );
+		$tax_data   = array();
+		$taxonomies = get_object_taxonomies( $post_type, 'objects' );
 
-        foreach ( $taxonomies as $tax_obj ) {
-            $total_terms = (int) wp_count_terms(
-                array(
-                    'taxonomy'   => $tax_obj->name,
-                    'hide_empty' => false,
-                )
-            );
+		foreach ( $taxonomies as $tax_obj ) {
+			$total_terms = (int) wp_count_terms(
+				array(
+					'taxonomy'   => $tax_obj->name,
+					'hide_empty' => false,
+				)
+			);
 
-            $terms_with_counts = $wpdb->get_results(
-                $wpdb->prepare(
-                    "SELECT t.term_id, t.slug, t.name, COUNT(p.ID) AS post_count
+			$terms_with_counts = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT t.term_id, t.slug, t.name, COUNT(p.ID) AS post_count
                      FROM {$wpdb->terms} t
                      INNER JOIN {$wpdb->term_taxonomy} tt ON tt.term_id = t.term_id AND tt.taxonomy = %s
                      INNER JOIN {$wpdb->term_relationships} tr ON tr.term_taxonomy_id = tt.term_taxonomy_id
@@ -154,46 +154,46 @@ function extrachill_api_docs_info_collect_post_types() {
                      WHERE p.post_type = %s AND p.post_status = 'publish'
                      GROUP BY t.term_id, t.slug, t.name
                      HAVING post_count > 0",
-                    $tax_obj->name,
-                    $post_type
-                ),
-                ARRAY_A
-            );
+					$tax_obj->name,
+					$post_type
+				),
+				ARRAY_A
+			);
 
-            $assigned_term_count = is_array( $terms_with_counts ) ? count( $terms_with_counts ) : 0;
+			$assigned_term_count = is_array( $terms_with_counts ) ? count( $terms_with_counts ) : 0;
 
-            $terms = array();
+			$terms = array();
 
-            foreach ( $terms_with_counts as $term_row ) {
-                $terms[] = array(
-                    'slug'  => $term_row['slug'],
-                    'name'  => $term_row['name'],
-                    'count' => (int) $term_row['post_count'],
-                );
-            }
+			foreach ( $terms_with_counts as $term_row ) {
+				$terms[] = array(
+					'slug'  => $term_row['slug'],
+					'name'  => $term_row['name'],
+					'count' => (int) $term_row['post_count'],
+				);
+			}
 
-            $tax_data[] = array(
-                'slug'                => $tax_obj->name,
-                'label'               => $tax_obj->label,
-                'hierarchical'        => (bool) $tax_obj->hierarchical,
-                'public'              => (bool) $tax_obj->public,
-                'total_term_count'    => $total_terms,
-                'assigned_term_count' => $assigned_term_count,
-                'terms'               => $terms,
-            );
-        }
+			$tax_data[] = array(
+				'slug'                => $tax_obj->name,
+				'label'               => $tax_obj->label,
+				'hierarchical'        => (bool) $tax_obj->hierarchical,
+				'public'              => (bool) $tax_obj->public,
+				'total_term_count'    => $total_terms,
+				'assigned_term_count' => $assigned_term_count,
+				'terms'               => $terms,
+			);
+		}
 
-        $data[ $post_type ] = array(
-            'slug'             => $post_type,
-            'label'            => $object->label,
-            'public'           => (bool) $object->public,
-            'has_archive'      => (bool) $object->has_archive,
-            'hierarchical'     => (bool) $object->hierarchical,
-            'supports'         => is_array( $object->supports ) ? array_values( $object->supports ) : array(),
-            'publish_count'    => $published_count,
-            'taxonomies'       => $tax_data,
-        );
-    }
+		$data[ $post_type ] = array(
+			'slug'          => $post_type,
+			'label'         => $object->label,
+			'public'        => (bool) $object->public,
+			'has_archive'   => (bool) $object->has_archive,
+			'hierarchical'  => (bool) $object->hierarchical,
+			'supports'      => is_array( $object->supports ) ? array_values( $object->supports ) : array(),
+			'publish_count' => $published_count,
+			'taxonomies'    => $tax_data,
+		);
+	}
 
-    return $data;
+	return $data;
 }

--- a/inc/routes/events/calendar.php
+++ b/inc/routes/events/calendar.php
@@ -61,14 +61,14 @@ function extrachill_api_register_events_calendar_route() {
 					'description'       => 'Time scope filter',
 				),
 				'lat'      => array(
-					'required'          => false,
-					'type'              => 'number',
-					'description'       => 'Latitude for geo filtering',
+					'required'    => false,
+					'type'        => 'number',
+					'description' => 'Latitude for geo filtering',
 				),
 				'lng'      => array(
-					'required'          => false,
-					'type'              => 'number',
-					'description'       => 'Longitude for geo filtering',
+					'required'    => false,
+					'type'        => 'number',
+					'description' => 'Longitude for geo filtering',
 				),
 				'radius'   => array(
 					'required'          => false,
@@ -84,10 +84,10 @@ function extrachill_api_register_events_calendar_route() {
 					'description'       => 'Search query',
 				),
 				'past'     => array(
-					'required'          => false,
-					'type'              => 'boolean',
-					'default'           => false,
-					'description'       => 'Show past events',
+					'required'    => false,
+					'type'        => 'boolean',
+					'default'     => false,
+					'description' => 'Show past events',
 				),
 			),
 		)

--- a/inc/routes/events/concert-tracking.php
+++ b/inc/routes/events/concert-tracking.php
@@ -66,10 +66,10 @@ function extrachill_api_register_concert_tracking_routes() {
 					'sanitize_callback' => 'absint',
 				),
 				'include_attendees' => array(
-					'required'          => false,
-					'type'              => 'boolean',
-					'default'           => false,
-					'description'       => 'Include attendee list.',
+					'required'    => false,
+					'type'        => 'boolean',
+					'default'     => false,
+					'description' => 'Include attendee list.',
 				),
 				'limit'             => array(
 					'required'          => false,
@@ -221,10 +221,12 @@ function extrachill_api_handle_concert_tracking_toggle( WP_REST_Request $request
 		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$result = $ability->execute( array(
-		'event_id' => (int) $request->get_param( 'event_id' ),
-		'blog_id'  => (int) $request->get_param( 'blog_id' ),
-	) );
+	$result = $ability->execute(
+		array(
+			'event_id' => (int) $request->get_param( 'event_id' ),
+			'blog_id'  => (int) $request->get_param( 'blog_id' ),
+		)
+	);
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -246,11 +248,13 @@ function extrachill_api_handle_concert_tracking_event( WP_REST_Request $request 
 		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$result = $ability->execute( array(
-		'event_id'          => (int) $request->get_param( 'event_id' ),
-		'include_attendees' => (bool) $request->get_param( 'include_attendees' ),
-		'limit'             => (int) $request->get_param( 'limit' ),
-	) );
+	$result = $ability->execute(
+		array(
+			'event_id'          => (int) $request->get_param( 'event_id' ),
+			'include_attendees' => (bool) $request->get_param( 'include_attendees' ),
+			'limit'             => (int) $request->get_param( 'limit' ),
+		)
+	);
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -272,15 +276,17 @@ function extrachill_api_handle_concert_tracking_user_shows( WP_REST_Request $req
 		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$result = $ability->execute( array(
-		'user_id'   => (int) $request->get_param( 'user_id' ),
-		'period'    => $request->get_param( 'period' ),
-		'year'      => (int) $request->get_param( 'year' ),
-		'date_from' => $request->get_param( 'date_from' ),
-		'date_to'   => $request->get_param( 'date_to' ),
-		'page'      => (int) $request->get_param( 'page' ),
-		'per_page'  => (int) $request->get_param( 'per_page' ),
-	) );
+	$result = $ability->execute(
+		array(
+			'user_id'   => (int) $request->get_param( 'user_id' ),
+			'period'    => $request->get_param( 'period' ),
+			'year'      => (int) $request->get_param( 'year' ),
+			'date_from' => $request->get_param( 'date_from' ),
+			'date_to'   => $request->get_param( 'date_to' ),
+			'page'      => (int) $request->get_param( 'page' ),
+			'per_page'  => (int) $request->get_param( 'per_page' ),
+		)
+	);
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -302,11 +308,13 @@ function extrachill_api_handle_concert_tracking_search( WP_REST_Request $request
 		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$result = $ability->execute( array(
-		'query'    => (string) $request->get_param( 'query' ),
-		'page'     => (int) $request->get_param( 'page' ),
-		'per_page' => (int) $request->get_param( 'per_page' ),
-	) );
+	$result = $ability->execute(
+		array(
+			'query'    => (string) $request->get_param( 'query' ),
+			'page'     => (int) $request->get_param( 'page' ),
+			'per_page' => (int) $request->get_param( 'per_page' ),
+		)
+	);
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -328,12 +336,14 @@ function extrachill_api_handle_concert_tracking_user_stats( WP_REST_Request $req
 		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$result = $ability->execute( array(
-		'user_id'   => (int) $request->get_param( 'user_id' ),
-		'year'      => (int) $request->get_param( 'year' ),
-		'date_from' => $request->get_param( 'date_from' ),
-		'date_to'   => $request->get_param( 'date_to' ),
-	) );
+	$result = $ability->execute(
+		array(
+			'user_id'   => (int) $request->get_param( 'user_id' ),
+			'year'      => (int) $request->get_param( 'year' ),
+			'date_from' => $request->get_param( 'date_from' ),
+			'date_to'   => $request->get_param( 'date_to' ),
+		)
+	);
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}

--- a/inc/routes/events/event-submissions.php
+++ b/inc/routes/events/event-submissions.php
@@ -24,21 +24,25 @@ function extrachill_api_register_event_submission_route() {
 		? ec_turnstile_permission_callback()
 		: '__return_true';
 
-	register_rest_route( 'extrachill/v1', '/event-submissions', array(
-		'methods'             => WP_REST_Server::CREATABLE,
-		'callback'            => 'extrachill_api_handle_event_submission',
-		'permission_callback' => $turnstile_callback,
-		'args'                => array(
-			'turnstile_response' => array(
-				'required' => false,
-				'type'     => 'string',
+	register_rest_route(
+		'extrachill/v1',
+		'/event-submissions',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_handle_event_submission',
+			'permission_callback' => $turnstile_callback,
+			'args'                => array(
+				'turnstile_response' => array(
+					'required' => false,
+					'type'     => 'string',
+				),
+				'system_prompt'      => array(
+					'required' => false,
+					'type'     => 'string',
+				),
 			),
-			'system_prompt'      => array(
-				'required' => false,
-				'type'     => 'string',
-			),
-		),
-	) );
+		)
+	);
 }
 
 function extrachill_api_handle_event_submission( WP_REST_Request $request ) {
@@ -48,17 +52,17 @@ function extrachill_api_handle_event_submission( WP_REST_Request $request ) {
 	}
 
 	$input = array(
-		'event_title'        => sanitize_text_field( $request->get_param( 'event_title' ) ),
-		'event_date'         => sanitize_text_field( $request->get_param( 'event_date' ) ),
-		'event_time'         => sanitize_text_field( $request->get_param( 'event_time' ) ),
-		'venue_name'         => sanitize_text_field( $request->get_param( 'venue_name' ) ),
-		'event_city'         => sanitize_text_field( $request->get_param( 'event_city' ) ),
-		'event_lineup'       => sanitize_text_field( $request->get_param( 'event_lineup' ) ),
-		'event_link'         => esc_url_raw( $request->get_param( 'event_link' ) ),
-		'notes'              => sanitize_textarea_field( $request->get_param( 'notes' ) ),
-		'contact_name'       => sanitize_text_field( $request->get_param( 'contact_name' ) ),
-		'contact_email'      => sanitize_email( $request->get_param( 'contact_email' ) ),
-		'system_prompt'      => sanitize_textarea_field( $request->get_param( 'system_prompt' ) ),
+		'event_title'   => sanitize_text_field( $request->get_param( 'event_title' ) ),
+		'event_date'    => sanitize_text_field( $request->get_param( 'event_date' ) ),
+		'event_time'    => sanitize_text_field( $request->get_param( 'event_time' ) ),
+		'venue_name'    => sanitize_text_field( $request->get_param( 'venue_name' ) ),
+		'event_city'    => sanitize_text_field( $request->get_param( 'event_city' ) ),
+		'event_lineup'  => sanitize_text_field( $request->get_param( 'event_lineup' ) ),
+		'event_link'    => esc_url_raw( $request->get_param( 'event_link' ) ),
+		'notes'         => sanitize_textarea_field( $request->get_param( 'notes' ) ),
+		'contact_name'  => sanitize_text_field( $request->get_param( 'contact_name' ) ),
+		'contact_email' => sanitize_email( $request->get_param( 'contact_email' ) ),
+		'system_prompt' => sanitize_textarea_field( $request->get_param( 'system_prompt' ) ),
 	);
 
 	// Pass through file upload data for flyer.

--- a/inc/routes/events/geocode.php
+++ b/inc/routes/events/geocode.php
@@ -53,9 +53,11 @@ function extrachill_api_events_geocode_handler( WP_REST_Request $request ) {
 		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$result = $ability->execute( array(
-		'q' => $request->get_param( 'q' ),
-	) );
+	$result = $ability->execute(
+		array(
+			'q' => $request->get_param( 'q' ),
+		)
+	);
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}

--- a/inc/routes/events/venues.php
+++ b/inc/routes/events/venues.php
@@ -169,9 +169,11 @@ function extrachill_api_events_venue_get_handler( WP_REST_Request $request ) {
 		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$result = $ability->execute( array(
-		'id' => (int) $request->get_param( 'id' ),
-	) );
+	$result = $ability->execute(
+		array(
+			'id' => (int) $request->get_param( 'id' ),
+		)
+	);
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}

--- a/inc/routes/giveaway/giveaway.php
+++ b/inc/routes/giveaway/giveaway.php
@@ -147,14 +147,16 @@ function extrachill_api_giveaway_run_handler( WP_REST_Request $request ) {
 		return new WP_Error( 'ability_missing', 'Giveaway ability not available.', array( 'status' => 500 ) );
 	}
 
-	$result = $ability->execute( array(
-		'media_input'  => $request->get_param( 'media_input' ),
-		'require_tag'  => $request->get_param( 'require_tag' ),
-		'min_tags'     => $request->get_param( 'min_tags' ),
-		'winner_count' => $request->get_param( 'winner_count' ),
-		'announce'     => $request->get_param( 'announce' ),
-		'message'      => $request->get_param( 'message' ),
-	) );
+	$result = $ability->execute(
+		array(
+			'media_input'  => $request->get_param( 'media_input' ),
+			'require_tag'  => $request->get_param( 'require_tag' ),
+			'min_tags'     => $request->get_param( 'min_tags' ),
+			'winner_count' => $request->get_param( 'winner_count' ),
+			'announce'     => $request->get_param( 'announce' ),
+			'message'      => $request->get_param( 'message' ),
+		)
+	);
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
@@ -174,7 +176,7 @@ function extrachill_api_giveaway_schedule_handler( WP_REST_Request $request ) {
 		return new WP_Error( 'task_system_missing', 'Data Machine Task System not available.', array( 'status' => 500 ) );
 	}
 
-	$run_at = $request->get_param( 'run_at' );
+	$run_at    = $request->get_param( 'run_at' );
 	$timestamp = strtotime( $run_at );
 	if ( ! $timestamp || $timestamp <= time() ) {
 		return new WP_Error( 'invalid_run_at', 'run_at must be a valid future UTC datetime.', array( 'status' => 400 ) );
@@ -203,12 +205,14 @@ function extrachill_api_giveaway_schedule_handler( WP_REST_Request $request ) {
 		return new WP_Error( 'schedule_failed', 'Failed to schedule giveaway task.', array( 'status' => 500 ) );
 	}
 
-	return rest_ensure_response( array(
-		'job_id'       => $job_id,
-		'task_type'    => 'giveaway',
-		'scheduled_at' => $run_at,
-		'params'       => $params,
-	) );
+	return rest_ensure_response(
+		array(
+			'job_id'       => $job_id,
+			'task_type'    => 'giveaway',
+			'scheduled_at' => $run_at,
+			'params'       => $params,
+		)
+	);
 }
 
 /**

--- a/inc/routes/media/network-media.php
+++ b/inc/routes/media/network-media.php
@@ -142,7 +142,14 @@ function extrachill_api_network_media_upload( WP_REST_Request $request ) {
 	$file = $files['file'];
 
 	if ( ! empty( $file['error'] ) && UPLOAD_ERR_OK !== $file['error'] ) {
-		return new WP_Error( 'upload_error', 'PHP reported an upload error.', array( 'status' => 400, 'php_error' => $file['error'] ) );
+		return new WP_Error(
+			'upload_error',
+			'PHP reported an upload error.',
+			array(
+				'status'    => 400,
+				'php_error' => $file['error'],
+			)
+		);
 	}
 
 	$ability = wp_get_ability( 'extrachill/network-media-upload' );

--- a/inc/routes/media/upload.php
+++ b/inc/routes/media/upload.php
@@ -22,59 +22,63 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_media_routes' );
 
 function extrachill_api_register_media_routes() {
-	register_rest_route( 'extrachill/v1', '/media', array(
+	register_rest_route(
+		'extrachill/v1',
+		'/media',
 		array(
-			'methods'             => WP_REST_Server::CREATABLE,
-			'callback'            => 'extrachill_api_media_upload_handler',
-			'permission_callback' => 'extrachill_api_media_permission_check',
-			'args'                => array(
-				'context'   => array(
-					'required'          => true,
-					'type'              => 'string',
-					'enum'              => array(
-						'user_avatar',
-						'artist_profile',
-						'artist_header',
-						'link_page_profile',
-						'link_page_background',
-						'content_embed',
-						'product_image',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => 'extrachill_api_media_upload_handler',
+				'permission_callback' => 'extrachill_api_media_permission_check',
+				'args'                => array(
+					'context'   => array(
+						'required'          => true,
+						'type'              => 'string',
+						'enum'              => array(
+							'user_avatar',
+							'artist_profile',
+							'artist_header',
+							'link_page_profile',
+							'link_page_background',
+							'content_embed',
+							'product_image',
+						),
+						'validate_callback' => 'rest_validate_request_arg',
 					),
-					'validate_callback' => 'rest_validate_request_arg',
-				),
-				'target_id' => array(
-					'required'          => false,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
+					'target_id' => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
-		array(
-			'methods'             => WP_REST_Server::DELETABLE,
-			'callback'            => 'extrachill_api_media_delete_handler',
-			'permission_callback' => 'extrachill_api_media_permission_check',
-			'args'                => array(
-				'context'   => array(
-					'required'          => true,
-					'type'              => 'string',
-					'enum'              => array(
-						'user_avatar',
-						'artist_profile',
-						'artist_header',
-						'link_page_profile',
-						'link_page_background',
-						'product_image',
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => 'extrachill_api_media_delete_handler',
+				'permission_callback' => 'extrachill_api_media_permission_check',
+				'args'                => array(
+					'context'   => array(
+						'required'          => true,
+						'type'              => 'string',
+						'enum'              => array(
+							'user_avatar',
+							'artist_profile',
+							'artist_header',
+							'link_page_profile',
+							'link_page_background',
+							'product_image',
+						),
+						'validate_callback' => 'rest_validate_request_arg',
 					),
-					'validate_callback' => 'rest_validate_request_arg',
-				),
-				'target_id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
+					'target_id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
-	) );
+		)
+	);
 }
 
 /**
@@ -287,13 +291,15 @@ function extrachill_api_media_upload_handler( WP_REST_Request $request ) {
 		wp_delete_attachment( $old_attachment_id, true );
 	}
 
-	return rest_ensure_response( array(
-		'attachment_id' => $attachment_id,
-		'url'           => wp_get_attachment_url( $attachment_id ),
-		'context'       => $context,
-		'target_id'     => $target_id,
-		'attachment'    => wp_prepare_attachment_for_js( $attachment_id ),
-	) );
+	return rest_ensure_response(
+		array(
+			'attachment_id' => $attachment_id,
+			'url'           => wp_get_attachment_url( $attachment_id ),
+			'context'       => $context,
+			'target_id'     => $target_id,
+			'attachment'    => wp_prepare_attachment_for_js( $attachment_id ),
+		)
+	);
 }
 
 /**
@@ -353,12 +359,14 @@ function extrachill_api_media_upload_product_image( $uploaded_file, $product_id 
 		restore_current_blog();
 	}
 
-	return rest_ensure_response( array(
-		'attachment_id' => $attachment_id,
-		'url'           => $url,
-		'context'       => 'product_image',
-		'target_id'     => $product_id,
-	) );
+	return rest_ensure_response(
+		array(
+			'attachment_id' => $attachment_id,
+			'url'           => $url,
+			'context'       => 'product_image',
+			'target_id'     => $product_id,
+		)
+	);
 }
 
 /**
@@ -451,11 +459,13 @@ function extrachill_api_media_delete_handler( WP_REST_Request $request ) {
 		);
 	}
 
-	return rest_ensure_response( array(
-		'deleted'   => true,
-		'context'   => $context,
-		'target_id' => $target_id,
-	) );
+	return rest_ensure_response(
+		array(
+			'deleted'   => true,
+			'context'   => $context,
+			'target_id' => $target_id,
+		)
+	);
 }
 
 /**
@@ -492,11 +502,13 @@ function extrachill_api_media_delete_product_image( $product_id ) {
 		restore_current_blog();
 	}
 
-	return rest_ensure_response( array(
-		'deleted'   => true,
-		'context'   => 'product_image',
-		'target_id' => $product_id,
-	) );
+	return rest_ensure_response(
+		array(
+			'deleted'   => true,
+			'context'   => 'product_image',
+			'target_id' => $product_id,
+		)
+	);
 }
 
 /**

--- a/inc/routes/newsletter/campaign.php
+++ b/inc/routes/newsletter/campaign.php
@@ -13,20 +13,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_newsletter_campaign_route' );
 
 function extrachill_api_register_newsletter_campaign_route() {
-	register_rest_route( 'extrachill/v1', '/newsletter/campaign/push', array(
-		'methods'             => WP_REST_Server::CREATABLE,
-		'callback'            => 'extrachill_api_newsletter_campaign_push_handler',
-		'permission_callback' => function() {
-			return current_user_can( 'manage_options' );
-		},
-		'args'                => array(
-			'post_id' => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/newsletter/campaign/push',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_newsletter_campaign_push_handler',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'args'                => array(
+				'post_id' => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
 			),
-		),
-	) );
+		)
+	);
 }
 
 function extrachill_api_newsletter_campaign_push_handler( $request ) {
@@ -51,9 +55,11 @@ function extrachill_api_newsletter_campaign_push_handler( $request ) {
 		);
 	}
 
-	return rest_ensure_response( array(
-		'success'     => $result['success'],
-		'message'     => $result['message'],
-		'campaign_id' => $result['campaign_id'],
-	) );
+	return rest_ensure_response(
+		array(
+			'success'     => $result['success'],
+			'message'     => $result['message'],
+			'campaign_id' => $result['campaign_id'],
+		)
+	);
 }

--- a/inc/routes/newsletter/management.php
+++ b/inc/routes/newsletter/management.php
@@ -16,169 +16,199 @@ add_action( 'extrachill_api_register_routes', 'extrachill_api_register_newslette
 function extrachill_api_register_newsletter_campaign_management_routes() {
 
 	// GET /newsletter/campaigns — List campaigns.
-	register_rest_route( 'extrachill/v1', '/newsletter/campaigns', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_newsletter_list_campaigns_handler',
-		'permission_callback' => function() {
-			return current_user_can( 'manage_options' );
-		},
-		'args'                => array(
-			'per_page' => array(
-				'required'          => false,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
-				'default'           => 20,
+	register_rest_route(
+		'extrachill/v1',
+		'/newsletter/campaigns',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_newsletter_list_campaigns_handler',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'args'                => array(
+				'per_page' => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+					'default'           => 20,
+				),
+				'offset'   => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+					'default'           => 0,
+				),
+				'status'   => array(
+					'required'          => false,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
 			),
-			'offset'   => array(
-				'required'          => false,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
-				'default'           => 0,
-			),
-			'status'   => array(
-				'required'          => false,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-		),
-	) );
+		)
+	);
 
 	// GET /newsletter/campaigns/<id> — Get campaign.
-	register_rest_route( 'extrachill/v1', '/newsletter/campaigns/(?P<id>\d+)', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_newsletter_get_campaign_handler',
-		'permission_callback' => function() {
-			return current_user_can( 'manage_options' );
-		},
-		'args'                => array(
-			'id' => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/newsletter/campaigns/(?P<id>\d+)',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_newsletter_get_campaign_handler',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'args'                => array(
+				'id' => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
 			),
-		),
-	) );
+		)
+	);
 
 	// DELETE /newsletter/campaigns/<id> — Delete campaign.
-	register_rest_route( 'extrachill/v1', '/newsletter/campaigns/(?P<id>\d+)', array(
-		'methods'             => WP_REST_Server::DELETABLE,
-		'callback'            => 'extrachill_api_newsletter_delete_campaign_handler',
-		'permission_callback' => function() {
-			return current_user_can( 'manage_options' );
-		},
-		'args'                => array(
-			'id' => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/newsletter/campaigns/(?P<id>\d+)',
+		array(
+			'methods'             => WP_REST_Server::DELETABLE,
+			'callback'            => 'extrachill_api_newsletter_delete_campaign_handler',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'args'                => array(
+				'id' => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
 			),
-		),
-	) );
+		)
+	);
 
 	// GET /newsletter/settings — Get settings.
-	register_rest_route( 'extrachill/v1', '/newsletter/settings', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_newsletter_get_settings_handler',
-		'permission_callback' => function() {
-			return current_user_can( 'manage_options' );
-		},
-	) );
+	register_rest_route(
+		'extrachill/v1',
+		'/newsletter/settings',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_newsletter_get_settings_handler',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+		)
+	);
 
 	// POST /newsletter/settings — Update settings.
-	register_rest_route( 'extrachill/v1', '/newsletter/settings', array(
-		'methods'             => WP_REST_Server::CREATABLE,
-		'callback'            => 'extrachill_api_newsletter_update_settings_handler',
-		'permission_callback' => function() {
-			return current_user_can( 'manage_options' );
-		},
-		'args'                => array(
-			'sendy_api_key' => array(
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
+	register_rest_route(
+		'extrachill/v1',
+		'/newsletter/settings',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_newsletter_update_settings_handler',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'args'                => array(
+				'sendy_api_key' => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'sendy_url'     => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'esc_url_raw',
+				),
+				'from_name'     => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'from_email'    => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_email',
+				),
+				'reply_to'      => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_email',
+				),
+				'brand_id'      => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'list_ids'      => array(
+					'type' => 'object',
+				),
 			),
-			'sendy_url'     => array(
-				'type'              => 'string',
-				'sanitize_callback' => 'esc_url_raw',
-			),
-			'from_name'     => array(
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-			'from_email'    => array(
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_email',
-			),
-			'reply_to'      => array(
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_email',
-			),
-			'brand_id'      => array(
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-			'list_ids'      => array(
-				'type'              => 'object',
-			),
-		),
-	) );
+		)
+	);
 
 	// GET /newsletter/subscriber-status — Check subscriber.
-	register_rest_route( 'extrachill/v1', '/newsletter/subscriber-status', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_newsletter_subscriber_status_handler',
-		'permission_callback' => function() {
-			return current_user_can( 'manage_options' );
-		},
-		'args'                => array(
-			'email'   => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_email',
+	register_rest_route(
+		'extrachill/v1',
+		'/newsletter/subscriber-status',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_newsletter_subscriber_status_handler',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'args'                => array(
+				'email'   => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_email',
+				),
+				'list_id' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
 			),
-			'list_id' => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-		),
-	) );
+		)
+	);
 
 	// POST /newsletter/sync — Bulk sync.
-	register_rest_route( 'extrachill/v1', '/newsletter/sync', array(
-		'methods'             => WP_REST_Server::CREATABLE,
-		'callback'            => 'extrachill_api_newsletter_sync_handler',
-		'permission_callback' => function() {
-			return current_user_can( 'manage_options' );
-		},
-		'args'                => array(
-			'integration' => array(
-				'required'          => true,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
+	register_rest_route(
+		'extrachill/v1',
+		'/newsletter/sync',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_newsletter_sync_handler',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'args'                => array(
+				'integration' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'emails'      => array(
+					'type' => 'array',
+				),
+				'since'       => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'dry_run'     => array(
+					'type'    => 'boolean',
+					'default' => false,
+				),
 			),
-			'emails'      => array(
-				'type'              => 'array',
-			),
-			'since'       => array(
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-			'dry_run'     => array(
-				'type'              => 'boolean',
-				'default'           => false,
-			),
-		),
-	) );
+		)
+	);
 }
 
 // ─── Handlers ────────────────────────────────────────────────────────────────
 
 function extrachill_api_newsletter_list_campaigns_handler( $request ) {
-	$result = extrachill_newsletter_ability_list_campaigns( array(
-		'per_page' => $request->get_param( 'per_page' ),
-		'offset'   => $request->get_param( 'offset' ),
-		'status'   => $request->get_param( 'status' ),
-	) );
+	$result = extrachill_newsletter_ability_list_campaigns(
+		array(
+			'per_page' => $request->get_param( 'per_page' ),
+			'offset'   => $request->get_param( 'offset' ),
+			'status'   => $request->get_param( 'status' ),
+		)
+	);
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
@@ -188,9 +218,11 @@ function extrachill_api_newsletter_list_campaigns_handler( $request ) {
 }
 
 function extrachill_api_newsletter_get_campaign_handler( $request ) {
-	$result = extrachill_newsletter_ability_get_campaign( array(
-		'campaign_id' => $request->get_param( 'id' ),
-	) );
+	$result = extrachill_newsletter_ability_get_campaign(
+		array(
+			'campaign_id' => $request->get_param( 'id' ),
+		)
+	);
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
@@ -200,9 +232,11 @@ function extrachill_api_newsletter_get_campaign_handler( $request ) {
 }
 
 function extrachill_api_newsletter_delete_campaign_handler( $request ) {
-	$result = extrachill_newsletter_ability_delete_campaign( array(
-		'campaign_id' => $request->get_param( 'id' ),
-	) );
+	$result = extrachill_newsletter_ability_delete_campaign(
+		array(
+			'campaign_id' => $request->get_param( 'id' ),
+		)
+	);
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
@@ -253,10 +287,12 @@ function extrachill_api_newsletter_update_settings_handler( $request ) {
 }
 
 function extrachill_api_newsletter_subscriber_status_handler( $request ) {
-	$result = extrachill_newsletter_ability_subscriber_status( array(
-		'email'   => $request->get_param( 'email' ),
-		'list_id' => $request->get_param( 'list_id' ),
-	) );
+	$result = extrachill_newsletter_ability_subscriber_status(
+		array(
+			'email'   => $request->get_param( 'email' ),
+			'list_id' => $request->get_param( 'list_id' ),
+		)
+	);
 
 	if ( is_wp_error( $result ) ) {
 		return $result;

--- a/inc/routes/shop/orders.php
+++ b/inc/routes/shop/orders.php
@@ -26,92 +26,104 @@ add_action( 'extrachill_api_register_routes', 'extrachill_api_register_shop_orde
  */
 function extrachill_api_register_shop_orders_routes() {
 	// List orders
-	register_rest_route( 'extrachill/v1', '/shop/orders', array(
+	register_rest_route(
+		'extrachill/v1',
+		'/shop/orders',
 		array(
-			'methods'             => WP_REST_Server::READABLE,
-			'callback'            => 'extrachill_api_shop_orders_list_handler',
-			'permission_callback' => 'extrachill_api_shop_orders_permission_check',
-			'args'                => array(
-				'artist_id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
-				),
-				'status' => array(
-					'required'          => false,
-					'type'              => 'string',
-					'default'           => 'all',
-					'enum'              => array( 'all', 'needs_fulfillment', 'completed' ),
-					'sanitize_callback' => 'sanitize_key',
-				),
-				'page' => array(
-					'required'          => false,
-					'type'              => 'integer',
-					'default'           => 1,
-					'sanitize_callback' => 'absint',
-				),
-				'per_page' => array(
-					'required'          => false,
-					'type'              => 'integer',
-					'default'           => 20,
-					'sanitize_callback' => 'absint',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_shop_orders_list_handler',
+				'permission_callback' => 'extrachill_api_shop_orders_permission_check',
+				'args'                => array(
+					'artist_id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'status'    => array(
+						'required'          => false,
+						'type'              => 'string',
+						'default'           => 'all',
+						'enum'              => array( 'all', 'needs_fulfillment', 'completed' ),
+						'sanitize_callback' => 'sanitize_key',
+					),
+					'page'      => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'default'           => 1,
+						'sanitize_callback' => 'absint',
+					),
+					'per_page'  => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'default'           => 20,
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
-	) );
+		)
+	);
 
 	// Update order status
-	register_rest_route( 'extrachill/v1', '/shop/orders/(?P<id>\d+)/status', array(
+	register_rest_route(
+		'extrachill/v1',
+		'/shop/orders/(?P<id>\d+)/status',
 		array(
-			'methods'             => WP_REST_Server::EDITABLE,
-			'callback'            => 'extrachill_api_shop_orders_status_handler',
-			'permission_callback' => 'extrachill_api_shop_orders_item_permission_check',
-			'args'                => array(
-				'id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
-				),
-				'artist_id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
-				),
-				'status' => array(
-					'required'          => true,
-					'type'              => 'string',
-					'enum'              => array( 'completed' ),
-					'sanitize_callback' => 'sanitize_key',
-				),
-				'tracking_number' => array(
-					'required'          => false,
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_text_field',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => 'extrachill_api_shop_orders_status_handler',
+				'permission_callback' => 'extrachill_api_shop_orders_item_permission_check',
+				'args'                => array(
+					'id'              => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'artist_id'       => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'status'          => array(
+						'required'          => true,
+						'type'              => 'string',
+						'enum'              => array( 'completed' ),
+						'sanitize_callback' => 'sanitize_key',
+					),
+					'tracking_number' => array(
+						'required'          => false,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
 				),
 			),
-		),
-	) );
+		)
+	);
 
 	// Refund order
-	register_rest_route( 'extrachill/v1', '/shop/orders/(?P<id>\d+)/refund', array(
+	register_rest_route(
+		'extrachill/v1',
+		'/shop/orders/(?P<id>\d+)/refund',
 		array(
-			'methods'             => WP_REST_Server::CREATABLE,
-			'callback'            => 'extrachill_api_shop_orders_refund_handler',
-			'permission_callback' => 'extrachill_api_shop_orders_item_permission_check',
-			'args'                => array(
-				'id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
-				),
-				'artist_id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => 'extrachill_api_shop_orders_refund_handler',
+				'permission_callback' => 'extrachill_api_shop_orders_item_permission_check',
+				'args'                => array(
+					'id'        => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'artist_id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
-	) );
+		)
+	);
 }
 
 /**

--- a/inc/routes/shop/product-images.php
+++ b/inc/routes/shop/product-images.php
@@ -181,9 +181,14 @@ function extrachill_api_shop_product_images_delete_handler( WP_REST_Request $req
 		);
 	}
 
-	$remaining = array_values( array_filter( $ordered_ids, function( $id ) use ( $attachment_id ) {
-		return (int) $id !== (int) $attachment_id;
-	} ) );
+	$remaining = array_values(
+		array_filter(
+			$ordered_ids,
+			function ( $id ) use ( $attachment_id ) {
+				return (int) $id !== (int) $attachment_id;
+			}
+		)
+	);
 
 	$set_order = extrachill_api_shop_product_images_set_ordered_ids( $product_id, $remaining );
 	if ( is_wp_error( $set_order ) ) {

--- a/inc/routes/shop/products.php
+++ b/inc/routes/shop/products.php
@@ -30,53 +30,61 @@ add_action( 'extrachill_api_register_routes', 'extrachill_api_register_shop_prod
  */
 function extrachill_api_register_shop_products_routes() {
 	// Collection routes: list and create
-	register_rest_route( 'extrachill/v1', '/shop/products', array(
+	register_rest_route(
+		'extrachill/v1',
+		'/shop/products',
 		array(
-			'methods'             => WP_REST_Server::READABLE,
-			'callback'            => 'extrachill_api_shop_products_list_handler',
-			'permission_callback' => 'extrachill_api_shop_products_permission_check',
-		),
-		array(
-			'methods'             => WP_REST_Server::CREATABLE,
-			'callback'            => 'extrachill_api_shop_products_create_handler',
-			'permission_callback' => 'extrachill_api_shop_products_permission_check',
-			'args'                => extrachill_api_shop_products_create_args(),
-		),
-	) );
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_shop_products_list_handler',
+				'permission_callback' => 'extrachill_api_shop_products_permission_check',
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => 'extrachill_api_shop_products_create_handler',
+				'permission_callback' => 'extrachill_api_shop_products_permission_check',
+				'args'                => extrachill_api_shop_products_create_args(),
+			),
+		)
+	);
 
 	// Item routes: get, update, delete
-	register_rest_route( 'extrachill/v1', '/shop/products/(?P<id>\d+)', array(
+	register_rest_route(
+		'extrachill/v1',
+		'/shop/products/(?P<id>\d+)',
 		array(
-			'methods'             => WP_REST_Server::READABLE,
-			'callback'            => 'extrachill_api_shop_products_get_handler',
-			'permission_callback' => 'extrachill_api_shop_products_item_permission_check',
-			'args'                => array(
-				'id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_shop_products_get_handler',
+				'permission_callback' => 'extrachill_api_shop_products_item_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
-		array(
-			'methods'             => WP_REST_Server::EDITABLE,
-			'callback'            => 'extrachill_api_shop_products_update_handler',
-			'permission_callback' => 'extrachill_api_shop_products_item_permission_check',
-			'args'                => extrachill_api_shop_products_update_args(),
-		),
-		array(
-			'methods'             => WP_REST_Server::DELETABLE,
-			'callback'            => 'extrachill_api_shop_products_delete_handler',
-			'permission_callback' => 'extrachill_api_shop_products_item_permission_check',
-			'args'                => array(
-				'id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => 'extrachill_api_shop_products_update_handler',
+				'permission_callback' => 'extrachill_api_shop_products_item_permission_check',
+				'args'                => extrachill_api_shop_products_update_args(),
+			),
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => 'extrachill_api_shop_products_delete_handler',
+				'permission_callback' => 'extrachill_api_shop_products_item_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
-	) );
+		)
+	);
 }
 
 /**
@@ -138,7 +146,7 @@ function extrachill_api_shop_get_user_artist_ids( $user_id = null ) {
 /**
  * Check if user can manage a specific artist.
  *
- * @param int $artist_id Artist profile ID.
+ * @param int      $artist_id Artist profile ID.
  * @param int|null $user_id User ID (defaults to current user).
  * @return bool True if user can manage the artist.
  */
@@ -159,70 +167,70 @@ function extrachill_api_shop_user_can_manage_artist( $artist_id, $user_id = null
  */
 function extrachill_api_shop_products_create_args() {
 	return array(
-		'artist_id'          => array(
+		'artist_id'      => array(
 			'required'          => true,
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
-			'validate_callback' => function( $value ) {
+			'validate_callback' => function ( $value ) {
 				return is_numeric( $value ) && (int) $value > 0;
 			},
 		),
-		'name'               => array(
+		'name'           => array(
 			'required'          => true,
 			'type'              => 'string',
 			'sanitize_callback' => 'sanitize_text_field',
 		),
-		'price'              => array(
+		'price'          => array(
 			'required'          => true,
 			'type'              => 'number',
-			'validate_callback' => function( $value ) {
+			'validate_callback' => function ( $value ) {
 				return is_numeric( $value ) && (float) $value > 0;
 			},
 		),
-		'sale_price'         => array(
+		'sale_price'     => array(
 			'required'          => false,
 			'type'              => 'number',
-			'validate_callback' => function( $value ) {
+			'validate_callback' => function ( $value ) {
 				return $value === null || is_numeric( $value );
 			},
 		),
-		'description'        => array(
+		'description'    => array(
 			'required' => false,
 			'type'     => 'string',
 		),
-		'manage_stock'       => array(
+		'manage_stock'   => array(
 			'required'          => false,
 			'type'              => 'boolean',
 			'sanitize_callback' => 'rest_sanitize_boolean',
 		),
-		'stock_quantity'     => array(
+		'stock_quantity' => array(
 			'required'          => false,
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
-			'validate_callback' => function( $value ) {
+			'validate_callback' => function ( $value ) {
 				return is_numeric( $value ) && (int) $value >= 0;
 			},
 		),
-		'image_id'           => array(
+		'image_id'       => array(
 			'required'          => false,
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
-			'validate_callback' => function( $value ) {
+			'validate_callback' => function ( $value ) {
 				return is_numeric( $value ) && (int) $value >= 0;
 			},
 		),
-		'gallery_ids'        => array(
+		'gallery_ids'    => array(
 			'required'          => false,
 			'type'              => 'array',
 			'items'             => array( 'type' => 'integer' ),
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				if ( ! is_array( $value ) ) {
 					return array();
 				}
 				return array_map( 'absint', $value );
 			},
 		),
-		'sizes'              => array(
+		'sizes'          => array(
 			'required'          => false,
 			'type'              => 'array',
 			'items'             => array(
@@ -232,19 +240,22 @@ function extrachill_api_shop_products_create_args() {
 					'stock' => array( 'type' => 'integer' ),
 				),
 			),
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				if ( ! is_array( $value ) ) {
 					return array();
 				}
-				return array_map( function( $item ) {
-					return array(
-						'name'  => sanitize_text_field( $item['name'] ?? '' ),
-						'stock' => absint( $item['stock'] ?? 0 ),
-					);
-				}, $value );
+				return array_map(
+					function ( $item ) {
+						return array(
+							'name'  => sanitize_text_field( $item['name'] ?? '' ),
+							'stock' => absint( $item['stock'] ?? 0 ),
+						);
+					},
+					$value
+				);
 			},
 		),
-		'ships_free'         => array(
+		'ships_free'     => array(
 			'required'          => false,
 			'type'              => 'boolean',
 			'sanitize_callback' => 'rest_sanitize_boolean',
@@ -258,26 +269,26 @@ function extrachill_api_shop_products_create_args() {
  */
 function extrachill_api_shop_products_update_args() {
 	return array(
-		'artist_id'         => array(
+		'artist_id'      => array(
 			'required'          => false,
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
-			'validate_callback' => function( $value ) {
+			'validate_callback' => function ( $value ) {
 				return $value === null || ( is_numeric( $value ) && (int) $value >= 0 );
 			},
 		),
-		'status'            => array(
+		'status'         => array(
 			'required'          => false,
 			'type'              => 'string',
 			'enum'              => array( 'draft', 'publish' ),
 			'sanitize_callback' => 'sanitize_key',
 			'validate_callback' => 'rest_validate_request_arg',
 		),
-		'image_ids'         => array(
+		'image_ids'      => array(
 			'required'          => false,
 			'type'              => 'array',
 			'items'             => array( 'type' => 'integer' ),
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				if ( $value === null ) {
 					return null;
 				}
@@ -287,56 +298,56 @@ function extrachill_api_shop_products_update_args() {
 				return array_values( array_filter( array_map( 'absint', $value ) ) );
 			},
 		),
-		'name'              => array(
+		'name'           => array(
 			'required'          => false,
 			'type'              => 'string',
 			'sanitize_callback' => 'sanitize_text_field',
 		),
-		'price'             => array(
+		'price'          => array(
 			'required'          => false,
 			'type'              => 'number',
-			'validate_callback' => function( $value ) {
+			'validate_callback' => function ( $value ) {
 				return $value === null || is_numeric( $value );
 			},
 		),
-		'sale_price'        => array(
+		'sale_price'     => array(
 			'required'          => false,
 			'type'              => 'number',
-			'validate_callback' => function( $value ) {
+			'validate_callback' => function ( $value ) {
 				return $value === null || is_numeric( $value );
 			},
 		),
-		'description'       => array(
+		'description'    => array(
 			'required' => false,
 			'type'     => 'string',
 		),
-		'manage_stock'      => array(
+		'manage_stock'   => array(
 			'required'          => false,
 			'type'              => 'boolean',
 			'sanitize_callback' => 'rest_sanitize_boolean',
 		),
-		'stock_quantity'    => array(
+		'stock_quantity' => array(
 			'required'          => false,
 			'type'              => 'integer',
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				return is_numeric( $value ) ? (int) $value : null;
 			},
-			'validate_callback' => function( $value ) {
+			'validate_callback' => function ( $value ) {
 				return $value === null || ( is_numeric( $value ) && (int) $value >= 0 );
 			},
 		),
-		'image_id'          => array(
+		'image_id'       => array(
 			'required'          => false,
 			'type'              => 'integer',
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				return is_numeric( $value ) ? absint( $value ) : null;
 			},
 		),
-		'gallery_ids'       => array(
+		'gallery_ids'    => array(
 			'required'          => false,
 			'type'              => 'array',
 			'items'             => array( 'type' => 'integer' ),
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				if ( $value === null ) {
 					return null;
 				}
@@ -346,7 +357,7 @@ function extrachill_api_shop_products_update_args() {
 				return array_map( 'absint', $value );
 			},
 		),
-		'sizes'             => array(
+		'sizes'          => array(
 			'required'          => false,
 			'type'              => 'array',
 			'items'             => array(
@@ -356,22 +367,25 @@ function extrachill_api_shop_products_update_args() {
 					'stock' => array( 'type' => 'integer' ),
 				),
 			),
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				if ( $value === null ) {
 					return null;
 				}
 				if ( ! is_array( $value ) ) {
 					return array();
 				}
-				return array_map( function( $item ) {
-					return array(
-						'name'  => sanitize_text_field( $item['name'] ?? '' ),
-						'stock' => absint( $item['stock'] ?? 0 ),
-					);
-				}, $value );
+				return array_map(
+					function ( $item ) {
+						return array(
+							'name'  => sanitize_text_field( $item['name'] ?? '' ),
+							'stock' => absint( $item['stock'] ?? 0 ),
+						);
+					},
+					$value
+				);
 			},
 		),
-		'ships_free'        => array(
+		'ships_free'     => array(
 			'required'          => false,
 			'type'              => 'boolean',
 			'sanitize_callback' => 'rest_sanitize_boolean',
@@ -482,12 +496,12 @@ function extrachill_api_shop_products_create_handler( WP_REST_Request $request )
 		);
 	}
 
-	$description   = $request->get_param( 'description' );
-	$sale_price    = $request->get_param( 'sale_price' );
-	$manage_stock  = $request->get_param( 'manage_stock' );
+	$description    = $request->get_param( 'description' );
+	$sale_price     = $request->get_param( 'sale_price' );
+	$manage_stock   = $request->get_param( 'manage_stock' );
 	$stock_quantity = $request->get_param( 'stock_quantity' );
-	$image_id      = $request->get_param( 'image_id' );
-	$gallery_ids   = $request->get_param( 'gallery_ids' );
+	$image_id       = $request->get_param( 'image_id' );
+	$gallery_ids    = $request->get_param( 'gallery_ids' );
 
 	$product_id = wp_insert_post(
 		array(
@@ -715,10 +729,12 @@ function extrachill_api_shop_products_delete_handler( WP_REST_Request $request )
 		);
 	}
 
-	return rest_ensure_response( array(
-		'deleted'    => true,
-		'product_id' => $product_id,
-	) );
+	return rest_ensure_response(
+		array(
+			'deleted'    => true,
+			'product_id' => $product_id,
+		)
+	);
 }
 
 /**
@@ -765,7 +781,7 @@ function extrachill_api_shop_products_build_response( $product_id ) {
 			'id'  => $gid,
 			'url' => wp_get_attachment_image_url( $gid, 'thumbnail' ),
 		);
-		$images[] = array(
+		$images[]       = array(
 			'id'  => $gid,
 			'url' => wp_get_attachment_image_url( $gid, 'thumbnail' ),
 		);
@@ -780,33 +796,37 @@ function extrachill_api_shop_products_build_response( $product_id ) {
 
 	$stock_quantity = null;
 	if ( ! empty( $sizes ) ) {
-		$stock_quantity = array_reduce( $sizes, function( $sum, $size ) {
-			return $sum + ( is_numeric( $size['stock'] ) ? (int) $size['stock'] : 0 );
-		}, 0 );
-		$manage_stock = true;
+		$stock_quantity = array_reduce(
+			$sizes,
+			function ( $sum, $size ) {
+				return $sum + ( is_numeric( $size['stock'] ) ? (int) $size['stock'] : 0 );
+			},
+			0
+		);
+		$manage_stock   = true;
 	} elseif ( $manage_stock ) {
 		$stock_quantity = $stock !== '' ? (int) $stock : 0;
 	}
 
 	return array(
-		'id'                => $product_id,
-		'name'              => $product_post->post_title,
-		'description'       => $product_post->post_content,
-		'price'             => $regular_price,
-		'sale_price'        => $sale_price,
-		'manage_stock'      => $manage_stock,
-		'stock_quantity'    => $stock_quantity,
-		'status'            => get_post_status( $product_id ),
-		'permalink'         => get_permalink( $product_id ),
-		'artist_id'         => $artist_id ? (int) $artist_id : null,
-		'image'             => array(
+		'id'             => $product_id,
+		'name'           => $product_post->post_title,
+		'description'    => $product_post->post_content,
+		'price'          => $regular_price,
+		'sale_price'     => $sale_price,
+		'manage_stock'   => $manage_stock,
+		'stock_quantity' => $stock_quantity,
+		'status'         => get_post_status( $product_id ),
+		'permalink'      => get_permalink( $product_id ),
+		'artist_id'      => $artist_id ? (int) $artist_id : null,
+		'image'          => array(
 			'id'  => $image_id,
 			'url' => $image_url,
 		),
-		'gallery'           => $gallery_urls,
-		'images'            => $images,
-		'sizes'             => $sizes,
-		'ships_free'        => '1' === get_post_meta( $product_id, '_ships_free', true ),
+		'gallery'        => $gallery_urls,
+		'images'         => $images,
+		'sizes'          => $sizes,
+		'ships_free'     => '1' === get_post_meta( $product_id, '_ships_free', true ),
 	);
 }
 
@@ -904,8 +924,8 @@ function extrachill_api_shop_products_can_publish( $product_id ) {
 	$stripe_status        = '';
 	try {
 		switch_to_blog( $artist_blog_id );
-		$stripe_account_id = (string) get_post_meta( $artist_id, '_stripe_connect_account_id', true );
-		$stripe_status     = (string) get_post_meta( $artist_id, '_stripe_connect_status', true );
+		$stripe_account_id    = (string) get_post_meta( $artist_id, '_stripe_connect_account_id', true );
+		$stripe_status        = (string) get_post_meta( $artist_id, '_stripe_connect_status', true );
 		$can_receive_payments = ( 'active' === $stripe_status );
 	} finally {
 		restore_current_blog();
@@ -994,7 +1014,6 @@ function extrachill_api_shop_products_set_image_order( $product_id, $image_ids )
 
 /**
  * Get product size variations with stock.
-
  *
  * Must be called within shop blog context.
  *
@@ -1007,14 +1026,16 @@ function extrachill_api_shop_get_product_sizes( $product_id ) {
 		return array();
 	}
 
-	$variations = get_posts( array(
-		'post_type'   => 'product_variation',
-		'post_parent' => $product_id,
-		'post_status' => array( 'publish', 'private' ),
-		'numberposts' => -1,
-		'orderby'     => 'menu_order',
-		'order'       => 'ASC',
-	) );
+	$variations = get_posts(
+		array(
+			'post_type'   => 'product_variation',
+			'post_parent' => $product_id,
+			'post_status' => array( 'publish', 'private' ),
+			'numberposts' => -1,
+			'orderby'     => 'menu_order',
+			'order'       => 'ASC',
+		)
+	);
 
 	$sizes = array();
 	foreach ( $variations as $variation ) {
@@ -1023,10 +1044,10 @@ function extrachill_api_shop_get_product_sizes( $product_id ) {
 			continue;
 		}
 
-		$term = get_term_by( 'slug', $size_attr, 'pa_size' );
+		$term      = get_term_by( 'slug', $size_attr, 'pa_size' );
 		$size_name = $term ? $term->name : $size_attr;
 
-		$stock = get_post_meta( $variation->ID, '_stock', true );
+		$stock   = get_post_meta( $variation->ID, '_stock', true );
 		$sizes[] = array(
 			'name'  => $size_name,
 			'stock' => $stock !== '' ? (int) $stock : 0,
@@ -1095,16 +1116,18 @@ function extrachill_api_shop_setup_product_variations( $product_id, $sizes, $pri
 	);
 	update_post_meta( $product_id, '_product_attributes', $product_attributes );
 
-	$existing_variations = get_posts( array(
-		'post_type'   => 'product_variation',
-		'post_parent' => $product_id,
-		'post_status' => array( 'publish', 'private', 'draft' ),
-		'numberposts' => -1,
-	) );
+	$existing_variations = get_posts(
+		array(
+			'post_type'   => 'product_variation',
+			'post_parent' => $product_id,
+			'post_status' => array( 'publish', 'private', 'draft' ),
+			'numberposts' => -1,
+		)
+	);
 
 	$existing_by_size = array();
 	foreach ( $existing_variations as $var ) {
-		$size_attr = get_post_meta( $var->ID, 'attribute_pa_size', true );
+		$size_attr                      = get_post_meta( $var->ID, 'attribute_pa_size', true );
 		$existing_by_size[ $size_attr ] = $var->ID;
 	}
 
@@ -1170,7 +1193,7 @@ function extrachill_api_shop_setup_product_variations( $product_id, $sizes, $pri
 		update_post_meta( $variation_id, '_stock', (string) $size_stock );
 		update_post_meta( $variation_id, '_stock_status', $size_stock > 0 ? 'instock' : 'outofstock' );
 
-		$menu_order++;
+		++$menu_order;
 	}
 
 	foreach ( $existing_by_size as $size_slug => $variation_id ) {
@@ -1193,13 +1216,15 @@ function extrachill_api_shop_setup_product_variations( $product_id, $sizes, $pri
  * @param int $product_id Product ID.
  */
 function extrachill_api_shop_convert_to_simple_product( $product_id ) {
-	$variations = get_posts( array(
-		'post_type'   => 'product_variation',
-		'post_parent' => $product_id,
-		'post_status' => array( 'publish', 'private', 'draft' ),
-		'numberposts' => -1,
-		'fields'      => 'ids',
-	) );
+	$variations = get_posts(
+		array(
+			'post_type'   => 'product_variation',
+			'post_parent' => $product_id,
+			'post_status' => array( 'publish', 'private', 'draft' ),
+			'numberposts' => -1,
+			'fields'      => 'ids',
+		)
+	);
 
 	foreach ( $variations as $variation_id ) {
 		wp_delete_post( $variation_id, true );

--- a/inc/routes/shop/shipping-address.php
+++ b/inc/routes/shop/shipping-address.php
@@ -48,38 +48,38 @@ function extrachill_api_register_shipping_address_routes() {
 						'type'              => 'integer',
 						'sanitize_callback' => 'absint',
 					),
-					'name'    => array(
+					'name'      => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'street1' => array(
+					'street1'   => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'street2' => array(
+					'street2'   => array(
 						'required'          => false,
 						'type'              => 'string',
 						'default'           => '',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'city'    => array(
+					'city'      => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'state'   => array(
+					'state'     => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'zip'     => array(
+					'zip'       => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'country' => array(
+					'country'   => array(
 						'required'          => false,
 						'type'              => 'string',
 						'default'           => 'US',

--- a/inc/routes/tools/markdown-export.php
+++ b/inc/routes/tools/markdown-export.php
@@ -304,7 +304,7 @@ function extrachill_api_get_event_markdown_meta_lines( WP_Post $post ) {
 	if ( empty( $meta_lines ) ) {
 		$event_datetime = '';
 		if ( function_exists( 'datamachine_get_event_dates' ) ) {
-			$dates = datamachine_get_event_dates( $post->ID );
+			$dates          = datamachine_get_event_dates( $post->ID );
 			$event_datetime = $dates && ! empty( $dates->start_datetime ) ? $dates->start_datetime : '';
 		}
 		if ( $event_datetime ) {

--- a/inc/routes/tools/qr-code.php
+++ b/inc/routes/tools/qr-code.php
@@ -9,7 +9,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_qr_code_route' );
@@ -18,32 +18,32 @@ add_action( 'extrachill_api_register_routes', 'extrachill_api_register_qr_code_r
  * Registers the QR code generation endpoint.
  */
 function extrachill_api_register_qr_code_route() {
-    register_rest_route(
-        'extrachill/v1',
-        '/tools/qr-code',
-        array(
-            'methods'             => WP_REST_Server::CREATABLE,
-            'callback'            => 'extrachill_api_generate_qr_code',
-            'permission_callback' => '__return_true',
-            'args'                => array(
-                'url'  => array(
-                    'required'          => true,
-                    'type'              => 'string',
-                    'sanitize_callback' => 'esc_url_raw',
-                    'validate_callback' => 'extrachill_api_validate_qr_url',
-                    'description'       => 'The URL to encode in the QR code.',
-                ),
-                'size' => array(
-                    'required'          => false,
-                    'type'              => 'integer',
-                    'default'           => 1000,
-                    'sanitize_callback' => 'absint',
-                    'validate_callback' => 'extrachill_api_validate_qr_size',
-                    'description'       => 'QR code size in pixels (default: 1000, max: 2000).',
-                ),
-            ),
-        )
-    );
+	register_rest_route(
+		'extrachill/v1',
+		'/tools/qr-code',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_generate_qr_code',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'url'  => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'esc_url_raw',
+					'validate_callback' => 'extrachill_api_validate_qr_url',
+					'description'       => 'The URL to encode in the QR code.',
+				),
+				'size' => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'default'           => 1000,
+					'sanitize_callback' => 'absint',
+					'validate_callback' => 'extrachill_api_validate_qr_size',
+					'description'       => 'QR code size in pixels (default: 1000, max: 2000).',
+				),
+			),
+		)
+	);
 }
 
 /**
@@ -53,23 +53,23 @@ function extrachill_api_register_qr_code_route() {
  * @return bool|WP_Error True if valid, WP_Error otherwise.
  */
 function extrachill_api_validate_qr_url( $url ) {
-    if ( empty( $url ) ) {
-        return new WP_Error(
-            'missing_url',
-            'URL is required.',
-            array( 'status' => 400 )
-        );
-    }
+	if ( empty( $url ) ) {
+		return new WP_Error(
+			'missing_url',
+			'URL is required.',
+			array( 'status' => 400 )
+		);
+	}
 
-    if ( ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
-        return new WP_Error(
-            'invalid_url',
-            'Please provide a valid URL.',
-            array( 'status' => 400 )
-        );
-    }
+	if ( ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
+		return new WP_Error(
+			'invalid_url',
+			'Please provide a valid URL.',
+			array( 'status' => 400 )
+		);
+	}
 
-    return true;
+	return true;
 }
 
 /**
@@ -79,25 +79,25 @@ function extrachill_api_validate_qr_url( $url ) {
  * @return bool|WP_Error True if valid, WP_Error otherwise.
  */
 function extrachill_api_validate_qr_size( $size ) {
-    $size = absint( $size );
+	$size = absint( $size );
 
-    if ( $size < 100 ) {
-        return new WP_Error(
-            'size_too_small',
-            'Size must be at least 100 pixels.',
-            array( 'status' => 400 )
-        );
-    }
+	if ( $size < 100 ) {
+		return new WP_Error(
+			'size_too_small',
+			'Size must be at least 100 pixels.',
+			array( 'status' => 400 )
+		);
+	}
 
-    if ( $size > 2000 ) {
-        return new WP_Error(
-            'size_too_large',
-            'Size cannot exceed 2000 pixels.',
-            array( 'status' => 400 )
-        );
-    }
+	if ( $size > 2000 ) {
+		return new WP_Error(
+			'size_too_large',
+			'Size cannot exceed 2000 pixels.',
+			array( 'status' => 400 )
+		);
+	}
 
-    return true;
+	return true;
 }
 
 /**
@@ -107,45 +107,47 @@ function extrachill_api_validate_qr_size( $size ) {
  * @return WP_REST_Response|WP_Error Response with QR code data URI or error.
  */
 function extrachill_api_generate_qr_code( $request ) {
-    $ability = wp_get_ability( 'extrachill/generate-qr-code' );
-    if ( ! $ability ) {
-        return new WP_Error(
-            'ability_missing',
-            'QR code ability is not available.',
-            array( 'status' => 500 )
-        );
-    }
+	$ability = wp_get_ability( 'extrachill/generate-qr-code' );
+	if ( ! $ability ) {
+		return new WP_Error(
+			'ability_missing',
+			'QR code ability is not available.',
+			array( 'status' => 500 )
+		);
+	}
 
-    $url  = $request->get_param( 'url' );
-    $size = $request->get_param( 'size' );
+	$url  = $request->get_param( 'url' );
+	$size = $request->get_param( 'size' );
 
-    $input = array(
-        'url' => $url,
-    );
+	$input = array(
+		'url' => $url,
+	);
 
-    if ( null !== $size ) {
-        $input['size'] = absint( $size );
-    }
+	if ( null !== $size ) {
+		$input['size'] = absint( $size );
+	}
 
-    $result = $ability->execute( $input );
-    if ( is_wp_error( $result ) ) {
-        $result->add_data( array( 'status' => 500 ) );
-        return $result;
-    }
+	$result = $ability->execute( $input );
+	if ( is_wp_error( $result ) ) {
+		$result->add_data( array( 'status' => 500 ) );
+		return $result;
+	}
 
-    if ( empty( $result['image'] ) || ! is_string( $result['image'] ) ) {
-        return new WP_Error(
-            'generation_failed',
-            'QR generation returned invalid image payload.',
-            array( 'status' => 500 )
-        );
-    }
+	if ( empty( $result['image'] ) || ! is_string( $result['image'] ) ) {
+		return new WP_Error(
+			'generation_failed',
+			'QR generation returned invalid image payload.',
+			array( 'status' => 500 )
+		);
+	}
 
-    $data_uri = 'data:image/png;base64,' . $result['image'];
+	$data_uri = 'data:image/png;base64,' . $result['image'];
 
-    return rest_ensure_response( array(
-        'image_url' => $data_uri,
-        'url'       => $result['url'] ?? $url,
-        'size'      => $result['size'] ?? ( $size ?: 1000 ),
-    ) );
+	return rest_ensure_response(
+		array(
+			'image_url' => $data_uri,
+			'url'       => $result['url'] ?? $url,
+			'size'      => $result['size'] ?? ( $size ?: 1000 ),
+		)
+	);
 }

--- a/inc/routes/users/artists.php
+++ b/inc/routes/users/artists.php
@@ -15,22 +15,49 @@ add_action( 'extrachill_api_register_routes', 'extrachill_api_register_user_arti
 
 function extrachill_api_register_user_artists_routes() {
 	// GET and POST for user artists list
-	register_rest_route( 'extrachill/v1', '/users/(?P<id>\d+)/artists', array(
+	register_rest_route(
+		'extrachill/v1',
+		'/users/(?P<id>\d+)/artists',
 		array(
-			'methods'             => WP_REST_Server::READABLE,
-			'callback'            => 'extrachill_api_user_artists_get_handler',
-			'permission_callback' => 'extrachill_api_user_artists_read_permission_check',
-			'args'                => array(
-				'id' => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'extrachill_api_user_artists_get_handler',
+				'permission_callback' => 'extrachill_api_user_artists_read_permission_check',
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
-		),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => 'extrachill_api_user_artists_post_handler',
+				'permission_callback' => 'extrachill_api_user_artists_admin_permission_check',
+				'args'                => array(
+					'id'        => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'artist_id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			),
+		)
+	);
+
+	// DELETE for specific artist relationship
+	register_rest_route(
+		'extrachill/v1',
+		'/users/(?P<id>\d+)/artists/(?P<artist_id>\d+)',
 		array(
-			'methods'             => WP_REST_Server::CREATABLE,
-			'callback'            => 'extrachill_api_user_artists_post_handler',
+			'methods'             => WP_REST_Server::DELETABLE,
+			'callback'            => 'extrachill_api_user_artists_delete_handler',
 			'permission_callback' => 'extrachill_api_user_artists_admin_permission_check',
 			'args'                => array(
 				'id'        => array(
@@ -44,27 +71,8 @@ function extrachill_api_register_user_artists_routes() {
 					'sanitize_callback' => 'absint',
 				),
 			),
-		),
-	) );
-
-	// DELETE for specific artist relationship
-	register_rest_route( 'extrachill/v1', '/users/(?P<id>\d+)/artists/(?P<artist_id>\d+)', array(
-		'methods'             => WP_REST_Server::DELETABLE,
-		'callback'            => 'extrachill_api_user_artists_delete_handler',
-		'permission_callback' => 'extrachill_api_user_artists_admin_permission_check',
-		'args'                => array(
-			'id'        => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
-			),
-			'artist_id' => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
-			),
-		),
-	) );
+		)
+	);
 }
 
 /**
@@ -228,12 +236,14 @@ function extrachill_api_user_artists_post_handler( WP_REST_Request $request ) {
 		);
 	}
 
-	return rest_ensure_response( array(
-		'success'   => true,
-		'message'   => 'Artist relationship added.',
-		'user_id'   => $user_id,
-		'artist_id' => $artist_id,
-	) );
+	return rest_ensure_response(
+		array(
+			'success'   => true,
+			'message'   => 'Artist relationship added.',
+			'user_id'   => $user_id,
+			'artist_id' => $artist_id,
+		)
+	);
 }
 
 /**
@@ -261,10 +271,12 @@ function extrachill_api_user_artists_delete_handler( WP_REST_Request $request ) 
 		);
 	}
 
-	return rest_ensure_response( array(
-		'success'   => true,
-		'message'   => 'Artist relationship removed.',
-		'user_id'   => $user_id,
-		'artist_id' => $artist_id,
-	) );
+	return rest_ensure_response(
+		array(
+			'success'   => true,
+			'message'   => 'Artist relationship removed.',
+			'user_id'   => $user_id,
+			'artist_id' => $artist_id,
+		)
+	);
 }

--- a/inc/routes/users/leaderboard.php
+++ b/inc/routes/users/leaderboard.php
@@ -14,25 +14,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_users_leaderboard_routes' );
 
 function extrachill_api_register_users_leaderboard_routes() {
-	register_rest_route( 'extrachill/v1', '/users/leaderboard', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_users_leaderboard_get_handler',
-		'permission_callback' => '__return_true',
-		'args'                => array(
-			'page'     => array(
-				'required'          => false,
-				'type'              => 'integer',
-				'default'           => 1,
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/users/leaderboard',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_users_leaderboard_get_handler',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'page'     => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'default'           => 1,
+					'sanitize_callback' => 'absint',
+				),
+				'per_page' => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'default'           => 25,
+					'sanitize_callback' => 'absint',
+				),
 			),
-			'per_page' => array(
-				'required'          => false,
-				'type'              => 'integer',
-				'default'           => 25,
-				'sanitize_callback' => 'absint',
-			),
-		),
-	) );
+		)
+	);
 }
 
 function extrachill_api_users_leaderboard_get_handler( WP_REST_Request $request ) {
@@ -45,10 +49,12 @@ function extrachill_api_users_leaderboard_get_handler( WP_REST_Request $request 
 	$per_page = (int) $request->get_param( 'per_page' );
 	$per_page = max( 1, min( 100, $per_page ) );
 
-	$result = $ability->execute( array(
-		'page'     => $page,
-		'per_page' => $per_page,
-	) );
+	$result = $ability->execute(
+		array(
+			'page'     => $page,
+			'per_page' => $per_page,
+		)
+	);
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}

--- a/inc/routes/users/users.php
+++ b/inc/routes/users/users.php
@@ -17,18 +17,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_user_routes' );
 
 function extrachill_api_register_user_routes() {
-	register_rest_route( 'extrachill/v1', '/users/(?P<id>\d+)', array(
-		'methods'             => WP_REST_Server::READABLE,
-		'callback'            => 'extrachill_api_user_get_handler',
-		'permission_callback' => 'extrachill_api_user_permission_check',
-		'args'                => array(
-			'id' => array(
-				'required'          => true,
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
+	register_rest_route(
+		'extrachill/v1',
+		'/users/(?P<id>\d+)',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_user_get_handler',
+			'permission_callback' => 'extrachill_api_user_permission_check',
+			'args'                => array(
+				'id' => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
 			),
-		),
-	) );
+		)
+	);
 }
 
 /**
@@ -114,8 +118,8 @@ function extrachill_api_build_user_response( $user, $full_data = false ) {
 	// Extended fields (own profile or admin only)
 	if ( $full_data ) {
 		// Lifetime membership
-		$membership_data       = get_user_meta( $user_id, 'extrachill_lifetime_membership', true );
-		$is_lifetime_member    = ! empty( $membership_data );
+		$membership_data    = get_user_meta( $user_id, 'extrachill_lifetime_membership', true );
+		$is_lifetime_member = ! empty( $membership_data );
 
 		// Artist/professional status
 		$is_artist       = get_user_meta( $user_id, 'user_is_artist', true ) === '1';
@@ -133,13 +137,13 @@ function extrachill_api_build_user_response( $user, $full_data = false ) {
 			$artist_count = count( $artists );
 		}
 
-		$response['email']               = $user->user_email;
-		$response['is_lifetime_member']  = $is_lifetime_member;
-		$response['is_artist']           = $is_artist;
-		$response['is_professional']     = $is_professional;
-		$response['can_create_artists']  = $can_create_artists;
-		$response['artist_count']        = $artist_count;
-		$response['registered']          = mysql2date( 'c', $user->user_registered );
+		$response['email']              = $user->user_email;
+		$response['is_lifetime_member'] = $is_lifetime_member;
+		$response['is_artist']          = $is_artist;
+		$response['is_professional']    = $is_professional;
+		$response['can_create_artists'] = $can_create_artists;
+		$response['artist_count']       = $artist_count;
+		$response['registered']         = mysql2date( 'c', $user->user_registered );
 	}
 
 	return $response;

--- a/inc/utils/id-generator.php
+++ b/inc/utils/id-generator.php
@@ -48,7 +48,7 @@ function extrachill_api_get_next_id( $link_page_id, $type ) {
 
 	$meta_key   = $map[ $type ];
 	$next_index = (int) get_post_meta( $link_page_id, $meta_key, true );
-	$next_index++;
+	++$next_index;
 	update_post_meta( $link_page_id, $meta_key, $next_index );
 
 	return sprintf( '%d-%s-%d', $link_page_id, $type, $next_index );


### PR DESCRIPTION
Supersedes #74 (which conflicted after dependent PRs merged: #66, #71, #72, #73). Re-ran phpcs auto-fix (`phpcbf --standard=WordPress`) cleanly on top of **current main**. **Formatting-only, no runtime changes.**

## Before / after (phpcs)
| | Before | After |
|---|---|---|
| phpcs findings | 677 | 76 |
| phpcs auto-fixable | 601 | 0 |

**1007 errors fixed across 50 files.** All 601 auto-fixable phpcs findings cleared.

### What phpcbf fixed (all safe formatting)
- 355 spaces→tabs indentation (`Generic.WhiteSpace.DisallowSpaceIndent`)
- 145 array double-arrow alignment (`WordPress.Arrays.MultipleStatementAlignment`)
- 38 short array syntax `[]`→`array()` (`Universal.Arrays.DisallowShortArraySyntax`)
- 38 multi-statement alignment
- 37 Yoda conditions (where auto-fixable)
- post-increment→pre-increment for standalone statements, operator spacing, control-structure spacing, etc.

### Remaining (76, all NON-auto-fixable — left untouched intentionally)
- 37 `WordPress.PHP.YodaConditions.NotYoda` (contexts phpcbf won't safely rewrite)
- 25 `Generic.CodeAnalysis.UnusedFunctionParameter`
- 10 `Universal.Operators.DisallowShortTernary`
- 2 `WordPress.Security.NonceVerification.Missing`
- 2 base64 discouraged-function warnings

These require manual judgment / potential logic changes, so they were deliberately **not** touched (formatting-only scope).

## Verification
- `git diff -w` confirms remaining changes are purely syntactic (`[]`→`array()`, line-wrapping, `$x++`→`++$x`).
- `php -l` passes on all 50 modified files.
- No CHANGELOG/version edits.