### PR TITLE
feat(analytics): route outbound clicks through /analytics/click

### DIFF
--- a/inc/routes/analytics/click.php
+++ b/inc/routes/analytics/click.php
@@ -14,6 +14,16 @@
  *             which bridge link converted) and `source_site` in event_data — the
  *             most analytically valuable bridge dimensions. See
  *             extrachill-multisite#58 and #62.
+ * - 'outbound': Tracks an OUTBOUND (off-network) click — a reader exiting to an
+ *             external domain (Spotify, a ticket link, an artist site, merch,
+ *             social). Fired client-side (sendBeacon) so it counts human intent
+ *             only and is bot-filtered by construction, exactly like 'bridge'.
+ *             Records `dest_host` + the normalized `destination_url` plus the
+ *             server-classified destination `category` in event_data, and
+ *             carries the anonymous first-party `visitor_id` (NULL under
+ *             GPC/DNT). This is the cross-DOMAIN counterpart to the cross-SITE
+ *             conversion map — the missing half of "where do readers go." See
+ *             extrachill-analytics#66.
  *
  * Future click types (internal_link, taxonomy_badge, cta, etc.) will route through abilities.
  */
@@ -38,7 +48,7 @@ function extrachill_api_register_click_route() {
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_key',
 					'validate_callback' => function ( $param ) {
-						$allowed = array( 'share', 'link_page_link', 'bridge' );
+						$allowed = array( 'share', 'link_page_link', 'bridge', 'outbound' );
 						return in_array( $param, $allowed, true );
 					},
 				),
@@ -90,6 +100,28 @@ function extrachill_api_register_click_route() {
 					'required'          => false,
 					'type'              => 'string',
 					'default'           => '',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'dest_host'         => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'visitor_id'        => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => '',
+					// Anonymous first-party UUID v4 echoed by the outbound beacon.
+					// Accept only a well-formed UUID v4; anything else (including
+					// empty / opted-out) is coerced to '' so the click records
+					// anonymously.
+					'validate_callback' => function ( $param ) {
+						return '' === $param || 1 === preg_match(
+							'/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+							(string) $param
+						);
+					},
 					'sanitize_callback' => 'sanitize_text_field',
 				),
 			),
@@ -158,6 +190,8 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 	$source_post       = (int) $request->get_param( 'source_post' );
 	$source_site       = $request->get_param( 'source_site' );
 	$term              = $request->get_param( 'term' );
+	$dest_host         = $request->get_param( 'dest_host' );
+	$visitor_id        = (string) $request->get_param( 'visitor_id' );
 
 	$normalized_destination = extrachill_api_normalize_tracked_url( $destination_url );
 
@@ -262,6 +296,64 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 				return new WP_Error(
 					'tracking_failed',
 					'Failed to record bridge click event.',
+					array( 'status' => 500 )
+				);
+			}
+			break;
+
+		case 'outbound':
+			if ( empty( $dest_host ) && empty( $normalized_destination ) ) {
+				return new WP_Error(
+					'missing_destination',
+					'dest_host or destination_url is required for outbound click type.',
+					array( 'status' => 400 )
+				);
+			}
+
+			// Derive the host from the destination URL when the client didn't
+			// send one explicitly (defensive — the JS always sends dest_host).
+			if ( empty( $dest_host ) ) {
+				$parsed_host = wp_parse_url( $normalized_destination, PHP_URL_HOST );
+				$dest_host   = is_string( $parsed_host ) ? $parsed_host : '';
+			}
+
+			$ability = wp_get_ability( 'extrachill/track-analytics-event' );
+			if ( ! $ability ) {
+				return new WP_Error(
+					'ability_missing',
+					'Analytics tracking ability not available.',
+					array( 'status' => 500 )
+				);
+			}
+
+			// Classify the destination once at write time so each stored row
+			// carries its category; the read ability honours the stamp and only
+			// re-classifies older/unstamped rows.
+			$category = function_exists( 'extrachill_analytics_classify_outbound_host' )
+				? extrachill_analytics_classify_outbound_host( $dest_host )
+				: 'other';
+
+			$event_id = $ability->execute(
+				array(
+					'event_type' => 'outbound_click',
+					'event_data' => array(
+						'dest_host' => $dest_host,
+						'dest_url'  => $normalized_destination,
+						'category'  => $category,
+					),
+					'source_url' => $source_url,
+					'visitor_id' => $visitor_id,
+				)
+			);
+
+			if ( is_wp_error( $event_id ) ) {
+				return $event_id;
+			}
+
+			if ( empty( $event_id ) ) {
+				return new WP_Error(
+					'tracking_failed',
+					'Failed to record outbound click event.',
 					array( 'status' => 500 )
 				);
 			}


### PR DESCRIPTION
## Summary

Adds an **`outbound`** `click_type` to the existing unified `/wp-json/extrachill/v1/analytics/click` endpoint — the capture path for off-network exit clicks. Companion to **Extra-Chill/extrachill-analytics#67** (the JS handler + read ability + classifier that close extrachill-analytics#66).

## What it does

- New `outbound` branch in `extrachill_api_click_handler()`, mirroring the `bridge` branch exactly: a **thin route** that delegates all write logic to the `extrachill/track-analytics-event` ability. **No new endpoint, no new store.**
- Records `dest_host` + the normalized `destination_url` and the **server-classified destination `category`** in `event_data`, and carries the anonymous first-party `visitor_id` (validated as UUID v4; coerced to `''` / NULL under GPC/DNT).
- The destination category is stamped **once at write time** via `extrachill_analytics_classify_outbound_host()` (from extrachill-analytics) so the read ability rolls up by category without re-classifying every row. Falls back to `other` if the classifier isn't loaded.
- Adds the `dest_host` and `visitor_id` route args with the same UUID-v4 validation the `/analytics/view` route uses.

## Why this route (not a new one)

The endpoint already routes `share` and `bridge` clicks through the analytics ability — outbound is the same shape of thing. Per RULES.md ("prove the thing doesn't already exist before building new infra"), extending the existing route is correct over inventing a parallel `/analytics/outbound` endpoint.

## Verification

- `php -l` clean.
- `phpcs --standard=WordPress` — the new `outbound` case adds **0 findings**; the 3 reported errors (file `@package` tag, function doc comment, a short-ternary in the pre-existing `share` case) are baseline, untouched by this diff.

Refs extrachill-analytics#66