### PR TITLE
feat: preserve term + source_site in canonical bridge analytics routes (deploy FIRST)

### DIFF
--- a/inc/routes/analytics/click.php
+++ b/inc/routes/analytics/click.php
@@ -10,7 +10,10 @@
  *             prefetch/prerender can fake a UTM arrival but not a real click in a
  *             JS-executing browser. Pairs with the bridge_impression event
  *             (see /analytics/impression) so CTR = clicks / impressions is
- *             computable and bot-filtered. See extrachill-multisite#58.
+ *             computable and bot-filtered. Records `term` (the clicked link text —
+ *             which bridge link converted) and `source_site` in event_data — the
+ *             most analytically valuable bridge dimensions. See
+ *             extrachill-multisite#58 and #62.
  *
  * Future click types (internal_link, taxonomy_badge, cta, etc.) will route through abilities.
  */
@@ -77,6 +80,18 @@ function extrachill_api_register_click_route() {
 					'default'           => 0,
 					'sanitize_callback' => 'absint',
 				),
+				'source_site'       => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_key',
+				),
+				'term'              => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
 			),
 		)
 	);
@@ -141,6 +156,8 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 	$link_page_id      = $request->get_param( 'link_page_id' );
 	$dest_site         = $request->get_param( 'dest_site' );
 	$source_post       = (int) $request->get_param( 'source_post' );
+	$source_site       = $request->get_param( 'source_site' );
+	$term              = $request->get_param( 'term' );
 
 	$normalized_destination = extrachill_api_normalize_tracked_url( $destination_url );
 
@@ -230,6 +247,8 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 					'event_data' => array(
 						'dest_site'   => $dest_site,
 						'source_post' => $source_post,
+						'source_site' => $source_site,
+						'term'        => $term,
 					),
 					'source_url' => $source_url,
 				)

--- a/inc/routes/analytics/impression.php
+++ b/inc/routes/analytics/impression.php
@@ -11,7 +11,9 @@
  * bridge_click event. See extrachill-multisite#58.
  *
  * Thin wrapper: records via the extrachill/track-analytics-event ability —
- * all write logic lives in the ability, not here.
+ * all write logic lives in the ability, not here. Records `source_site` (and
+ * `term` when present) in event_data so the impression denominator carries the
+ * same dimensions as the bridge_click numerator. See extrachill-multisite#62.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -49,6 +51,18 @@ function extrachill_api_register_impression_route() {
 					'default'           => 0,
 					'sanitize_callback' => 'absint',
 				),
+				'source_site'     => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_key',
+				),
+				'term'            => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
 			),
 		)
 	);
@@ -64,6 +78,8 @@ function extrachill_api_impression_handler( WP_REST_Request $request ) {
 	$impression_type = $request->get_param( 'impression_type' );
 	$source_url      = $request->get_param( 'source_url' );
 	$source_post     = (int) $request->get_param( 'source_post' );
+	$source_site     = $request->get_param( 'source_site' );
+	$term            = $request->get_param( 'term' );
 
 	if ( 'bridge' !== $impression_type ) {
 		return new WP_Error(
@@ -87,6 +103,8 @@ function extrachill_api_impression_handler( WP_REST_Request $request ) {
 			'event_type' => 'bridge_impression',
 			'event_data' => array(
 				'source_post' => $source_post,
+				'source_site' => $source_site,
+				'term'        => $term,
 			),
 			'source_url' => $source_url,
 		)


### PR DESCRIPTION
## Summary

Extends the canonical extrachill-api analytics bridge wrappers (`/analytics/click` with `click_type=bridge`, `/analytics/impression` with `impression_type=bridge`) so they record the full bridge dimensions — **`term`** (the clicked link text — *which* bridge link converted) and **`source_site`** — in `event_data`.

This is the **deploy-first** half of the two-plugin move in Extra-Chill/extrachill-multisite#62. The live bridge beacon receiver currently lives in extrachill-multisite (`/analytics/bridge-event`), a layer violation since extrachill-api is the canonical REST home for ability wrappers. These api routes already existed and were correctly shaped — but received zero bridge traffic and did **not** capture `term`/`source_site`. This PR makes them behavior-equivalent so the multisite PR can repoint the JS at them and delete the duplicate.

## Shape chosen: (A) — extend the two existing split routes

The issue offered two shapes:
- **(A)** Keep api's two-endpoint split (`/analytics/click` + `/analytics/impression`), extend both with `term`/`source_site`, JS posts per-kind.
- **(B)** Consolidate to a single api `/analytics/bridge-event` (`kind=click|impression`).

**Picked (A).** `/analytics/click` is genuinely shared by other live consumers — `share` (artist-platform share modal, `extrch-share-modal.js`) and `link_page_link` (link page public tracking, `link-page-public-tracking.js`). It can't be removed. Consolidating to (B) would either leave the split routes in place (two routes doing overlapping work — the exact redundancy #62 warns against) or break `share`/`link_page_link`. (A) extends the already-canonical, already-shared routes and adds zero new routes.

## Changes

- `inc/routes/analytics/click.php`: add optional `source_site` + `term` args; include both in the `bridge` case `event_data`. `share` and `link_page_link` cases untouched (new args are optional, default `''`).
- `inc/routes/analytics/impression.php`: add optional `source_site` + `term` args; include both in the `bridge_impression` `event_data`.

Both routes remain thin `wp_get_ability('extrachill/track-analytics-event')->execute()` wrappers — **no write logic added**.

## Verification

- `php -l` clean on both files.
- `phpcs --standard=WordPress`: the only findings are pre-existing baseline errors (missing `@package`/function docblocks, and the untouched `share`-case short ternary) — none on the added lines.
- Contract traced: the multisite JS payload keys (`click_type`/`impression_type`, `source_url`, `source_post`, `source_site`, `dest_site`, `term`) match these route `args` exactly; the route passes `term`/`source_site` into the ability `event_data`.

## ⚠️ Deploy ordering (critical)

**Deploy this (extrachill-api) BEFORE extrachill-multisite.** The multisite PR repoints the bridge JS at these extended routes and deletes the old `/analytics/bridge-event` receiver. If multisite ships first, the JS would post to routes that don't carry the bridge fields yet (field regression) — and the old route would already be gone.

## Related

- Issue: Extra-Chill/extrachill-multisite#62
- Paired PR (deploy SECOND): _multisite PR linked below_
- Background: Extra-Chill/extrachill-multisite#58 (original bridge instrumentation)

Do not merge — leaving for human review.