### PR TITLE
Add bridge click_type + impression route for network bridge instrumentation

### DIFF
--- a/inc/routes/analytics/click.php
+++ b/inc/routes/analytics/click.php
@@ -5,6 +5,12 @@
  * Unified click tracking endpoint. Routes to appropriate storage based on click_type:
  * - 'share': Tracks via extrachill/track-analytics-event ability to ec_events table
  * - 'link_page_link': Fires action hook for artist link page daily tables
+ * - 'bridge': Tracks a cross-site network-bridge click via the analytics ability.
+ *             Fired client-side (sendBeacon) so it counts human intent only —
+ *             prefetch/prerender can fake a UTM arrival but not a real click in a
+ *             JS-executing browser. Pairs with the bridge_impression event
+ *             (see /analytics/impression) so CTR = clicks / impressions is
+ *             computable and bot-filtered. See extrachill-multisite#58.
  *
  * Future click types (internal_link, taxonomy_badge, cta, etc.) will route through abilities.
  */
@@ -29,7 +35,7 @@ function extrachill_api_register_click_route() {
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_key',
 					'validate_callback' => function ( $param ) {
-						$allowed = array( 'share', 'link_page_link' );
+						$allowed = array( 'share', 'link_page_link', 'bridge' );
 						return in_array( $param, $allowed, true );
 					},
 				),
@@ -57,6 +63,18 @@ function extrachill_api_register_click_route() {
 				'link_page_id'      => array(
 					'required'          => false,
 					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'dest_site'         => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_key',
+				),
+				'source_post'       => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'default'           => 0,
 					'sanitize_callback' => 'absint',
 				),
 			),
@@ -121,6 +139,8 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 	$element_text      = $request->get_param( 'element_text' );
 	$share_destination = $request->get_param( 'share_destination' );
 	$link_page_id      = $request->get_param( 'link_page_id' );
+	$dest_site         = $request->get_param( 'dest_site' );
+	$source_post       = (int) $request->get_param( 'source_post' );
 
 	$normalized_destination = extrachill_api_normalize_tracked_url( $destination_url );
 
@@ -192,6 +212,40 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 			 * @param string $element_text         The link text at time of click.
 			 */
 			do_action( 'extrachill_link_click_recorded', $link_page_id, $normalized_destination, $element_text );
+			break;
+
+		case 'bridge':
+			$ability = wp_get_ability( 'extrachill/track-analytics-event' );
+			if ( ! $ability ) {
+				return new WP_Error(
+					'ability_missing',
+					'Analytics tracking ability not available.',
+					array( 'status' => 500 )
+				);
+			}
+
+			$event_id = $ability->execute(
+				array(
+					'event_type' => 'bridge_click',
+					'event_data' => array(
+						'dest_site'   => $dest_site,
+						'source_post' => $source_post,
+					),
+					'source_url' => $source_url,
+				)
+			);
+
+			if ( is_wp_error( $event_id ) ) {
+				return $event_id;
+			}
+
+			if ( empty( $event_id ) ) {
+				return new WP_Error(
+					'tracking_failed',
+					'Failed to record bridge click event.',
+					array( 'status' => 500 )
+				);
+			}
 			break;
 	}
 

--- a/inc/routes/analytics/impression.php
+++ b/inc/routes/analytics/impression.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * REST route: POST /wp-json/extrachill/v1/analytics/impression
+ *
+ * Records a cross-site network-bridge impression — fired client-side
+ * (sendBeacon) once per pageview when the bridge actually renders with cards.
+ * Because it runs only in a real, JS-executing browser, prefetch/prerender/
+ * crawler hits (the source of the bridge channel's bot inflation) never fire
+ * it. It is the exposure denominator that makes CTR = clicks / impressions
+ * computable, and it shares the same humans-with-JS bot filter as the
+ * bridge_click event. See extrachill-multisite#58.
+ *
+ * Thin wrapper: records via the extrachill/track-analytics-event ability —
+ * all write logic lives in the ability, not here.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_impression_route' );
+
+function extrachill_api_register_impression_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/analytics/impression',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_impression_handler',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'impression_type' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_key',
+					'validate_callback' => function ( $param ) {
+						$allowed = array( 'bridge' );
+						return in_array( $param, $allowed, true );
+					},
+				),
+				'source_url'      => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'esc_url_raw',
+				),
+				'source_post'     => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'default'           => 0,
+					'sanitize_callback' => 'absint',
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Handle impression tracking request.
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response|WP_Error
+ */
+function extrachill_api_impression_handler( WP_REST_Request $request ) {
+	$impression_type = $request->get_param( 'impression_type' );
+	$source_url      = $request->get_param( 'source_url' );
+	$source_post     = (int) $request->get_param( 'source_post' );
+
+	if ( 'bridge' !== $impression_type ) {
+		return new WP_Error(
+			'invalid_impression_type',
+			'Unsupported impression type.',
+			array( 'status' => 400 )
+		);
+	}
+
+	$ability = wp_get_ability( 'extrachill/track-analytics-event' );
+	if ( ! $ability ) {
+		return new WP_Error(
+			'ability_missing',
+			'Analytics tracking ability not available.',
+			array( 'status' => 500 )
+		);
+	}
+
+	$event_id = $ability->execute(
+		array(
+			'event_type' => 'bridge_impression',
+			'event_data' => array(
+				'source_post' => $source_post,
+			),
+			'source_url' => $source_url,
+		)
+	);
+
+	if ( is_wp_error( $event_id ) ) {
+		return $event_id;
+	}
+
+	if ( empty( $event_id ) ) {
+		return new WP_Error(
+			'tracking_failed',
+			'Failed to record bridge impression event.',
+			array( 'status' => 500 )
+		);
+	}
+
+	return rest_ensure_response( array( 'recorded' => true ) );
+}


### PR DESCRIPTION
Part of Extra-Chill/extrachill-multisite#58. This is the canonical REST surface for the cross-site network-bridge instrumentation — paired with extrachill-multisite#59 (render-side enqueue) and extrachill-analytics#31 (CTR rollup ability).

## What

Routes the bridge click + impression events through the **existing** extrachill-api analytics surface instead of a feature plugin owning its own REST route (which was the layering violation in the first cut of #59).

- **`/analytics/click` gains a `bridge` click_type** — records a `bridge_click` event via the `extrachill/track-analytics-event` ability, exactly mirroring the existing `share` click_type. The file already declared this was the growth path: *"Future click types ... will route through abilities."* Carries `dest_site` + `source_post`.
- **New thin `/analytics/impression` route** — records `bridge_impression` the same way, fired once per pageview when the bridge renders with cards. Autoloaded by the recursive `inc/routes/` iterator; no registration wiring needed.

## Convention alignment

Both handlers are **thin wrappers** over `wp_get_ability('extrachill/track-analytics-event')->execute()` — no write logic lives in the route, per the network rule *"extrachill-api is a REST wrapper ONLY; abilities own logic/writes."* `impression.php` follows the established route-file house style (sibling `view-count.php` / `click.php`: no `@package` tag, no register-fn doc comment).

## Bot filter

Both events are fired client-side via `sendBeacon` (see extrachill-multisite#59's JS), so they count **humans-with-JS only** — prefetch/prerender/crawler hits that never run JS fire neither. That makes `CTR = clicks / impressions` (computed by extrachill-analytics#31) bot-filtered by construction, unlike the raw GA4 `network_bridge` channel's sub-1.0 pv/session noise.

## Verify

- `php -l` clean on both files.
- phpcs (WordPress): `click.php` introduces **zero** new findings (the 3 reported are pre-existing baseline — `@package`, register-fn doc, and a short-ternary on an untouched line); `impression.php` matches the directory's established baseline exactly.