### PR TITLE
feat: thread visitor_id through view ingest + add retention read route

### DIFF
--- a/inc/routes/analytics/retention.php
+++ b/inc/routes/analytics/retention.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * REST route: GET /wp-json/extrachill/v1/analytics/retention
+ *
+ * Read route wrapping the extrachill/get-retention-stats ability from
+ * extrachill-analytics. Returns deterministic, bot-filtered visitor-retention
+ * metrics (return rate, weekly cohort retention, cross-site return, session
+ * depth) computed from first-party pageview events.
+ *
+ * Thin wrapper only — all computation lives in the ability.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_analytics_retention_route' );
+
+/**
+ * Register the analytics retention read route.
+ */
+function extrachill_api_register_analytics_retention_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/analytics/retention',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_analytics_retention_handler',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_network_options' );
+			},
+			'args'                => array(
+				'days'         => array(
+					'required' => false,
+					'type'     => 'integer',
+					'default'  => 28,
+				),
+				'blog_id'      => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'default'           => 0,
+					'sanitize_callback' => 'absint',
+				),
+				'cohort_weeks' => array(
+					'required' => false,
+					'type'     => 'integer',
+					'default'  => 8,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Handle the retention stats request.
+ *
+ * Wraps the extrachill/get-retention-stats ability from extrachill-analytics.
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response|WP_Error
+ */
+function extrachill_api_analytics_retention_handler( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/get-retention-stats' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-analytics plugin is required.', array( 'status' => 500 ) );
+	}
+
+	$result = $ability->execute(
+		array(
+			'days'         => (int) $request->get_param( 'days' ),
+			'blog_id'      => (int) $request->get_param( 'blog_id' ),
+			'cohort_weeks' => (int) $request->get_param( 'cohort_weeks' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}

--- a/inc/routes/analytics/view-count.php
+++ b/inc/routes/analytics/view-count.php
@@ -21,7 +21,7 @@ function extrachill_api_register_view_count_route() {
 			'callback'            => 'extrachill_api_view_count_handler',
 			'permission_callback' => '__return_true',
 			'args'                => array(
-				'post_id' => array(
+				'post_id'    => array(
 					'required'          => true,
 					'type'              => 'integer',
 					'validate_callback' => function ( $param ) {
@@ -29,29 +29,51 @@ function extrachill_api_register_view_count_route() {
 					},
 					'sanitize_callback' => 'absint',
 				),
+				'visitor_id' => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => '',
+					// Anonymous first-party UUID v4 echoed by the beacon. Accept only a
+					// well-formed UUID v4; anything else (including empty / opted-out)
+					// is coerced to '' so the ability records the pageview anonymously.
+					'validate_callback' => function ( $param ) {
+						return '' === $param || 1 === preg_match(
+							'/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+							(string) $param
+						);
+					},
+					'sanitize_callback' => 'sanitize_text_field',
+				),
 			),
 		)
 	);
 }
 
 function extrachill_api_view_count_handler( $request ) {
-	$post_id = $request->get_param( 'post_id' );
+	$post_id    = (int) $request->get_param( 'post_id' );
+	$visitor_id = (string) $request->get_param( 'visitor_id' );
 
-	if ( ! function_exists( 'ec_track_post_views' ) ) {
+	// Thin wrapper: all write logic (post-meta bump, pageview event row carrying
+	// visitor_id, link-page daily-table action) lives in the analytics ability.
+	$ability = wp_get_ability( 'extrachill/track-page-view' );
+	if ( ! $ability ) {
 		return new WP_Error(
-			'function_missing',
-			'View tracking function not available.',
+			'ability_not_found',
+			'extrachill-analytics plugin is required.',
 			array( 'status' => 500 )
 		);
 	}
 
-	// Track all-time views (theme system)
-	ec_track_post_views( $post_id );
+	$result = $ability->execute(
+		array(
+			'post_id'    => $post_id,
+			'visitor_id' => $visitor_id,
+		)
+	);
 
-	// For link pages, also fire action for 90-day daily table tracking
-	if ( get_post_type( $post_id ) === 'artist_link_page' ) {
-		do_action( 'extrachill_link_page_view_recorded', $post_id );
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	return rest_ensure_response( array( 'recorded' => true ) );
+	return rest_ensure_response( $result );
 }


### PR DESCRIPTION
Refs Extra-Chill/extrachill-analytics#35
Pairs with Extra-Chill/extrachill-analytics#36

## Summary

Wires the first-party visitor-retention feature through the REST surface. Thin wrappers only — all logic stays in the abilities (extrachill-api is REST-only).

- **`POST /analytics/view`** (`inc/routes/analytics/view-count.php`): now accepts an optional `visitor_id`, validated as a UUID v4 (empty allowed → recorded anonymously). The handler routes the entire write through the `extrachill/track-page-view` ability — which bumps `ec_post_views` (back-compat) **and** writes a `pageview` event row carrying `visitor_id` — replacing the previous direct `ec_track_post_views()` call, per canonical-home (logic lives in the ability).
- **`GET /analytics/retention`** (`inc/routes/analytics/retention.php`, new): wraps `extrachill/get-retention-stats`. Returns return rate, weekly cohort retention, cross-site return, and session depth. Permission: `manage_network_options`.

## Privacy stance (as enforced here)

- `visitor_id` is validated against a strict UUID v4 regex in the route's `validate_callback`; non-UUID values are rejected. The value carries **no PII** — it's the random first-party id minted server-side by extrachill-analytics.
- The route never mints or reads cookies; it only passes through what the beacon echoes. When the visitor opted out (GPC/DNT), the beacon sends no `visitor_id` and the pageview is recorded anonymously.

## Data flow

Beacon `POST {post_id, visitor_id}` → `view-count.php` validates UUID → `extrachill/track-page-view` ability → post-meta bump + (non-bot) `pageview` event INSERT with `visitor_id` → row in `c8c_extrachill_analytics_events`. The retention read route runs the inverse aggregation via `extrachill/get-retention-stats`.

## Deploy ordering

The extrachill-analytics ability changes (#36) **must deploy before or with** this plugin — both routes wrap abilities (`extrachill/track-page-view`, `extrachill/get-retention-stats`) that #36 introduces/extends. The route guards on `wp_get_ability()` and returns a 500 `ability_not_found` if analytics is older, so an out-of-order deploy degrades safely rather than fataling.

## Owner checklist

- [ ] **Privacy-policy disclosure line** must be published (page ID 3) before this is considered done — see the suggested sentence in extrachill-analytics#36. Do not edit the live policy via the bot.

## Notes / verification

- `php -l` clean on both changed files.
- `phpcs --standard=WordPress` introduces zero new non-baseline findings (the remaining `@package`/function-docblock findings on `view-count.php` pre-exist on `main`).