### PR TITLE
fix(analytics): accept and store dest_site on bridge impressions

### DIFF
--- a/inc/routes/analytics/impression.php
+++ b/inc/routes/analytics/impression.php
@@ -11,9 +11,11 @@
  * bridge_click event. See extrachill-multisite#58.
  *
  * Thin wrapper: records via the extrachill/track-analytics-event ability —
- * all write logic lives in the ability, not here. Records `source_site` (and
- * `term` when present) in event_data so the impression denominator carries the
- * same dimensions as the bridge_click numerator. See extrachill-multisite#62.
+ * all write logic lives in the ability, not here. Records `dest_site`,
+ * `source_site` (and `term` when present) in event_data so the impression
+ * denominator carries the same per-destination dimensions as the bridge_click
+ * numerator — making CTR = clicks / impressions computable per destination.
+ * See extrachill-multisite#62 and extrachill-analytics#75.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -57,6 +59,12 @@ function extrachill_api_register_impression_route() {
 					'default'           => '',
 					'sanitize_callback' => 'sanitize_key',
 				),
+				'dest_site'       => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_key',
+				),
 				'term'            => array(
 					'required'          => false,
 					'type'              => 'string',
@@ -79,6 +87,7 @@ function extrachill_api_impression_handler( WP_REST_Request $request ) {
 	$source_url      = $request->get_param( 'source_url' );
 	$source_post     = (int) $request->get_param( 'source_post' );
 	$source_site     = $request->get_param( 'source_site' );
+	$dest_site       = $request->get_param( 'dest_site' );
 	$term            = $request->get_param( 'term' );
 
 	if ( 'bridge' !== $impression_type ) {
@@ -102,6 +111,7 @@ function extrachill_api_impression_handler( WP_REST_Request $request ) {
 		array(
 			'event_type' => 'bridge_impression',
 			'event_data' => array(
+				'dest_site'   => $dest_site,
 				'source_post' => $source_post,
 				'source_site' => $source_site,
 				'term'        => $term,


### PR DESCRIPTION
## Summary

Fixes the receiver half of the bridge-CTR granularity mismatch tracked in **Extra-Chill/extrachill-analytics#75**.

The bridge impression route (`POST /wp-json/extrachill/v1/analytics/impression`) stored only `source_post / source_site / term` — no `dest_site` — so every `bridge_impression` row was dest-less, while `bridge_click` rows (via the sibling `click.php`) carry `dest_site`. That made per-destination CTR structurally uncomputable.

## Change

- Register a `dest_site` arg on the impression route, mirroring exactly how `click.php` registers it for `click_type=bridge` (`required: false`, `type: string`, `default: ''`, `sanitize_callback: sanitize_key`).
- Read it in the handler (`$dest_site = $request->get_param( 'dest_site' )`).
- Include it in the `event_data` passed to the `extrachill/track-analytics-event` ability, in the same `dest_site / source_post / source_site / term` shape the bridge_click event uses — so the impression denominator now carries the same per-destination dimensions as the click numerator.

This is a thin-wrapper change only: all write logic still lives in the `track-analytics-event` ability. The new param is paired with the per-card `dest_site` now emitted by the multisite instrumentation (sibling PR) and consumed by the per-destination CTR read (sibling analytics PR).

## Layer purity

REST receive/store stays in extrachill-api. No logic moved across layers.

## Verification

- `php -l` clean.
- `phpcs --standard=WordPress` on the changed file: the only 2 findings (`@package` tag on the file header, missing doc comment on `extrachill_api_register_impression_route()`) are **pre-existing baseline** at lines 19/27, outside every changed hunk (my hunks are at ~11, 59, 87, 111). Zero new findings on changed lines.

Refs Extra-Chill/extrachill-analytics#75