### PR TITLE
fix(events): resolve upcoming-counts ability in events-blog context to stop cross-site log spam (closes #86)

### DIFF
--- a/inc/routes/events/upcoming-counts.php
+++ b/inc/routes/events/upcoming-counts.php
@@ -64,18 +64,19 @@ function extrachill_api_register_events_upcoming_counts_route() {
 /**
  * Handle upcoming counts request.
  *
- * Invokes the extrachill/events-upcoming-counts ability (registered in extrachill-events).
- * Route affinity middleware ensures this runs on the events site.
+ * Invokes the extrachill/events-upcoming-counts ability (registered in extrachill-events,
+ * which is active only on the events site). Because this REST route is network-wide, it can
+ * be called from any site in the network. To reach the events-registered ability — and the
+ * events-site taxonomy/post tables it reads — we switch to the events blog before resolving
+ * and executing the ability, then always restore the original context.
+ *
+ * Switching before wp_get_ability() also prevents the WP core "ability not found" notice that
+ * would otherwise be emitted on every cross-site call (see issue #86).
  *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response data or error.
  */
 function extrachill_api_events_upcoming_counts_handler( WP_REST_Request $request ) {
-	$ability = wp_get_ability( 'extrachill/events-upcoming-counts' );
-	if ( ! $ability ) {
-		return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
-	}
-
 	$input = array(
 		'taxonomy' => $request->get_param( 'taxonomy' ),
 		'limit'    => (int) $request->get_param( 'limit' ),
@@ -91,10 +92,32 @@ function extrachill_api_events_upcoming_counts_handler( WP_REST_Request $request
 		$input['location_slug'] = $location_slug;
 	}
 
-	$result = $ability->execute( $input );
-	if ( is_wp_error( $result ) ) {
-		return $result;
+	// Resolve the events blog. The ability and its data live on the events site.
+	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 0;
+	$current_blog   = get_current_blog_id();
+	$did_switch     = false;
+
+	// Only switch when we can resolve the events blog and we're not already on it.
+	if ( $events_blog_id > 0 && $events_blog_id !== $current_blog ) {
+		switch_to_blog( $events_blog_id );
+		$did_switch = true;
 	}
 
-	return rest_ensure_response( $result );
+	try {
+		$ability = wp_get_ability( 'extrachill/events-upcoming-counts' );
+		if ( ! $ability ) {
+			return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return rest_ensure_response( $result );
+	} finally {
+		if ( $did_switch ) {
+			restore_current_blog();
+		}
+	}
 }


### PR DESCRIPTION
## Root cause

`extrachill/events-upcoming-counts` is registered by **extrachill-events**, which is active **only on the events site (blog 7)**. The REST route handler in **extrachill-api** (`inc/routes/events/upcoming-counts.php`) is network-wide and called `wp_get_ability( 'extrachill/events-upcoming-counts' )` in whatever blog context the request arrived in.

On any non-events site the ability is not registered, so `wp_get_ability()` emitted a WP core notice — `Function WP_Abilities_Registry::get_registered was called incorrectly. Ability "extrachill/events-upcoming-counts" not found` — **before** returning null and hitting the existing `! $ability` guard. This was the #1 entry in the production debug.log (~12 notices/minute, continuous), driven by callers hitting the route from non-events contexts.

## The fix

Switch to the events blog **before** resolving and executing the ability, then always restore:

- Resolve the events blog via `function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 0` (the established platform pattern).
- Skip the switch when already on the events blog, or when the events blog can't be resolved (`0`) — falling back to current behaviour and the existing clean `ability_not_found` 500.
- `switch_to_blog()` before `wp_get_ability()` so the ability is registered in scope and the core notice is never emitted in the normal cross-site case.
- `restore_current_blog()` runs in a `finally` block, guaranteeing the context is restored on **every** return path (success, `WP_Error`, ability-missing).

The ability reads from the current blog's tables (`$wpdb`, `taxonomy_exists`, `get_term_by`, `get_term_link`) and does **not** do its own `switch_to_blog`, so switching context in the route is exactly what makes the events-site data reachable — no double-switching.

## Behaviour unchanged

Response shape, input mapping (`taxonomy`, `limit`, `slug`, `location_slug`), and `is_wp_error( $result )` handling are identical from the caller's perspective. The only change is: no more log spam and the route is correctly reachable cross-site.

## Verification

- `php -l inc/routes/events/upcoming-counts.php` — clean.
- `homeboy lint --changed-since main` — lint phase passed, **0 findings**.
- No leaked `switch_to_blog` context on any return path (try/finally).

Closes #86