### PR TITLE
feat: canonical community stats route (extrachill/v1)

### DIFF
--- a/inc/routes/community/stats.php
+++ b/inc/routes/community/stats.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Community Stats Endpoint
+ *
+ * Thin REST wrapper around the extrachill/community-get-stats ability.
+ * Route affinity middleware ensures this runs on the community site, where
+ * extrachill-community (a per-site plugin) registers the ability.
+ *
+ * This is the canonical platform door for the cross-site NetworkStats
+ * loopback (blog 1 → community blog): the loopback hits
+ * /extrachill/v1/community/stats rather than the generic core Abilities
+ * /run endpoint. Mirrors the sibling /community/taxonomy-counts route.
+ *
+ * @endpoint GET /extrachill/v1/community/stats
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_community_stats_route' );
+
+/**
+ * Register the community stats endpoint.
+ */
+function extrachill_api_register_community_stats_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/community/stats',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'extrachill_api_community_stats_handler',
+			'permission_callback' => '__return_true',
+		)
+	);
+}
+
+/**
+ * Handle community stats request.
+ *
+ * Thin wrapper: extracts no inputs (the ability takes none) and delegates
+ * to the extrachill/community-get-stats ability. All logic lives in the
+ * ability. Route affinity middleware ensures this runs on the community
+ * site where the ability is registered.
+ *
+ * @return WP_REST_Response|WP_Error Stats payload or error.
+ */
+function extrachill_api_community_stats_handler() {
+	$ability = wp_get_ability( 'extrachill/community-get-stats' );
+
+	if ( ! $ability ) {
+		return new WP_Error(
+			'ability_unavailable',
+			'The extrachill/community-get-stats ability is not available.',
+			array( 'status' => 503 )
+		);
+	}
+
+	$result = $ability->execute( array() );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response( $result );
+}


### PR DESCRIPTION
## Summary

Adds a new thin REST route **`GET /extrachill/v1/community/stats`** that delegates to the `extrachill/community-get-stats` ability. This is the canonical platform door for the cross-site community-stats read.

## Why this is a layering correction of community#142

community#140 was the original symptom: the NetworkStats community providers (`community_members`, `community_topics`) returned null off the community blog because `extrachill/community-get-stats` is a per-site ability not loaded in other sites' processes. The expedient fix, **community#142** (merged + deployed), made it reachable cross-site by setting `show_in_rest => true` and pointing the loopback at the **generic core WP Abilities run endpoint** (`/wp-abilities/v1/abilities/extrachill/community-get-stats/run`).

That works mechanically but is the **wrong door** architecturally. This platform has a dedicated unified REST namespace (`extrachill/v1`, owned by extrachill-api) that is the canonical surface for cross-site/platform reads. Cross-site loopbacks are built around `extrachill/v1` thin routes + route-affinity middleware — not the generic core abilities endpoint (separate auth model, bypasses the platform namespace).

## What this PR changes

- New file `inc/routes/community/stats.php`, self-registering on `extrachill_api_register_routes` (auto-loaded by the recursive `inc/routes/` loader — no manual wiring needed).
- **Mirrors the sibling `inc/routes/community/taxonomy-counts.php` exactly**: `register_rest_route('extrachill/v1', ...)`, `methods => WP_REST_Server::READABLE`, `permission_callback => '__return_true'` (public aggregate counts rendered on `/power` — readable, matching taxonomy-counts), `@endpoint` docblock.
- Handler is a pure thin wrapper: `wp_get_ability('extrachill/community-get-stats')->execute(array())`, returns the result with the same WP_Error / `rest_ensure_response` shape. All logic stays in the ability.
- Route-affinity already maps `/extrachill/v1/community/` → community blog, so this resolves on the right site.

## Why it lives here

extrachill-api owns the `extrachill/v1` namespace — the canonical home for platform REST routes.

## Cross-PR dependency + merge order

This is **PR 1 of 3**, interdependent. Intended merge/release order:
1. **extrachill-api** — this PR (the route must exist first)
2. **extrachill-multisite** — repoint the NetworkStats loopback to `GET /community/stats`
3. **extrachill-community** — revert the `show_in_rest => true` from #142

Release/deploy the three together.

Refs Extra-Chill/extrachill-community#140 (symptom), Extra-Chill/extrachill-community#142 (expedient fix being corrected).