### PR TITLE
fix: forward beacon referrer param to track-page-view ability

### DIFF
--- a/inc/routes/analytics/view-count.php
+++ b/inc/routes/analytics/view-count.php
@@ -44,6 +44,17 @@ function extrachill_api_register_view_count_route() {
 					},
 					'sanitize_callback' => 'sanitize_text_field',
 				),
+				'referrer'   => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => '',
+					// Raw client-side document.referrer captured by the beacon. The
+					// tracking ability normalizes it to a host-only `referrer_host`
+					// (no query strings, no PII) and drops direct/same-host values,
+					// so validation stays permissive here — garbage normalizes to
+					// nothing downstream.
+					'sanitize_callback' => 'sanitize_text_field',
+				),
 			),
 		)
 	);
@@ -52,6 +63,7 @@ function extrachill_api_register_view_count_route() {
 function extrachill_api_view_count_handler( $request ) {
 	$post_id    = (int) $request->get_param( 'post_id' );
 	$visitor_id = (string) $request->get_param( 'visitor_id' );
+	$referrer   = (string) $request->get_param( 'referrer' );
 
 	// Thin wrapper: all write logic (post-meta bump, pageview event row carrying
 	// visitor_id, link-page daily-table action) lives in the analytics ability.
@@ -68,6 +80,7 @@ function extrachill_api_view_count_handler( $request ) {
 		array(
 			'post_id'    => $post_id,
 			'visitor_id' => $visitor_id,
+			'referrer'   => $referrer,
 		)
 	);
 


### PR DESCRIPTION
Fixes #99.

The `POST /extrachill/v1/analytics/view` wrapper declared only `post_id` and `visitor_id`, silently dropping the `referrer` the view-tracking beacon has been sending all along. Downstream, the `extrachill/track-page-view` ability's referrer normalization (`referrer_host` provenance stamping) was dead code — 100% of 43k+ production pageview rows have no `referrer_host`.

This adds the `referrer` arg to the route registration (permissive validation by design — the ability normalizes to a host-only value and drops direct/same-host referrers) and forwards it into the ability call.

No changes needed in extrachill-analytics: the JS capture and the server-side normalization were already correct, just never connected.