### PR TITLE
fix: resolve browser analytics identity from cookies

### DIFF
--- a/docs/routes/analytics/click.md
+++ b/docs/routes/analytics/click.md
@@ -11,7 +11,7 @@ Unified click tracking endpoint that routes to appropriate storage based on clic
 ### Common Parameters
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `click_type` | string | Yes | Type of click: `share`, `link_page_link` |
+| `click_type` | string | Yes | Type of click: `share`, `link_page_link`, `bridge`, or `outbound` |
 | `source_url` | string | Yes | Page URL where the click occurred |
 | `destination_url` | string | Conditional | URL being navigated to (required for `link_page_link`) |
 | `element_text` | string | No | Text content of the clicked element |
@@ -26,12 +26,21 @@ Unified click tracking endpoint that routes to appropriate storage based on clic
 | --- | --- | --- | --- |
 | `link_page_id` | integer | Yes (when `click_type=link_page_link`) | WordPress post ID of the artist link page |
 
+### Outbound Click Parameters
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `dest_host` | string | Conditional | External destination host. Required when `destination_url` is absent. |
+| `destination_url` | string | Conditional | External destination URL. Required when `dest_host` is absent. |
+
+Outbound identity is never accepted from the browser. The Analytics integration reads an existing valid first-party `ec_vid` cookie server-side; clicks with no cookie, a cross-site request without the cookie, or GPC/DNT opt-out remain anonymous. Outbound clicks do not mint an identity, preventing a first click from racing the pageview beacon.
+
 ## Storage Routing
 
 | Click Type | Storage | Via |
 | --- | --- | --- |
 | `share` | `{base_prefix}extrachill_analytics_events` table | `extrachill_track_analytics_event('share_click', ...)` |
 | `link_page_link` | `{prefix}extrch_link_page_daily_link_clicks` table | `do_action('extrachill_link_click_recorded', ...)` |
+| `outbound` | `{base_prefix}extrachill_analytics_events` table | `extrachill/track-analytics-event` ability |
 
 ## URL Normalization
 

--- a/docs/routes/analytics/view-count.md
+++ b/docs/routes/analytics/view-count.md
@@ -10,11 +10,14 @@ Captures post view events asynchronously. Useful for blocks and templates that w
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `post_id` | integer | Yes | Target WordPress post ID. Must be a positive integer. |
+| `referrer` | string | No | Browser referrer. Analytics normalizes this to a host-only value. |
 
 ## Processing Steps
 1. Validates the payload via REST schema.
-2. Confirms `ec_track_post_views()` exists (provided by the `extrachill-analytics` plugin). Returns `500 function_missing` if unavailable.
-3. Calls `ec_track_post_views( $post_id )` to increment counters.
+2. Confirms the Analytics-owned `extrachill/track-page-view` ability is available. Returns `500 ability_not_found` if unavailable.
+3. Executes the ability to increment counters and record the pageview.
+
+Visitor identity is never accepted from the browser payload. The Analytics-owned pageview ability resolves an existing first-party `ec_vid` cookie or mints one only on its early pageview path. GPC/DNT opt-out and cross-site requests without that cookie remain anonymous.
 
 **Note**: This endpoint is public (`permission_callback` is `__return_true`). If the post type is `artist_link_page`, it also fires `extrachill_link_page_view_recorded`.
 

--- a/inc/routes/analytics/click.php
+++ b/inc/routes/analytics/click.php
@@ -20,10 +20,10 @@
  *             only and is bot-filtered by construction, exactly like 'bridge'.
  *             Records `dest_host` + the normalized `destination_url` plus the
  *             server-classified destination `category` in event_data, and
- *             carries the anonymous first-party `visitor_id` (NULL under
- *             GPC/DNT). This is the cross-DOMAIN counterpart to the cross-SITE
- *             conversion map — the missing half of "where do readers go." See
- *             extrachill-analytics#66.
+ *             carries an existing cookie-owned anonymous `visitor_id` (NULL
+ *             under GPC/DNT or when no first-party cookie exists). This is the
+ *             cross-DOMAIN counterpart to the cross-SITE conversion map — the
+ *             missing half of "where do readers go." See extrachill-analytics#66.
  *
  * Future click types (internal_link, taxonomy_badge, cta, etc.) will route through abilities.
  */
@@ -108,22 +108,6 @@ function extrachill_api_register_click_route() {
 					'default'           => '',
 					'sanitize_callback' => 'sanitize_text_field',
 				),
-				'visitor_id'        => array(
-					'required'          => false,
-					'type'              => 'string',
-					'default'           => '',
-					// Anonymous first-party UUID v4 echoed by the outbound beacon.
-					// Accept only a well-formed UUID v4; anything else (including
-					// empty / opted-out) is coerced to '' so the click records
-					// anonymously.
-					'validate_callback' => function ( $param ) {
-						return '' === $param || 1 === preg_match(
-							'/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
-							(string) $param
-						);
-					},
-					'sanitize_callback' => 'sanitize_text_field',
-				),
 			),
 		)
 	);
@@ -191,7 +175,6 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 	$source_site       = $request->get_param( 'source_site' );
 	$term              = $request->get_param( 'term' );
 	$dest_host         = $request->get_param( 'dest_host' );
-	$visitor_id        = (string) $request->get_param( 'visitor_id' );
 
 	$normalized_destination = extrachill_api_normalize_tracked_url( $destination_url );
 
@@ -332,6 +315,9 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 			$category = function_exists( 'extrachill_analytics_classify_outbound_host' )
 				? extrachill_analytics_classify_outbound_host( $dest_host )
 				: 'other';
+			$visitor_id = function_exists( 'extrachill_analytics_read_visitor_id' )
+				? extrachill_analytics_read_visitor_id()
+				: '';
 
 			$event_id = $ability->execute(
 				array(

--- a/inc/routes/analytics/view-count.php
+++ b/inc/routes/analytics/view-count.php
@@ -29,21 +29,6 @@ function extrachill_api_register_view_count_route() {
 					},
 					'sanitize_callback' => 'absint',
 				),
-				'visitor_id' => array(
-					'required'          => false,
-					'type'              => 'string',
-					'default'           => '',
-					// Anonymous first-party UUID v4 echoed by the beacon. Accept only a
-					// well-formed UUID v4; anything else (including empty / opted-out)
-					// is coerced to '' so the ability records the pageview anonymously.
-					'validate_callback' => function ( $param ) {
-						return '' === $param || 1 === preg_match(
-							'/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
-							(string) $param
-						);
-					},
-					'sanitize_callback' => 'sanitize_text_field',
-				),
 				'referrer'   => array(
 					'required'          => false,
 					'type'              => 'string',
@@ -62,11 +47,11 @@ function extrachill_api_register_view_count_route() {
 
 function extrachill_api_view_count_handler( $request ) {
 	$post_id    = (int) $request->get_param( 'post_id' );
-	$visitor_id = (string) $request->get_param( 'visitor_id' );
 	$referrer   = (string) $request->get_param( 'referrer' );
 
 	// Thin wrapper: all write logic (post-meta bump, pageview event row carrying
-	// visitor_id, link-page daily-table action) lives in the analytics ability.
+	// cookie-resolved visitor identity, link-page daily-table action) lives in the
+	// analytics ability.
 	$ability = wp_get_ability( 'extrachill/track-page-view' );
 	if ( ! $ability ) {
 		return new WP_Error(
@@ -78,9 +63,8 @@ function extrachill_api_view_count_handler( $request ) {
 
 	$result = $ability->execute(
 		array(
-			'post_id'    => $post_id,
-			'visitor_id' => $visitor_id,
-			'referrer'   => $referrer,
+			'post_id'  => $post_id,
+			'referrer' => $referrer,
 		)
 	);
 

--- a/tests/unit/OutboundClickIdentityTest.php
+++ b/tests/unit/OutboundClickIdentityTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Contract tests for outbound-click visitor identity.
+ *
+ * @package ExtraChill\API\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ensures the browser adapter trusts only the first-party request cookie.
+ */
+final class OutboundClickIdentityTest extends TestCase {
+	/**
+	 * Pageviews also leave identity resolution to the Analytics ability.
+	 */
+	public function test_pageview_route_does_not_accept_client_visitor_id(): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source fixture.
+		$source = file_get_contents( dirname( __DIR__, 2 ) . '/inc/routes/analytics/view-count.php' );
+
+		$this->assertNotFalse( $source );
+		$this->assertStringNotContainsString( "\$request->get_param( 'visitor_id' )", $source );
+		$this->assertStringNotContainsString( "'visitor_id' => array(", $source );
+		$this->assertStringNotContainsString( "'visitor_id' => \$visitor_id", $source );
+	}
+
+	/**
+	 * Client input must not expose or control visitor identity.
+	 */
+	public function test_route_does_not_accept_client_visitor_id(): void {
+		$source = $this->get_route_source();
+
+		$this->assertStringNotContainsString( "\$request->get_param( 'visitor_id' )", $source );
+		$this->assertStringNotContainsString( "'visitor_id'        => array(", $source );
+	}
+
+	/**
+	 * Outbound events use the Analytics-owned cookie reader without minting.
+	 */
+	public function test_route_reads_existing_cookie_identity(): void {
+		$source = $this->get_route_source();
+
+		$this->assertStringContainsString( 'extrachill_analytics_read_visitor_id()', $source );
+		$this->assertStringNotContainsString( 'extrachill_analytics_get_or_mint_visitor_id()', $source );
+	}
+
+	/**
+	 * The outbound event receives the read-only Analytics resolver result.
+	 */
+	public function test_outbound_event_uses_cookie_resolver_result(): void {
+		$source = $this->get_route_source();
+
+		$this->assertStringContainsString(
+			"\$visitor_id = function_exists( 'extrachill_analytics_read_visitor_id' )",
+			$source
+		);
+		$this->assertStringContainsString(
+			"'visitor_id' => \$visitor_id",
+			$source
+		);
+	}
+
+	/**
+	 * Read the click route source.
+	 *
+	 * @return string
+	 */
+	private function get_route_source() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source fixture.
+		$source = file_get_contents( dirname( __DIR__, 2 ) . '/inc/routes/analytics/click.php' );
+
+		$this->assertNotFalse( $source );
+
+		return $source;
+	}
+}


### PR DESCRIPTION
## Summary
- Remove browser-supplied `visitor_id` from the public pageview and outbound-click route schemas and handlers, preventing cached HTML or forged beacon payloads from assigning another visitor's identity.
- Leave pageview identity entirely with the Analytics-owned `extrachill/track-page-view` ability, which can resolve or mint only on its first-party pageview path.
- Resolve outbound attribution through Analytics' read-only `extrachill_analytics_read_visitor_id()` helper so a cookieless first click remains anonymous and cannot race the pageview beacon; GPC/DNT and cross-site/custom-domain requests without the cookie remain anonymous.
- Document the public identity boundary and add API contract coverage that protects against reintroducing browser identity input or outbound minting.

## Compatibility
This adapter change depends on Extra-Chill/extrachill-analytics #165 removing localized `visitorId` values from browser configuration. Existing browser beacons remain compatible because the removed field was optional; server-side cookie resolution is now authoritative.

## Verification
- `php -l inc/routes/analytics/click.php`
- `php -l inc/routes/analytics/view-count.php`
- `php -l tests/unit/OutboundClickIdentityTest.php`
- `git diff --check`
- `composer test` could not run because this assigned worktree has no `vendor/bin/phpunit`.
- `composer lint:php` could not run because this assigned worktree has no `vendor/bin/phpcs`.
- `homeboy review extrachill-api --changed-only --summary` was safely declined by Homeboy's hot-machine resource policy; no local override was used.

Closes #111
Closes #112