### PR TITLE
refactor(notifications): repoint community routes to network substrate abilities

### DIFF
--- a/inc/routes/community/notifications.php
+++ b/inc/routes/community/notifications.php
@@ -31,10 +31,16 @@ function extrachill_api_register_community_notifications_routes() {
 					'type'     => 'boolean',
 					'default'  => false,
 				),
+				// Backward-compatible: existing clients send "limit"; mapped to per_page below.
 				'limit'  => array(
 					'required' => false,
 					'type'     => 'integer',
 					'default'  => 50,
+				),
+				'page'   => array(
+					'required' => false,
+					'type'     => 'integer',
+					'default'  => 1,
 				),
 			),
 		)
@@ -60,9 +66,9 @@ function extrachill_api_community_notifications_permission() {
 }
 
 function extrachill_api_community_notifications_list_handler( WP_REST_Request $request ) {
-	$ability = wp_get_ability( 'extrachill/community-get-notifications' );
+	$ability = wp_get_ability( 'extrachill/get-notifications' );
 	if ( ! $ability ) {
-		return new WP_Error( 'ability_missing', 'community-get-notifications ability not available.', array( 'status' => 503 ) );
+		return new WP_Error( 'ability_missing', 'get-notifications ability not available.', array( 'status' => 503 ) );
 	}
 
 	$input = array(
@@ -73,9 +79,15 @@ function extrachill_api_community_notifications_list_handler( WP_REST_Request $r
 		$input['unread'] = true;
 	}
 
+	// Map the legacy "limit" route arg to the substrate ability's "per_page".
 	$limit = (int) $request->get_param( 'limit' );
 	if ( $limit > 0 ) {
-		$input['limit'] = $limit;
+		$input['per_page'] = $limit;
+	}
+
+	$page = (int) $request->get_param( 'page' );
+	if ( $page > 0 ) {
+		$input['page'] = $page;
 	}
 
 	$result = $ability->execute( $input );
@@ -87,12 +99,13 @@ function extrachill_api_community_notifications_list_handler( WP_REST_Request $r
 	return rest_ensure_response( $result );
 }
 
-function extrachill_api_community_notifications_mark_read_handler( WP_REST_Request $request ) {
-	$ability = wp_get_ability( 'extrachill/community-mark-notifications-read' );
+function extrachill_api_community_notifications_mark_read_handler() {
+	$ability = wp_get_ability( 'extrachill/mark-notifications-read' );
 	if ( ! $ability ) {
-		return new WP_Error( 'ability_missing', 'community-mark-notifications-read ability not available.', array( 'status' => 503 ) );
+		return new WP_Error( 'ability_missing', 'mark-notifications-read ability not available.', array( 'status' => 503 ) );
 	}
 
+	// No notification_id => marks ALL unread, preserving the original mark-all behavior.
 	$result = $ability->execute(
 		array(
 			'user_id' => get_current_user_id(),


### PR DESCRIPTION
## Summary

Repoints the community-notifications REST routes in `extrachill-api` from the deprecated community-only blob abilities onto the **network notification substrate** abilities registered by `extrachill-users`.

This is a thin-wrapper repoint only — per the platform rule, `extrachill-api` is a REST wrapper and abilities own all logic.

## Route repoint

| Route | Old ability | New substrate ability |
|-------|-------------|------------------------|
| `GET /wp-json/extrachill/v1/community/notifications` | `extrachill/community-get-notifications` | `extrachill/get-notifications` |
| `POST /wp-json/extrachill/v1/community/notifications/mark-read` | `extrachill/community-mark-notifications-read` | `extrachill/mark-notifications-read` |

Route paths, HTTP methods, and `permission_callback` are unchanged.

## `limit` → `per_page` mapping

The new substrate ability uses `page` / `per_page` pagination instead of the old `limit` param. To keep existing clients working:

- The legacy `limit` route arg is preserved and mapped to the ability's `per_page` input.
- An optional `page` route arg (default 1) is added and passed through.
- `unread` and `user_id => get_current_user_id()` are passed through unchanged.

The mark-read handler passes no `notification_id`, so the substrate ability marks **all** unread notifications — preserving the original mark-all behavior.

## Verification

- `php -l` clean on the changed file.
- `homeboy lint --changed-since HEAD` passes (also resolved a now-unused `$request` param surfaced on the changed file).
- Grep-confirmed **zero** remaining references to the three old ability names (`community-get-notifications`, `community-mark-notifications-read`, `community-clear-notifications`) anywhere in the plugin.

## Dependencies / coordination

- **Depends on** the `extrachill-users` network notification substrate (already merged to `main`; not yet deployed to production reference).
- **Coordinates with** the parallel `extrachill-community` cutover PR that deletes the old `community-*` blob abilities.

Parent epic: Extra-Chill/extrachill-community#82