### PR TITLE
refactor: delegate contact route to extrachill/contact-submit ability

### DIFF
--- a/inc/routes/contact/submit.php
+++ b/inc/routes/contact/submit.php
@@ -2,8 +2,18 @@
 /**
  * REST route: POST /wp-json/extrachill/v1/contact/submit
  *
- * Contact form submission endpoint with Turnstile verification,
- * email notifications, and Sendy newsletter integration.
+ * Thin REST wrapper for the extrachill/contact-submit ability.
+ *
+ * The underlying extrachill/contact-submit ability (registered in the
+ * extrachill-contact plugin) owns all of the contact-submission logic:
+ * Cloudflare Turnstile verification, input sanitisation, admin + user
+ * email dispatch, and Sendy newsletter sync.
+ *
+ * Because the ability performs Turnstile verification itself, this route
+ * does NOT verify Turnstile at the HTTP boundary — Turnstile tokens are
+ * single-use, so verifying here and again in the ability would always fail
+ * the second check. The token is declared as a request arg and passed
+ * through to the ability, which is the single place that verifies it.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -19,7 +29,10 @@ function extrachill_api_register_contact_submit_route() {
 		array(
 			'methods'             => WP_REST_Server::CREATABLE,
 			'callback'            => 'extrachill_api_handle_contact_submit',
-			'permission_callback' => ec_turnstile_permission_callback(),
+			// Turnstile is verified inside the extrachill/contact-submit
+			// ability, not here. Tokens are single-use, so the route must
+			// not also verify or the ability's check would always fail.
+			'permission_callback' => '__return_true',
 			'args'                => array(
 				'name'               => array(
 					'required'          => true,
@@ -52,27 +65,28 @@ function extrachill_api_register_contact_submit_route() {
 }
 
 function extrachill_api_handle_contact_submit( WP_REST_Request $request ) {
-	$name    = $request->get_param( 'name' );
-	$email   = $request->get_param( 'email' );
-	$subject = $request->get_param( 'subject' );
-	$message = $request->get_param( 'message' );
-
-	if ( ! function_exists( 'ec_contact_send_admin_email' ) ) {
+	$ability = wp_get_ability( 'extrachill/contact-submit' );
+	if ( ! $ability ) {
 		return new WP_Error(
-			'contact_unavailable',
+			'ability_not_found',
 			__( 'Contact form processing unavailable.', 'extrachill-api' ),
 			array( 'status' => 500 )
 		);
 	}
 
-	ec_contact_send_admin_email( $name, $email, $subject, $message );
-	ec_contact_send_user_confirmation( $name, $email, $subject, $message );
-	ec_contact_sync_to_sendy( $email );
-
-	return rest_ensure_response(
+	$result = $ability->execute(
 		array(
-			'success' => true,
-			'message' => __( 'Your message has been sent successfully. We\'ll get back to you soon.', 'extrachill-api' ),
+			'name'               => $request->get_param( 'name' ),
+			'email'              => $request->get_param( 'email' ),
+			'subject'            => $request->get_param( 'subject' ),
+			'message'            => $request->get_param( 'message' ),
+			'turnstile_response' => $request->get_param( 'turnstile_response' ),
 		)
 	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }


### PR DESCRIPTION
## Summary

`inc/routes/contact/submit.php` re-implemented contact submission inline instead of delegating to the existing `extrachill/contact-submit` ability (registered in `extrachill-contact`, `show_in_rest => true`). The ability already does everything the route did — Turnstile verification, sanitization, admin email, user confirmation, Sendy sync — but was never called (dead code).

This makes the route a **thin shim** that delegates to the ability. The ability gains a live caller.

Closes #78

## Before / after

**Before** — route duplicated the work and only the route ran:
```php
'permission_callback' => ec_turnstile_permission_callback(),
// ...
ec_contact_send_admin_email( $name, $email, $subject, $message );
ec_contact_send_user_confirmation( $name, $email, $subject, $message );
ec_contact_sync_to_sendy( $email );

return rest_ensure_response( array(
    'success' => true,
    'message' => __( 'Your message has been sent successfully. ...', 'extrachill-api' ),
) );
```

**After** — route delegates to the ability:
```php
'permission_callback' => '__return_true',
// ...
$ability = wp_get_ability( 'extrachill/contact-submit' );
if ( ! $ability ) {
    return new WP_Error( 'ability_not_found', __( 'Contact form processing unavailable.', 'extrachill-api' ), array( 'status' => 500 ) );
}

$result = $ability->execute( array(
    'name'               => $request->get_param( 'name' ),
    'email'              => $request->get_param( 'email' ),
    'subject'            => $request->get_param( 'subject' ),
    'message'            => $request->get_param( 'message' ),
    'turnstile_response' => $request->get_param( 'turnstile_response' ),
) );

if ( is_wp_error( $result ) ) {
    return $result;
}

return rest_ensure_response( $result );
```

## Ability input schema mapped to

`extrachill/contact-submit` declares (all required):

| Key | Type | Source |
|-----|------|--------|
| `name` | string | `$request->get_param('name')` |
| `email` | string (email) | `$request->get_param('email')` |
| `subject` | string | `$request->get_param('subject')` |
| `message` | string | `$request->get_param('message')` |
| `turnstile_response` | string | `$request->get_param('turnstile_response')` |

The route's request args are unchanged, so each maps 1:1. The ability also re-sanitizes internally (`sanitize_text_field` / `sanitize_email` / `sanitize_textarea_field`), so it is self-contained even for non-REST callers (CLI, etc.).

## Turnstile handling (route vs ability — the key decision)

Unlike `/event-submissions` (whose `extrachill/submit-event` ability is **captcha-free**, so the route keeps `ec_turnstile_permission_callback()`), the `extrachill/contact-submit` ability **verifies Turnstile itself** via `ec_verify_turnstile_response()`.

Cloudflare Turnstile tokens are **single-use** — `siteverify` returns `timeout-or-duplicate` the second time a token is presented. If the route kept `ec_turnstile_permission_callback()` **and** passed the token to the ability, the ability's verification would always fail. So:

- Route permission callback dropped to `__return_true`.
- `turnstile_response` is still a required arg and is passed through to the ability.
- **The ability is the single place that verifies Turnstile.**

This keeps verification working and avoids the double-verify bug, while still requiring a token at the boundary (required arg).

## Response shape unchanged

The ability returns `{ success: bool, message: string }` on success — identical to what the route returned inline. On failure it returns a `WP_Error` (with `status` in error data, e.g. `403` for failed Turnstile, `400` for invalid email, `500` for unavailable processing), which REST serializes to the appropriate HTTP status. Existing clients see the same success payload and equivalent or better error responses.

## Constraints

- PR only — no merge, no release, no deploy.
- Conventional commit (`refactor:`). CHANGELOG / version untouched (homeboy owns both).
- Edited in a Data Machine worktree, not production.