### PR TITLE
feat: forward referrer + utm params to registration source attribution

### DIFF
--- a/inc/routes/auth/register.php
+++ b/inc/routes/auth/register.php
@@ -99,6 +99,15 @@ function extrachill_api_register_auth_register_route() {
 					'type'     => 'boolean',
 					'default'  => false,
 				),
+				'referrer'             => array(
+					'required'          => false,
+					'type'              => 'string',
+					'sanitize_callback' => 'esc_url_raw',
+				),
+				'utm'                  => array(
+					'required' => false,
+					'type'     => 'object',
+				),
 			),
 		)
 	);
@@ -152,6 +161,10 @@ function extrachill_api_auth_register_handler( WP_REST_Request $request ) {
 		'registration_source'  => (string) $request->get_param( 'registration_source' ),
 		'registration_method'  => (string) $request->get_param( 'registration_method' ),
 		'success_redirect_url' => (string) $request->get_param( 'success_redirect_url' ),
+		// Source attribution (last-touch). Sanitization of utm happens in the
+		// extrachill-users service via extrachill_users_sanitize_utm().
+		'referrer'             => (string) $request->get_param( 'referrer' ),
+		'utm'                  => (array) $request->get_param( 'utm' ),
 	);
 
 	$result = extrachill_users_register_with_tokens( $payload );


### PR DESCRIPTION
Companion to **Extra-Chill/extrachill-users#146** (closes Extra-Chill/extrachill-users#145).

The `/wp-json/extrachill/v1/auth/register` REST route whitelists params and assembles an explicit payload, so new `referrer` / `utm` fields would be dropped without this change. This wires the last-touch source-attribution params through to the extrachill-users registration service.

## What changed
**`inc/routes/auth/register.php`**
- Adds `referrer` (string, `esc_url_raw` sanitized) and `utm` (object) to the route `args` schema.
- Forwards both into the `$payload` passed to `extrachill_users_register_with_tokens()`.
- UTM value sanitization happens downstream in `extrachill_users_sanitize_utm()` (extrachill-users), keeping this route a thin pass-through.

## Verification
- `php -l` clean.
- `homeboy lint extrachill-api --file inc/routes/auth/register.php`: **PHPCS + PHPStan both pass, zero findings.**

## Merge order
Either order is safe (fields are optional everywhere), but merging extrachill-users#146 first means the service is ready to consume these params the moment this lands.