### PR TITLE
feat: expose Local Scene adapters

### DIFF
--- a/inc/routes/users/settings.php
+++ b/inc/routes/users/settings.php
@@ -34,17 +34,30 @@ function extrachill_api_register_user_settings_routes() {
 				'callback'            => 'extrachill_api_user_settings_update',
 				'permission_callback' => 'extrachill_api_user_settings_permission',
 				'args'                => array(
-					'first_name'   => array(
+					'first_name'             => array(
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'last_name'    => array(
+					'last_name'              => array(
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'display_name' => array(
+					'display_name'           => array(
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'local_scene'            => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_title',
+					),
+					'local_scene_visibility' => array(
+						'type'              => 'string',
+						'enum'              => array( 'public', 'private' ),
+						'sanitize_callback' => 'sanitize_key',
+					),
+					'default_event_location' => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_title',
 					),
 				),
 			),
@@ -140,14 +153,11 @@ function extrachill_api_user_settings_update( WP_REST_Request $request ) {
 
 	$input = array( 'user_id' => get_current_user_id() );
 
-	if ( null !== $request->get_param( 'first_name' ) ) {
-		$input['first_name'] = $request->get_param( 'first_name' );
-	}
-	if ( null !== $request->get_param( 'last_name' ) ) {
-		$input['last_name'] = $request->get_param( 'last_name' );
-	}
-	if ( null !== $request->get_param( 'display_name' ) ) {
-		$input['display_name'] = $request->get_param( 'display_name' );
+	$fields = array( 'first_name', 'last_name', 'display_name', 'local_scene', 'local_scene_visibility', 'default_event_location' );
+	foreach ( $fields as $field ) {
+		if ( null !== $request->get_param( $field ) ) {
+			$input[ $field ] = $request->get_param( $field );
+		}
 	}
 
 	$result = $ability->execute( $input );

--- a/inc/routes/users/users.php
+++ b/inc/routes/users/users.php
@@ -4,10 +4,7 @@
  *
  * GET /wp-json/extrachill/v1/users/{id} - Retrieve user profile data
  *
- * Permission model:
- * - Own profile or admin: Full data access
- * - Other logged-in users: Limited public fields
- * - Not logged in: 401 error
+ * Profile data is supplied by the public Extra Chill Users profile ability.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -65,86 +62,13 @@ function extrachill_api_user_permission_check( WP_REST_Request $request ) {
  * GET handler - retrieve user profile data
  */
 function extrachill_api_user_get_handler( WP_REST_Request $request ) {
-	$user_id      = $request->get_param( 'id' );
-	$current_user = get_current_user_id();
-	$is_own       = $current_user === $user_id;
-	$is_admin     = current_user_can( 'manage_options' );
+	$ability = wp_get_ability( 'extrachill/get-user-profile' );
 
-	$user = get_userdata( $user_id );
-
-	$response = extrachill_api_build_user_response( $user, $is_own || $is_admin );
-
-	return rest_ensure_response( $response );
-}
-
-/**
- * Build user response data
- *
- * @param WP_User $user      User object
- * @param bool    $full_data Whether to include all fields or just public fields
- * @return array
- */
-function extrachill_api_build_user_response( $user, $full_data = false ) {
-	$user_id = $user->ID;
-
-	// Avatar URL
-	$avatar_url = get_avatar_url( $user_id, array( 'size' => 96 ) );
-
-	// Profile URL (uses extrachill-users canonical function if available)
-	$profile_url = function_exists( 'extrachill_get_user_profile_url' )
-		? extrachill_get_user_profile_url( $user_id, $user->user_email )
-		: get_author_posts_url( $user_id );
-
-	// Team member status
-	$is_team_member = function_exists( 'ec_is_team_member' )
-		? ec_is_team_member( $user_id )
-		: false;
-
-	// Last active timestamp
-	$last_active = get_user_meta( $user_id, 'last_active', true );
-
-	// Public fields (available to all logged-in users)
-	$response = array(
-		'id'             => $user_id,
-		'display_name'   => $user->display_name,
-		'username'       => $user->user_login,
-		'slug'           => $user->user_nicename,
-		'avatar_url'     => $avatar_url,
-		'profile_url'    => $profile_url,
-		'is_team_member' => $is_team_member,
-		'last_active'    => $last_active ? (int) $last_active : null,
-	);
-
-	// Extended fields (own profile or admin only)
-	if ( $full_data ) {
-		// Lifetime membership
-		$membership_data    = get_user_meta( $user_id, 'extrachill_lifetime_membership', true );
-		$is_lifetime_member = ! empty( $membership_data );
-
-		// Artist/professional status
-		$is_artist       = get_user_meta( $user_id, 'user_is_artist', true ) === '1';
-		$is_professional = get_user_meta( $user_id, 'user_is_professional', true ) === '1';
-
-		// Can create artists
-		$can_create_artists = function_exists( 'ec_can_create_artist_profiles' )
-			? ec_can_create_artist_profiles( $user_id )
-			: false;
-
-		// Artist count
-		$artist_count = 0;
-		if ( function_exists( 'ec_get_artists_for_user' ) ) {
-			$artists      = ec_get_artists_for_user( $user_id );
-			$artist_count = count( $artists );
-		}
-
-		$response['email']              = $user->user_email;
-		$response['is_lifetime_member'] = $is_lifetime_member;
-		$response['is_artist']          = $is_artist;
-		$response['is_professional']    = $is_professional;
-		$response['can_create_artists'] = $can_create_artists;
-		$response['artist_count']       = $artist_count;
-		$response['registered']         = mysql2date( 'c', $user->user_registered );
+	if ( ! $ability ) {
+		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	return $response;
+	$result = $ability->execute( array( 'user_id' => $request->get_param( 'id' ) ) );
+
+	return is_wp_error( $result ) ? $result : rest_ensure_response( $result );
 }

--- a/tests/unit/UserLocalSceneAdaptersTest.php
+++ b/tests/unit/UserLocalSceneAdaptersTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Contract tests for Local Scene REST adapters.
+ *
+ * @package ExtraChill\API\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that REST adapters mirror the Users-owned scene contract.
+ */
+class UserLocalSceneAdaptersTest extends TestCase {
+
+	/**
+	 * Settings registration includes canonical fields and aliases.
+	 */
+	public function test_settings_route_exposes_canonical_and_compatibility_fields() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local fixture.
+		$source = file_get_contents( dirname( __DIR__, 2 ) . '/inc/routes/users/settings.php' );
+
+		$this->assertStringContainsString( "'local_scene'", $source );
+		$this->assertStringContainsString( "'local_scene_visibility'", $source );
+		$this->assertStringContainsString( "'default_event_location'", $source );
+		$this->assertStringContainsString( "array( 'public', 'private' )", $source );
+	}
+
+	/**
+	 * The adapter forwards every supported scene setting.
+	 */
+	public function test_settings_adapter_forwards_canonical_and_compatibility_fields() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local fixture.
+		$source = file_get_contents( dirname( __DIR__, 2 ) . '/inc/routes/users/settings.php' );
+
+		$this->assertStringContainsString(
+			"array( 'first_name', 'last_name', 'display_name', 'local_scene', 'local_scene_visibility', 'default_event_location' )",
+			$source
+		);
+	}
+
+	/**
+	 * Public reads rely on the Users-owned privacy implementation.
+	 */
+	public function test_public_user_route_delegates_profile_privacy_to_users() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local fixture.
+		$source = file_get_contents( dirname( __DIR__, 2 ) . '/inc/routes/users/users.php' );
+
+		$this->assertStringContainsString( "wp_get_ability( 'extrachill/get-user-profile' )", $source );
+		$this->assertStringNotContainsString( 'get_user_meta(', $source );
+		$this->assertStringNotContainsString( 'extrachill_api_build_user_response', $source );
+	}
+
+	/**
+	 * Existing local_city clients remain supported by profile updates.
+	 */
+	public function test_legacy_local_city_profile_update_remains_available() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local fixture.
+		$source = file_get_contents( dirname( __DIR__, 2 ) . '/inc/routes/users/profile.php' );
+
+		$this->assertStringContainsString( "'local_city'", $source );
+		$this->assertStringContainsString( "\$input['local_city']", $source );
+	}
+}


### PR DESCRIPTION
Forwards canonical Local Scene and visibility through user settings REST routes and delegates public profile reads to Users privacy enforcement. Retains compatibility fields. Focused tests pass. Fixes #105.