### PR TITLE
fix: use core post type supports API

### DIFF
--- a/inc/routes/docs/docs-info.php
+++ b/inc/routes/docs/docs-info.php
@@ -189,11 +189,21 @@ function extrachill_api_docs_info_collect_post_types() {
 			'public'        => (bool) $object->public,
 			'has_archive'   => (bool) $object->has_archive,
 			'hierarchical'  => (bool) $object->hierarchical,
-			'supports'      => is_array( $object->supports ) ? array_values( $object->supports ) : array(),
+			'supports'      => extrachill_api_docs_info_get_post_type_supports( $post_type ),
 			'publish_count' => $published_count,
 			'taxonomies'    => $tax_data,
 		);
 	}
 
 	return $data;
+}
+
+/**
+ * Gets a post type's supported features as a list of feature names.
+ *
+ * @param string $post_type Post type slug.
+ * @return array
+ */
+function extrachill_api_docs_info_get_post_type_supports( $post_type ) {
+	return array_keys( get_all_post_type_supports( $post_type ) );
 }

--- a/tests/Unit/routes/docs/docs-infoTest.php
+++ b/tests/Unit/routes/docs/docs-infoTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Tests for docs-info post type support metadata.
+ *
+ * @package ExtraChill\API\Tests
+ */
+
+/**
+ * Tests docs-info post type support metadata.
+ */
+class Docs_InfoTest extends WP_UnitTestCase { // phpcs:ignore Generic.Classes.OpeningBraceSameLine -- WP test convention.
+
+	/**
+	 * Removes post types registered by tests.
+	 */
+	public function tear_down() {
+		unregister_post_type( 'api_doc_supported' );
+		unregister_post_type( 'api_doc_none' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Feature-keyed core supports are normalized to feature names.
+	 */
+	public function test_post_type_supports_are_returned_as_feature_names() {
+		register_post_type(
+			'api_doc_supported',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'editor' ),
+			)
+		);
+
+		$this->assertTrue( get_all_post_type_supports( 'api_doc_supported' )['title'] );
+		$this->assertTrue( get_all_post_type_supports( 'api_doc_supported' )['editor'] );
+		$this->assertSame(
+			array_keys( get_all_post_type_supports( 'api_doc_supported' ) ),
+			extrachill_api_docs_info_get_post_type_supports( 'api_doc_supported' )
+		);
+	}
+
+	/**
+	 * Post types without supports return an empty feature list.
+	 */
+	public function test_post_type_without_supports_returns_empty_list() {
+		register_post_type(
+			'api_doc_none',
+			array(
+				'public'   => true,
+				'supports' => false,
+			)
+		);
+
+		$this->assertSame( array(), get_all_post_type_supports( 'api_doc_none' ) );
+		$this->assertSame( array(), extrachill_api_docs_info_get_post_type_supports( 'api_doc_none' ) );
+	}
+}


### PR DESCRIPTION
## Summary
- replace the invalid `WP_Post_Type::$supports` read with `get_all_post_type_supports()` feature keys
- add docs-info coverage for supported and unsupported post types

## Verification
- `php -l inc/routes/docs/docs-info.php`
- `php -l tests/Unit/routes/docs/docs-infoTest.php`
- `phpcs --standard=WordPress tests/Unit/routes/docs/docs-infoTest.php`
- focused helper and WordPress core runtime assertions

Fixes #103