### PR TITLE
fix: use core post type support API in docs route

### DIFF
--- a/inc/routes/docs/docs-info.php
+++ b/inc/routes/docs/docs-info.php
@@ -189,7 +189,7 @@ function extrachill_api_docs_info_collect_post_types() {
 			'public'        => (bool) $object->public,
 			'has_archive'   => (bool) $object->has_archive,
 			'hierarchical'  => (bool) $object->hierarchical,
-			'supports'      => is_array( $object->supports ) ? array_values( $object->supports ) : array(),
+			'supports'      => array_keys( get_all_post_type_supports( $post_type ) ),
 			'publish_count' => $published_count,
 			'taxonomies'    => $tax_data,
 		);

--- a/tests/Unit/routes/docs/docs-infoTest.php
+++ b/tests/Unit/routes/docs/docs-infoTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Tests for the docs-info route post-type support collection.
+ *
+ * @package ExtraChill\API\Tests
+ */
+
+/**
+ * Regression coverage for issue #103: the docs route must read post-type
+ * supports via the canonical core API (get_all_post_type_supports()) rather
+ * than the transient WP_Post_Type::$supports property, which core unsets
+ * after register_post_type() runs.
+ */
+class Docs_Info_Post_Type_SupportsTest extends WP_UnitTestCase {
+
+	/**
+	 * Clean up post types registered during a test so they cannot leak into
+	 * other test classes sharing the process.
+	 */
+	public function tear_down() {
+		foreach ( array( 'ec_doc_sup', 'ec_doc_nosup' ) as $pt ) {
+			if ( post_type_exists( $pt ) ) {
+				unregister_post_type( $pt );
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The collect helper should return feature names (not undefined-property
+	 * values) for a post type that declares supports.
+	 */
+	public function test_supports_returned_as_feature_names_for_supported_type() {
+		register_post_type(
+			'ec_doc_sup',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
+			)
+		);
+
+		$data = extrachill_api_docs_info_collect_post_types();
+
+		$this->assertArrayHasKey( 'ec_doc_sup', $data );
+
+		$supports = $data['ec_doc_sup']['supports'];
+		$this->assertIsArray( $supports );
+
+		// Each entry must be a feature string, not a boolean/integer leftover
+		// from reading the unset $supports property.
+		foreach ( $supports as $feature ) {
+			$this->assertIsString( $feature );
+		}
+
+		$this->assertContains( 'title', $supports );
+		$this->assertContains( 'editor', $supports );
+		$this->assertContains( 'thumbnail', $supports );
+		$this->assertContains( 'excerpt', $supports );
+	}
+
+	/**
+	 * A post type registered with supports => false should produce an empty
+	 * list, not an undefined-property warning.
+	 */
+	public function test_supports_empty_when_none_declared() {
+		register_post_type(
+			'ec_doc_nosup',
+			array(
+				'public'   => true,
+				'supports' => false,
+			)
+		);
+
+		$data = extrachill_api_docs_info_collect_post_types();
+
+		$this->assertArrayHasKey( 'ec_doc_nosup', $data );
+		$this->assertSame( array(), $data['ec_doc_nosup']['supports'] );
+	}
+
+	/**
+	 * Core built-in public post types should report their registered supports.
+	 */
+	public function test_supports_populated_for_core_post_type() {
+		$data = extrachill_api_docs_info_collect_post_types();
+
+		$this->assertArrayHasKey( 'post', $data );
+		$this->assertIsArray( $data['post']['supports'] );
+		$this->assertContains( 'title', $data['post']['supports'] );
+		$this->assertContains( 'editor', $data['post']['supports'] );
+	}
+}


### PR DESCRIPTION
## Root cause

`inc/routes/docs/docs-info.php:192` read `WP_Post_Type::$supports` directly:

```php
'supports' => is_array( $object->supports ) ? array_values( $object->supports ) : array(),
```

Although `WP_Post_Type::$supports` is a declared property, WordPress core **unsets** it inside `WP_Post_Type::add_supports()` (`wp-includes/class-wp-post-type.php:685`) once `register_post_type()` finishes wiring support features into the global `$_wp_post_type_features` map. After registration the property no longer exists on the object, so reading it emits:

```
PHP Warning: Undefined property: WP_Post_Type::$supports
```

…and `is_array()` falls through to the empty-array branch, so the route always returned `supports = []` regardless of the post type's actual features. Production error analytics recorded 24 warnings/7d.

## Canonical WordPress API used

`get_all_post_type_supports( $post_type )` (`wp-includes/post.php:2326`) — the canonical read API for post-type support state, backed by the global `$_wp_post_type_features` map that core populates during registration. The fix normalizes its feature-keyed return to the route's expected list shape with `array_keys()`:

```php
'supports' => array_keys( get_all_post_type_supports( $post_type ) ),
```

This is the existing core primitive, not a wrapper or a direct object-property assumption.

## Behavior change

- `supports` now returns the actual list of registered feature-name strings (e.g. `["title","editor","thumbnail","excerpt",...]`) instead of always `[]`.
- Post types registered with `'supports' => false` correctly return `[]`.
- The `Undefined property: WP_Post_Type::$supports` warning no longer fires.
- No other field or route behavior changes.

## Verification performed

- `php -l` passes on both modified files.
- PHPCS (WordPress standard) run on both changed files: the test file is clean (0 findings); the only remaining findings in `docs-info.php` are **pre-existing** (missing `@package` in the file header, and the direct-DB-call warnings on the taxonomy query at line 147) — none introduced by this change.
- Live WordPress core verification (`wp eval`):
  - Confirmed `isset( $post_type_object->supports ) === false` post-registration (the warning source).
  - Confirmed `array_keys( get_all_post_type_supports( 'post' ) )` returns 11 feature-name strings, all `is_string === true`, including `title`, `editor`, and `autosave` (implied by `editor`).
  - Confirmed a post type registered with `'supports' => false` yields `[]`.
- Demonstrated the old production behavior returns `supports = []` for all public post types (`post`, `page`, `guest-author`), confirming the bug this fixes.
- Added `WP_UnitTestCase` regression coverage (`tests/Unit/routes/docs/docs-infoTest.php`) covering: a post type **with** supports, a post type **without** supports (`supports => false`), and a core built-in type. (Note: the playground PHPUnit harness currently cannot execute due to a pre-existing, unrelated bootstrap failure — `Undefined constant "STDERR" at vendor/composer/platform_check.php:17` — which affects all tests in this repo and is independent of this change.)

## Autonomy notes

- Chose `array_keys( get_all_post_type_supports( $post_type ) )` over `post_type_supports()` iteration because the route needs the full feature list in one call, matching the issue's stated approach.
- Kept test post-type slugs ≤20 characters to satisfy WordPress core's `register_post_type()` length constraint (`wp-includes/post.php:1828`).

Closes #103.

No release or deployment was performed.