### PR TITLE
fix: remove Admin Tools route delegation inversions

### DIFF
--- a/inc/routes/admin/artist-access.php
+++ b/inc/routes/admin/artist-access.php
@@ -266,11 +266,11 @@ function extrachill_api_artist_access_email_approve( $request ) {
 	}
 
 	if ( ! empty( $result['skipped'] ) ) {
-		wp_safe_redirect( admin_url( 'tools.php?page=extrachill-admin-tools#artist-access-requests&already_approved=1' ) );
+		wp_safe_redirect( network_admin_url( 'users.php?page=extrachill-artist-access&already_approved=1' ) );
 		exit;
 	}
 
-	wp_safe_redirect( admin_url( 'tools.php?page=extrachill-admin-tools#artist-access-requests&approved=1' ) );
+	wp_safe_redirect( network_admin_url( 'users.php?page=extrachill-artist-access&approved=1' ) );
 	exit;
 }
 

--- a/inc/routes/admin/taxonomy-sync.php
+++ b/inc/routes/admin/taxonomy-sync.php
@@ -26,7 +26,9 @@ function extrachill_api_register_taxonomy_sync_routes() {
 				'target_sites' => array(
 					'required'          => true,
 					'type'              => 'array',
+					'items'             => array( 'type' => 'string' ),
 					'sanitize_callback' => 'extrachill_api_taxonomy_sync_sanitize_site_slugs',
+					'description'       => 'Target site slugs resolved by ec_get_blog_id().',
 				),
 				'taxonomies'   => array(
 					'required'          => true,
@@ -57,7 +59,13 @@ function extrachill_api_taxonomy_sync_sanitize_site_slugs( $value ) {
 
 	$site_slugs = array();
 	foreach ( $value as $site_slug ) {
+		if ( ! is_string( $site_slug ) ) {
+			continue;
+		}
 		$site_slug = sanitize_key( $site_slug );
+		if ( is_numeric( $site_slug ) ) {
+			continue;
+		}
 		if ( '' === $site_slug ) {
 			continue;
 		}
@@ -88,27 +96,183 @@ function extrachill_api_taxonomy_sync_sanitize_taxonomies( $value ) {
 /**
  * Syncs shared taxonomies from the main site to target sites.
  *
- * Wraps the extrachill/sync-taxonomies ability.
- *
  * @param WP_REST_Request $request The REST request object.
  * @return WP_REST_Response|WP_Error Response with sync report or error.
  */
 function extrachill_api_taxonomy_sync( WP_REST_Request $request ) {
-	$ability = wp_get_ability( 'extrachill/sync-taxonomies' );
-	if ( ! $ability ) {
-		return new WP_Error( 'ability_not_found', 'Taxonomy sync ability is not available.', array( 'status' => 500 ) );
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return new WP_Error( 'dependency_missing', 'Required function ec_get_blog_id() not available.', array( 'status' => 500 ) );
 	}
 
-	$result = $ability->execute(
-		array(
-			'target_sites' => $request->get_param( 'target_sites' ),
-			'taxonomies'   => $request->get_param( 'taxonomies' ),
-		)
+	$target_sites = $request->get_param( 'target_sites' );
+	$taxonomies   = $request->get_param( 'taxonomies' );
+
+	if ( empty( $target_sites ) || empty( $taxonomies ) ) {
+		return new WP_Error( 'invalid_params', 'Please select at least one target site and one taxonomy.', array( 'status' => 400 ) );
+	}
+
+	$target_blog_ids = array();
+	foreach ( $target_sites as $site_slug ) {
+		$blog_id = ec_get_blog_id( $site_slug );
+		if ( $blog_id ) {
+			$target_blog_ids[] = absint( $blog_id );
+		}
+	}
+
+	if ( empty( $target_blog_ids ) ) {
+		return new WP_Error( 'invalid_params', 'No valid target sites selected.', array( 'status' => 400 ) );
+	}
+
+	return rest_ensure_response( extrachill_api_perform_taxonomy_sync( $target_blog_ids, $taxonomies ) );
+}
+
+/**
+ * Group source terms by parent term ID.
+ *
+ * @param WP_Term[] $terms Terms to organize.
+ * @return array<int,WP_Term[]>
+ */
+function extrachill_api_organize_terms_by_parent( $terms ) {
+	$hierarchy = array();
+	foreach ( $terms as $term ) {
+		$parent_id                 = (int) $term->parent;
+		$hierarchy[ $parent_id ][] = $term;
+	}
+
+	return $hierarchy;
+}
+
+/**
+ * Sync one hierarchical term and its descendants.
+ *
+ * @param WP_Term $term                Source term.
+ * @param string  $taxonomy            Taxonomy slug.
+ * @param array   $hierarchy           Terms grouped by source parent ID.
+ * @param int     $parent_id_on_target Target parent term ID.
+ * @param array   $site_report         Per-site counters.
+ * @param array   $report              Aggregate counters.
+ */
+function extrachill_api_sync_term_recursive( $term, $taxonomy, $hierarchy, $parent_id_on_target, &$site_report, &$report ) {
+	++$report['total_terms_processed'];
+	$existing_term = term_exists( $term->slug, $taxonomy );
+
+	if ( $existing_term ) {
+		++$site_report['skipped'];
+		++$report['total_terms_skipped'];
+		$synced_term_id = is_array( $existing_term ) ? $existing_term['term_id'] : $existing_term;
+	} else {
+		$term_args = array(
+			'slug'        => $term->slug,
+			'description' => $term->description,
+		);
+		if ( $parent_id_on_target > 0 ) {
+			$term_args['parent'] = $parent_id_on_target;
+		}
+
+		$result = wp_insert_term( $term->name, $taxonomy, $term_args );
+		if ( is_wp_error( $result ) ) {
+			++$site_report['failed'];
+			return;
+		}
+
+		++$site_report['created'];
+		++$report['total_terms_created'];
+		$synced_term_id = $result['term_id'];
+	}
+
+	foreach ( $hierarchy[ $term->term_id ] ?? array() as $child_term ) {
+		extrachill_api_sync_term_recursive( $child_term, $taxonomy, $hierarchy, $synced_term_id, $site_report, $report );
+	}
+}
+
+/**
+ * Copy selected taxonomies from the main site to target blog IDs.
+ *
+ * @param int[]    $target_blog_ids Target blog IDs.
+ * @param string[] $taxonomies     Taxonomy slugs.
+ * @return array Sync report.
+ */
+function extrachill_api_perform_taxonomy_sync( $target_blog_ids, $taxonomies ) {
+	$source_blog_id = ec_get_blog_id( 'main' );
+	$report         = array(
+		'total_terms_processed' => 0,
+		'total_terms_created'   => 0,
+		'total_terms_skipped'   => 0,
+		'breakdown'             => array(),
 	);
 
-	if ( is_wp_error( $result ) ) {
-		return $result;
+	if ( ! $source_blog_id ) {
+		return $report;
 	}
 
-	return rest_ensure_response( $result );
+	foreach ( $taxonomies as $taxonomy ) {
+		try {
+			switch_to_blog( $source_blog_id );
+			$source_terms    = get_terms(
+				array(
+					'taxonomy'   => $taxonomy,
+					'hide_empty' => false,
+				)
+			);
+			$is_hierarchical = is_taxonomy_hierarchical( $taxonomy );
+		} finally {
+			restore_current_blog();
+		}
+
+		if ( is_wp_error( $source_terms ) || empty( $source_terms ) ) {
+			continue;
+		}
+
+		$report['breakdown'][ $taxonomy ] = array(
+			'source_terms' => count( $source_terms ),
+			'sites'        => array(),
+		);
+
+		foreach ( $target_blog_ids as $target_blog_id ) {
+			$site_report = array(
+				'created' => 0,
+				'skipped' => 0,
+				'failed'  => 0,
+			);
+			try {
+				switch_to_blog( $target_blog_id );
+				if ( $is_hierarchical ) {
+					$hierarchy = extrachill_api_organize_terms_by_parent( $source_terms );
+					foreach ( $hierarchy[0] ?? array() as $root_term ) {
+						extrachill_api_sync_term_recursive( $root_term, $taxonomy, $hierarchy, 0, $site_report, $report );
+					}
+				} else {
+					foreach ( $source_terms as $term ) {
+						++$report['total_terms_processed'];
+						if ( term_exists( $term->slug, $taxonomy ) ) {
+							++$site_report['skipped'];
+							++$report['total_terms_skipped'];
+							continue;
+						}
+
+						$result = wp_insert_term(
+							$term->name,
+							$taxonomy,
+							array(
+								'slug'        => $term->slug,
+								'description' => $term->description,
+							)
+						);
+						if ( is_wp_error( $result ) ) {
+							++$site_report['failed'];
+							continue;
+						}
+						++$site_report['created'];
+						++$report['total_terms_created'];
+					}
+				}
+			} finally {
+				restore_current_blog();
+			}
+
+			$report['breakdown'][ $taxonomy ]['sites'][ (string) $target_blog_id ] = $site_report;
+		}
+	}
+
+	return $report;
 }

--- a/tests/unit/test-taxonomy-sync.php
+++ b/tests/unit/test-taxonomy-sync.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Unit tests for taxonomy sync contracts.
+ *
+ * @package ExtraChill\API\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class Test_Taxonomy_Sync extends TestCase {
+
+	/**
+	 * Target sites are public site slugs, not numeric blog IDs.
+	 */
+	public function test_target_site_sanitizer_preserves_slugs() {
+		$result = extrachill_api_taxonomy_sync_sanitize_site_slugs(
+			array( 'community', 'events', 'community', '', 'News Wire' )
+		);
+
+		$this->assertSame( array( 'community', 'events', 'newswire' ), $result );
+	}
+
+	/**
+	 * Numeric values do not silently become valid blog identifiers.
+	 */
+	public function test_target_site_sanitizer_rejects_numeric_values() {
+		$result = extrachill_api_taxonomy_sync_sanitize_site_slugs( array( 2, '2', 'events' ) );
+
+		$this->assertSame( array( 'events' ), $result );
+	}
+
+	/**
+	 * Only shared taxonomy slugs may pass through the route.
+	 */
+	public function test_taxonomy_sanitizer_enforces_shared_taxonomies() {
+		$result = extrachill_api_taxonomy_sync_sanitize_taxonomies(
+			array( 'location', 'artist', 'category', 'venue', 'artist' )
+		);
+
+		$this->assertSame( array( 'location', 'artist', 'venue' ), $result );
+	}
+
+	/**
+	 * Terms are grouped under their source parent IDs.
+	 */
+	public function test_terms_are_grouped_by_parent() {
+		$root         = (object) array( 'term_id' => 10, 'parent' => 0 );
+		$child        = (object) array( 'term_id' => 11, 'parent' => 10 );
+		$second_root  = (object) array( 'term_id' => 12, 'parent' => 0 );
+		$hierarchy    = extrachill_api_organize_terms_by_parent( array( $root, $child, $second_root ) );
+
+		$this->assertSame( array( $root, $second_root ), $hierarchy[0] );
+		$this->assertSame( array( $child ), $hierarchy[10] );
+	}
+}


### PR DESCRIPTION
## Summary
- restore API-owned taxonomy synchronization instead of recursively delegating through the retiring Admin Tools ability
- preserve stable owner ability adapters for QR, team management, and lifetime memberships as ownership moves to Network and Users
- redirect one-click artist approvals to the owner-native network Users screen and document the slug-based taxonomy target contract with tests

Closes #101
Part of Extra-Chill/extrachill-admin-tools#16.

## Route Delegation Map
| Route | Previous delegation | New delegation |
| --- | --- | --- |
| `POST /extrachill/v1/tools/qr-code` | `extrachill/generate-qr-code` owned by Admin Tools | same canonical ability, owned by `extrachill-network` via Extra-Chill/extrachill-network#103 |
| `GET /extrachill/v1/admin/team-members` | API-native role query | unchanged API read adapter over the `extra_chill_team` role |
| `POST /extrachill/v1/admin/team-members/sync` | `extrachill/sync-team-members` owned by Admin Tools | same canonical ability, owned by `extrachill-users` via Extra-Chill/extrachill-users#173 |
| `PUT /extrachill/v1/admin/team-members/{user_id}` | `extrachill/manage-team-member` owned by Admin Tools | same canonical ability, owned by `extrachill-users` via Extra-Chill/extrachill-users#173 |
| `GET /extrachill/v1/admin/lifetime-membership` | API-native user-meta query | unchanged API read adapter |
| `POST /extrachill/v1/admin/lifetime-membership/grant` | `extrachill/grant-lifetime-membership` owned by Admin Tools | same canonical ability, owned by `extrachill-users` via Extra-Chill/extrachill-users#173 |
| `DELETE /extrachill/v1/admin/lifetime-membership/{user_id}` | `extrachill/revoke-lifetime-membership` owned by Admin Tools | same canonical ability, owned by `extrachill-users` via Extra-Chill/extrachill-users#173 |
| `POST /extrachill/v1/admin/taxonomies/sync` | Admin Tools ability constructed a REST request back into this callback, producing recursion | API-owned sync primitive restored from the route's pre-ability implementation |
| `GET /extrachill/v1/admin/artist-access/{user_id}/approve` | redirected to `tools.php?page=extrachill-admin-tools` | redirects to network `users.php?page=extrachill-artist-access` |

## Compatibility Evidence
- Public route paths, methods, permission callbacks, ability names, and adapter response handling remain unchanged.
- QR still converts the owner ability's base64 `image` field into the existing `image_url` data URI response.
- Team and membership routes still return owner ability results through `rest_ensure_response()` and preserve owner `WP_Error` data.
- Taxonomy sync restores the exact aggregate fields used before the inversion: `total_terms_processed`, `total_terms_created`, `total_terms_skipped`, and `breakdown` keyed by taxonomy and numeric blog ID.
- Historical implementation evidence confirms `target_sites` accepts slugs resolved with `ec_get_blog_id()`; numeric blog IDs only appear in response breakdown keys. The REST schema now explicitly declares string items and the sanitizer rejects numeric values.
- Hierarchical terms retain parent relationships; flat terms retain slug and description behavior.

## Landing Order
1. Land Extra-Chill/extrachill-network#103 so `extrachill-network` can own `extrachill/generate-qr-code` during overlap.
2. Land Extra-Chill/extrachill-users#173 so Users owns team, membership, and artist-access workflows during overlap.
3. Land this PR to remove taxonomy recursion and point artist-access redirects at Users.
4. Retire Admin Tools under Extra-Chill/extrachill-admin-tools#16 after all consumers resolve against destination owners.

The stable ability-name adapters allow steps 1-3 to overlap without changing HTTP contracts; destination registrations are expected to guard against duplicate registration during rollout.

## Tests
- `php -l inc/routes/admin/taxonomy-sync.php`
- `php -l inc/routes/admin/artist-access.php`
- `php -l tests/unit/test-taxonomy-sync.php`
- `homeboy review lint extrachill-api --path /var/lib/datamachine/workspace/extrachill-api@retire-admin-tools-delegation --changed-only --errors-only --force-hot --allow-local-hot` (passes with no findings)
- Added taxonomy contract coverage for slug sanitization, numeric-ID rejection, taxonomy allowlisting, and parent grouping.
- `homeboy review test ... --skip-lint` could not start PHPUnit because the installed WP Codebox runtime lacks a `buildWordPressPhpunitRecipe` recipe-builder export; no tests executed and no test failure was observed.