### PR TITLE
fix: guard events-upcoming-counts ability resolution with wp_has_ability() (#171)

### DIFF
--- a/inc/routes/events/upcoming-counts.php
+++ b/inc/routes/events/upcoming-counts.php
@@ -70,8 +70,12 @@ function extrachill_api_register_events_upcoming_counts_route() {
  * events-site taxonomy/post tables it reads — we switch to the events blog before resolving
  * and executing the ability, then always restore the original context.
  *
- * Switching before wp_get_ability() also prevents the WP core "ability not found" notice that
- * would otherwise be emitted on every cross-site call (see issue #86).
+ * switch_to_blog() changes only the DB context — it does not load the
+ * extrachill-events plugin code, so the ability is registered only when this
+ * request actually runs on a site where extrachill-events is active. We
+ * therefore guard with wp_has_ability() (a notice-free registry check) before
+ * calling wp_get_ability(), which otherwise emits a core "ability not found"
+ * notice on every cross-site / internal dispatch (see issues #86, #171).
  *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response data or error.
@@ -104,6 +108,18 @@ function extrachill_api_events_upcoming_counts_handler( WP_REST_Request $request
 	}
 
 	try {
+		// Guard with wp_has_ability() before resolving. switch_to_blog() only
+		// changes the DB context — it does NOT load extrachill-events' code, so
+		// the ability is registered only when this request runs on a site where
+		// extrachill-events is active. wp_get_ability() emits a core
+		// "_doing_it_wrong" notice whenever the ability is absent; wp_has_ability()
+		// performs the same registry check without the notice. This keeps stray
+		// cross-site / internal dispatches (e.g. rest_do_request from the cache
+		// warmer) from polluting the log and tripping headers-already-sent.
+		if ( ! function_exists( 'wp_has_ability' ) || ! wp_has_ability( 'extrachill/events-upcoming-counts' ) ) {
+			return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );
+		}
+
 		$ability = wp_get_ability( 'extrachill/events-upcoming-counts' );
 		if ( ! $ability ) {
 			return new WP_Error( 'ability_not_found', 'extrachill-events plugin is required.', array( 'status' => 500 ) );


### PR DESCRIPTION
## Summary

Stops a `WP_Abilities_Registry::get_registered was called incorrectly — Ability "extrachill/events-upcoming-counts" not found` notice from firing on every cross-site / internal dispatch of the upcoming-counts route. That notice's mid-bootstrap output was tripping `Cannot modify header information - headers already sent in ms-settings.php:84`.

Fixes Extra-Chill/extrachill-events#171.

## Root cause

The handler called `wp_get_ability( 'extrachill/events-upcoming-counts' )` and only checked for `null` afterward. WP core's `wp_get_ability()` → `get_registered()` emits a `_doing_it_wrong` notice whenever the ability is **not registered**. That ability is registered by **extrachill-events**, which is active on the **events site only** — so on every other site the call always emitted the notice.

The existing `switch_to_blog( events )` in this handler does **not** fix it: `switch_to_blog()` swaps the DB context but does **not** load extrachill-events' PHP, so the ability stays unregistered on the calling site. Stray internal dispatches — notably `rest_do_request()` from the `extrachill-multisite` cache warmer (`badge-count-warmer.php`) and `taxonomy-links.php` — therefore spammed the log and tripped headers-already-sent.

This surfaced while resolving the 2026-06-02 network-wide login outage: after enabling `WP_REDIS_GRACEFUL` (the primary fix), the remaining `headers already sent` entries were no longer Redis-driven — they were preceded by **this** notice instead.

## Fix

Guard with `wp_has_ability()` — the notice-free registry existence check — before calling `wp_get_ability()`. 

- On the **events site**: behavior is identical (ability present → resolves and executes as before).
- On **any other site / stray dispatch**: returns the existing `ability_not_found` 500 **without** emitting a core notice.

## Testing

- `php -l` clean.
- `homeboy lint` (PHPCS + PHPStan) — 0 findings on the changed file.

## Notes

- Net behavior change is only the suppression of the spurious notice; no functional/API change for legitimate events-site calls.
- Follow-up worth considering (not in this PR): the `extrachill-multisite` cache warmer and `taxonomy-links.php` dispatch this route via `rest_do_request()` from the main blog; if affinity forwarding isn't applied for internal dispatch, those calls hit this 500 path instead of the events site. Tracked thinking for a separate issue if the warm is actually failing rather than just noisy.