### PR TITLE
feat: team-readable REST routes for analytics reports

### DIFF
--- a/inc/routes/analytics/conversion-map.php
+++ b/inc/routes/analytics/conversion-map.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * REST route: GET /wp-json/extrachill/v1/analytics/conversion-map
+ *
+ * Read route wrapping the extrachill/get-conversion-map ability from
+ * extrachill-analytics. Returns the first-party, bot-filtered cross-surface
+ * conversion map: for visitors whose first session starts on an editorial
+ * article (blog 1), the share that reach a platform surface (events/community/
+ * artist) same-session or on a return visit, ranked per entry article and per
+ * entry category.
+ *
+ * Thin wrapper only — all computation lives in the ability.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_analytics_conversion_map_route' );
+
+/**
+ * Register the analytics conversion-map read route.
+ */
+function extrachill_api_register_analytics_conversion_map_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/analytics/conversion-map',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_analytics_conversion_map_handler',
+			'permission_callback' => 'extrachill_api_analytics_reports_permission_check',
+			'args'                => array(
+				'days'               => array(
+					'required' => false,
+					'type'     => 'integer',
+					'default'  => 28,
+				),
+				'session_gap_mins'   => array(
+					'required' => false,
+					'type'     => 'integer',
+					'default'  => 30,
+				),
+				'top_articles'       => array(
+					'required' => false,
+					'type'     => 'integer',
+					'default'  => 25,
+				),
+				'min_entry_sessions' => array(
+					'required' => false,
+					'type'     => 'integer',
+					'default'  => 1,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Handle the conversion-map request.
+ *
+ * Wraps the extrachill/get-conversion-map ability from extrachill-analytics.
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response|WP_Error
+ */
+function extrachill_api_analytics_conversion_map_handler( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/get-conversion-map' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-analytics plugin is required.', array( 'status' => 500 ) );
+	}
+
+	$result = $ability->execute(
+		array(
+			'days'               => (int) $request->get_param( 'days' ),
+			'session_gap_mins'   => (int) $request->get_param( 'session_gap_mins' ),
+			'top_articles'       => (int) $request->get_param( 'top_articles' ),
+			'min_entry_sessions' => (int) $request->get_param( 'min_entry_sessions' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}

--- a/inc/routes/analytics/meta.php
+++ b/inc/routes/analytics/meta.php
@@ -23,9 +23,7 @@ function extrachill_api_register_analytics_meta_routes() {
 		array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => 'extrachill_api_analytics_meta_handler',
-			'permission_callback' => function () {
-				return current_user_can( 'manage_network_options' );
-			},
+			'permission_callback' => 'extrachill_api_analytics_reports_permission_check',
 		)
 	);
 }

--- a/inc/routes/analytics/reports-permission.php
+++ b/inc/routes/analytics/reports-permission.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Shared permission check for team-readable analytics report routes.
+ *
+ * The reporting abilities in extrachill-analytics (summary, retention,
+ * surface-growth, meta, conversion-map) were relaxed to the team-readable tier
+ * (the `access_studio` cap, granted by the extra_chill_team role) so the Studio
+ * "Network" tab can render for the whole team. The REST wrapper is a SECOND,
+ * independent gate — if it stayed admin-only, team members would be blocked
+ * before the ability ran. This helper mirrors the ability-layer policy so both
+ * gates line up.
+ *
+ * TIERED POLICY (settled, see analytics issue #92):
+ *   - Team-readable: traffic, growth, retention, top content, conversion.
+ *   - Admin-only (unchanged): revenue, attacks/scanner, PHP errors, purges —
+ *     those routes keep manage_network_options and must NOT use this helper.
+ *
+ * Uses the `access_studio` cap directly (the cap behind ec_is_team_member())
+ * to avoid a cross-plugin function dependency.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Whether the current actor may read team-readable analytics reports over REST.
+ *
+ * True for network/site admins and for extra_chill_team members
+ * (the access_studio cap).
+ *
+ * @return bool
+ */
+function extrachill_api_analytics_reports_permission_check() {
+	return current_user_can( 'manage_network_options' )
+		|| current_user_can( 'manage_options' )
+		|| current_user_can( 'access_studio' );
+}

--- a/inc/routes/analytics/retention.php
+++ b/inc/routes/analytics/retention.php
@@ -28,9 +28,7 @@ function extrachill_api_register_analytics_retention_route() {
 		array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => 'extrachill_api_analytics_retention_handler',
-			'permission_callback' => function () {
-				return current_user_can( 'manage_network_options' );
-			},
+			'permission_callback' => 'extrachill_api_analytics_reports_permission_check',
 			'args'                => array(
 				'days'         => array(
 					'required' => false,

--- a/inc/routes/analytics/summary.php
+++ b/inc/routes/analytics/summary.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * REST route: GET /wp-json/extrachill/v1/analytics/summary
+ *
+ * Read route wrapping the extrachill/get-analytics-summary ability from
+ * extrachill-analytics. Returns event counts grouped by type over an optional
+ * rolling window, with optional event_type / blog_id filtering.
+ *
+ * This is the canonical home for the summary the Studio Network tab and the
+ * analytics dashboard client call by name (closes #24 — the ability was not
+ * reachable over REST). Thin wrapper only — all computation lives in the
+ * ability.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_analytics_summary_route' );
+
+/**
+ * Register the analytics summary read route.
+ */
+function extrachill_api_register_analytics_summary_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/analytics/summary',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_analytics_summary_handler',
+			'permission_callback' => 'extrachill_api_analytics_reports_permission_check',
+			'args'                => array(
+				'days'       => array(
+					'required' => false,
+					'type'     => 'integer',
+					'default'  => 28,
+				),
+				'event_type' => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_key',
+				),
+				'blog_id'    => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'default'           => 0,
+					'sanitize_callback' => 'absint',
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Handle the analytics summary request.
+ *
+ * Wraps the extrachill/get-analytics-summary ability from extrachill-analytics.
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response|WP_Error
+ */
+function extrachill_api_analytics_summary_handler( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/get-analytics-summary' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-analytics plugin is required.', array( 'status' => 500 ) );
+	}
+
+	$result = $ability->execute(
+		array(
+			'days'       => (int) $request->get_param( 'days' ),
+			'event_type' => $request->get_param( 'event_type' ),
+			'blog_id'    => (int) $request->get_param( 'blog_id' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}

--- a/inc/routes/analytics/surface-growth.php
+++ b/inc/routes/analytics/surface-growth.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * REST route: GET /wp-json/extrachill/v1/analytics/surface-growth
+ *
+ * Read route wrapping the extrachill/get-surface-growth ability from
+ * extrachill-analytics. Returns a normalized, cross-surface growth-rate read
+ * (supply: inventory growth per week; demand: organic-sessions slope) for each
+ * live Extra Chill surface, plus a ranked fastest-growing surface.
+ *
+ * Thin wrapper only — all computation lives in the ability.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_analytics_surface_growth_route' );
+
+/**
+ * Register the analytics surface-growth read route.
+ */
+function extrachill_api_register_analytics_surface_growth_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/analytics/surface-growth',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_analytics_surface_growth_handler',
+			'permission_callback' => 'extrachill_api_analytics_reports_permission_check',
+			'args'                => array(
+				'weeks' => array(
+					'required' => false,
+					'type'     => 'integer',
+					'default'  => 4,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Handle the surface-growth request.
+ *
+ * Wraps the extrachill/get-surface-growth ability from extrachill-analytics.
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response|WP_Error
+ */
+function extrachill_api_analytics_surface_growth_handler( WP_REST_Request $request ) {
+	$ability = wp_get_ability( 'extrachill/get-surface-growth' );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-analytics plugin is required.', array( 'status' => 500 ) );
+	}
+
+	$result = $ability->execute(
+		array(
+			'weeks' => (int) $request->get_param( 'weeks' ),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}


### PR DESCRIPTION
## Summary

The **REST-layer** half of extrachill-analytics #92 (the routes live here, not in extrachill-analytics). Adds thin **Shape A** wrappers and relaxes the existing analytics report routes to the team-readable tier so the Studio "Network" tab can call them.

New routes on `extrachill/v1`, registered on `extrachill_api_register_routes`:

| Route | Ability | Notes |
|-------|---------|-------|
| `GET /analytics/summary` | `extrachill/get-analytics-summary` | **Closes #24** — ability was unreachable over REST |
| `GET /analytics/surface-growth` | `extrachill/get-surface-growth` | new |
| `GET /analytics/conversion-map` | `extrachill/get-conversion-map` | new |

Relaxed existing routes (gate only):

- `GET /analytics/retention` — was `manage_network_options`
- `GET /analytics/meta` — was `manage_network_options`

## Permission policy

New shared `extrachill_api_analytics_reports_permission_check()` (`inc/routes/analytics/reports-permission.php`) mirrors the relaxed ability-layer policy: admins (`manage_network_options` / `manage_options`) **plus** `extra_chill_team` members (the `access_studio` cap). This is a **second, independent gate** — if the REST wrapper stayed admin-only, team members would be 403'd before the ability ran.

## Tiered policy (settled)

- **Team-readable** (relaxed here): traffic, growth, retention, top content, conversion.
- **Admin-only** (intentionally untouched): revenue, attacks/scanner, PHP errors, purges.

## Paired PR

The ability-layer half (each ability's own `permission_callback`): Extra-Chill/extrachill-analytics#95. Both must merge for team read to work end-to-end.

## Notes

- Route files are auto-loaded via the recursive `inc/routes/` iterator at plugin load; the permission helper function is defined at require time and used when routes register on `rest_api_init`, so ordering is safe.
- `php -l` clean on all files. phpcs vendor not installed in this checkout (pre-existing, #75); no new lint introduced in changed files.

Refs #92, closes #24