### PR TITLE
refactor: delegate content-blocks routes to their abilities

### DIFF
--- a/inc/routes/content-blocks/band-name.php
+++ b/inc/routes/content-blocks/band-name.php
@@ -2,8 +2,11 @@
 /**
  * REST route: POST /wp-json/extrachill/v1/content-blocks/band-name
  *
- * Band name generator endpoint.
- * Delegates to business logic in extrachill-content-blocks plugin.
+ * Thin REST wrapper for the extrachill/generate-band-name ability.
+ *
+ * Canonical band-name generation logic lives in the
+ * extrachill/generate-band-name ability (extrachill-content-blocks plugin).
+ * This route validates input at the HTTP boundary and delegates.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,66 +16,55 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_content_blocks_band_name_route' );
 
 function extrachill_api_register_content_blocks_band_name_route() {
-	register_rest_route(
-		'extrachill/v1',
-		'/content-blocks/band-name',
-		array(
-			'methods'             => WP_REST_Server::CREATABLE,
-			'callback'            => 'extrachill_api_content_blocks_band_name_handler',
-			'permission_callback' => '__return_true',
-			'args'                => array(
-				'input'           => array(
-					'required'          => true,
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_text_field',
-				),
-				'genre'           => array(
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_text_field',
-				),
-				'number_of_words' => array(
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
-				),
-				'first_the'       => array(
-					'type' => 'boolean',
-				),
-				'and_the'         => array(
-					'type' => 'boolean',
-				),
+	register_rest_route( 'extrachill/v1', '/content-blocks/band-name', array(
+		'methods'             => WP_REST_Server::CREATABLE,
+		'callback'            => 'extrachill_api_content_blocks_band_name_handler',
+		'permission_callback' => '__return_true',
+		'args'                => array(
+			'input'           => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
 			),
-		)
-	);
+			'genre'           => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'number_of_words' => array(
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			),
+			'first_the'       => array(
+				'type' => 'boolean',
+			),
+			'and_the'         => array(
+				'type' => 'boolean',
+			),
+		),
+	) );
 }
 
 function extrachill_api_content_blocks_band_name_handler( $request ) {
-	$input           = $request->get_param( 'input' );
-	$genre           = $request->get_param( 'genre' );
-	$number_of_words = $request->get_param( 'number_of_words' );
-	$first_the       = $request->get_param( 'first_the' );
-	$and_the         = $request->get_param( 'and_the' );
-
-	if ( empty( $input ) ) {
+	$ability = wp_get_ability( 'extrachill/generate-band-name' );
+	if ( ! $ability ) {
 		return new WP_Error(
-			'invalid_input',
-			'Please enter your name or word',
-			array( 'status' => 400 )
-		);
-	}
-
-	if ( ! function_exists( 'extrachill_content_blocks_generate_band_name' ) ) {
-		return new WP_Error(
-			'function_missing',
-			'Band name generator function not available. Please ensure extrachill-content-blocks plugin is activated.',
+			'ability_not_found',
+			'Band name generator unavailable. Please ensure extrachill-content-blocks plugin is activated.',
 			array( 'status' => 500 )
 		);
 	}
 
-	$generated_name = extrachill_content_blocks_generate_band_name( $input, $genre, $number_of_words, $first_the, $and_the );
+	$result = $ability->execute( array(
+		'input'           => $request->get_param( 'input' ),
+		'genre'           => $request->get_param( 'genre' ),
+		'number_of_words' => $request->get_param( 'number_of_words' ),
+		'first_the'       => $request->get_param( 'first_the' ),
+		'and_the'         => $request->get_param( 'and_the' ),
+	) );
 
-	return rest_ensure_response(
-		array(
-			'name' => $generated_name,
-		)
-	);
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }

--- a/inc/routes/content-blocks/image-voting.php
+++ b/inc/routes/content-blocks/image-voting.php
@@ -2,7 +2,11 @@
 /**
  * REST route: GET /wp-json/extrachill/v1/content-blocks/image-voting/vote-count/{post_id}/{instance_id}
  *
- * Image voting count endpoint. Self-contained — no plugin dependency.
+ * Thin REST wrapper for the extrachill/image-voting-list ability.
+ *
+ * Canonical vote-count lookup logic lives in the
+ * extrachill/image-voting-list ability (extrachill-content-blocks plugin).
+ * This route validates input at the HTTP boundary and delegates.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -12,58 +16,48 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_content_blocks_image_voting_route' );
 
 function extrachill_api_register_content_blocks_image_voting_route() {
-	register_rest_route(
-		'extrachill/v1',
-		'/content-blocks/image-voting/vote-count/(?P<post_id>\d+)/(?P<instance_id>[a-zA-Z0-9\-]+)',
-		array(
-			'methods'             => WP_REST_Server::READABLE,
-			'callback'            => 'extrachill_api_content_blocks_image_voting_handler',
-			'permission_callback' => '__return_true',
-			'args'                => array(
-				'post_id'     => array(
-					'required'          => true,
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
-				),
-				'instance_id' => array(
-					'required'          => true,
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_text_field',
-				),
+	register_rest_route( 'extrachill/v1', '/content-blocks/image-voting/vote-count/(?P<post_id>\d+)/(?P<instance_id>[a-zA-Z0-9\-]+)', array(
+		'methods'             => WP_REST_Server::READABLE,
+		'callback'            => 'extrachill_api_content_blocks_image_voting_handler',
+		'permission_callback' => '__return_true',
+		'args'                => array(
+			'post_id'     => array(
+				'required'          => true,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
 			),
-		)
-	);
+			'instance_id' => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+		),
+	) );
 }
 
 function extrachill_api_content_blocks_image_voting_handler( $request ) {
-	$post_id     = $request->get_param( 'post_id' );
-	$instance_id = $request->get_param( 'instance_id' );
-
-	$post = get_post( $post_id );
-	if ( ! $post ) {
+	$ability = wp_get_ability( 'extrachill/image-voting-list' );
+	if ( ! $ability ) {
 		return new WP_Error(
-			'post_not_found',
-			'Post not found',
-			array( 'status' => 404 )
+			'ability_not_found',
+			'Image voting unavailable. Please ensure extrachill-content-blocks plugin is activated.',
+			array( 'status' => 500 )
 		);
 	}
 
-	$blocks     = parse_blocks( $post->post_content );
-	$vote_count = 0;
+	$result = $ability->execute( array(
+		'post_id'     => $request->get_param( 'post_id' ),
+		'instance_id' => $request->get_param( 'instance_id' ),
+	) );
 
-	foreach ( $blocks as $block ) {
-		if ( 'extrachill/image-voting' === $block['blockName'] ) {
-			$block_id = $block['attrs']['uniqueBlockId'] ?? '';
-			if ( $block_id === $instance_id ) {
-				$vote_count = intval( $block['attrs']['voteCount'] ?? 0 );
-				break;
-			}
+	if ( is_wp_error( $result ) ) {
+		// The list ability returns a bare 'post_not_found' WP_Error without an
+		// HTTP status; preserve the route's original 404 for that case.
+		if ( 'post_not_found' === $result->get_error_code() ) {
+			return new WP_Error( 'post_not_found', 'Post not found', array( 'status' => 404 ) );
 		}
+		return $result;
 	}
 
-	return rest_ensure_response(
-		array(
-			'vote_count' => $vote_count,
-		)
-	);
+	return rest_ensure_response( $result );
 }

--- a/inc/routes/content-blocks/rapper-name.php
+++ b/inc/routes/content-blocks/rapper-name.php
@@ -2,8 +2,11 @@
 /**
  * REST route: POST /wp-json/extrachill/v1/content-blocks/rapper-name
  *
- * Rapper name generator endpoint.
- * Delegates to business logic in extrachill-content-blocks plugin.
+ * Thin REST wrapper for the extrachill/generate-rapper-name ability.
+ *
+ * Canonical rapper-name generation logic lives in the
+ * extrachill/generate-rapper-name ability (extrachill-content-blocks plugin).
+ * This route validates input at the HTTP boundary and delegates.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,63 +16,52 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_content_blocks_rapper_name_route' );
 
 function extrachill_api_register_content_blocks_rapper_name_route() {
-	register_rest_route(
-		'extrachill/v1',
-		'/content-blocks/rapper-name',
-		array(
-			'methods'             => WP_REST_Server::CREATABLE,
-			'callback'            => 'extrachill_api_content_blocks_rapper_name_handler',
-			'permission_callback' => '__return_true',
-			'args'                => array(
-				'input'           => array(
-					'required'          => true,
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_text_field',
-				),
-				'gender'          => array(
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_text_field',
-				),
-				'style'           => array(
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_text_field',
-				),
-				'number_of_words' => array(
-					'type'              => 'integer',
-					'sanitize_callback' => 'absint',
-				),
+	register_rest_route( 'extrachill/v1', '/content-blocks/rapper-name', array(
+		'methods'             => WP_REST_Server::CREATABLE,
+		'callback'            => 'extrachill_api_content_blocks_rapper_name_handler',
+		'permission_callback' => '__return_true',
+		'args'                => array(
+			'input'           => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
 			),
-		)
-	);
+			'gender'          => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'style'           => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'number_of_words' => array(
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			),
+		),
+	) );
 }
 
 function extrachill_api_content_blocks_rapper_name_handler( $request ) {
-	$input           = $request->get_param( 'input' );
-	$gender          = $request->get_param( 'gender' );
-	$style           = $request->get_param( 'style' );
-	$number_of_words = $request->get_param( 'number_of_words' );
-
-	if ( empty( $input ) ) {
+	$ability = wp_get_ability( 'extrachill/generate-rapper-name' );
+	if ( ! $ability ) {
 		return new WP_Error(
-			'invalid_input',
-			'Please enter your name',
-			array( 'status' => 400 )
-		);
-	}
-
-	if ( ! function_exists( 'extrachill_content_blocks_generate_rapper_name' ) ) {
-		return new WP_Error(
-			'function_missing',
-			'Rapper name generator function not available. Please ensure extrachill-content-blocks plugin is activated.',
+			'ability_not_found',
+			'Rapper name generator unavailable. Please ensure extrachill-content-blocks plugin is activated.',
 			array( 'status' => 500 )
 		);
 	}
 
-	$generated_name = extrachill_content_blocks_generate_rapper_name( $input, $style, $gender, $number_of_words );
+	$result = $ability->execute( array(
+		'input'           => $request->get_param( 'input' ),
+		'style'           => $request->get_param( 'style' ),
+		'gender'          => $request->get_param( 'gender' ),
+		'number_of_words' => $request->get_param( 'number_of_words' ),
+	) );
 
-	return rest_ensure_response(
-		array(
-			'name' => $generated_name,
-		)
-	);
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
 }


### PR DESCRIPTION
## Summary

Sibling cleanup to #78. Three `content-blocks` REST routes re-implemented logic inline by calling `extrachill-content-blocks` functions directly, while the matching abilities already wrapped that logic and sat as **dead code** — their docblocks literally say *"Canonical logic ported from extrachill-api's ... route."* This makes each route a thin shim that delegates to its ability.

| Route | Was calling inline | Now delegates to |
|-------|--------------------|------------------|
| `POST /content-blocks/band-name` | `extrachill_content_blocks_generate_band_name()` | `extrachill/generate-band-name` |
| `POST /content-blocks/rapper-name` | `extrachill_content_blocks_generate_rapper_name()` | `extrachill/generate-rapper-name` |
| `GET /content-blocks/image-voting/vote-count/{id}/{instance}` | inline `parse_blocks()` loop | `extrachill/image-voting-list` |

## Why these three are safe

All three abilities register `permission_callback => '__return_true'`, so delegating via `wp_get_ability()->execute()` does **not** change access (the routes are public). `execute()` does run the ability's permission check internally, which is exactly why the *vote* route is excluded (see below). Input schemas are exact supersets and response shapes are unchanged:

- band-name / rapper-name → `{ name: string }`
- image-voting vote-count → `{ vote_count: int }`

## Response-shape parity preserved

The `image-voting-list` ability returns a bare `post_not_found` `WP_Error` **without** an HTTP status, whereas the original route returned a `404`. The shim re-maps that one case back to `status 404` so existing clients see the identical response. All other errors pass through unchanged.

## Excluded on purpose: image-voting *vote*

`POST /content-blocks/image-voting/vote` was **not** delegated. Its ability `extrachill/image-voting-vote` gates on `is_user_logged_in`, but the block votes **anonymously by email** (newsletter opt-in) and the route is public. `WP_Ability::execute()` enforces the ability's permission callback, so delegating would break logged-out voting. That permission mismatch is a real decision, tracked in #81.

## Before / after (band-name, representative)

**Before:**
```php
'permission_callback' => '__return_true',
// ...
if ( ! function_exists( 'extrachill_content_blocks_generate_band_name' ) ) { /* 500 */ }
$generated_name = extrachill_content_blocks_generate_band_name( $input, $genre, $number_of_words, $first_the, $and_the );
return rest_ensure_response( array( 'name' => $generated_name ) );
```

**After:**
```php
$ability = wp_get_ability( 'extrachill/generate-band-name' );
if ( ! $ability ) { /* 500 ability_not_found */ }
$result = $ability->execute( array(
    'input' => $request->get_param('input'), 'genre' => $request->get_param('genre'),
    'number_of_words' => $request->get_param('number_of_words'),
    'first_the' => $request->get_param('first_the'), 'and_the' => $request->get_param('and_the'),
) );
if ( is_wp_error( $result ) ) { return $result; }
return rest_ensure_response( $result );
```

## Constraints

- PR only — no merge, no release, no deploy.
- Conventional `refactor:` commit. CHANGELOG / version untouched (homeboy owns both).
- Edited in a Data Machine worktree, not production.
- `php -l` clean on all three files.

Related: #78 (the original contact-route delegation), #81 (the excluded vote-route permission decision).