### PR TITLE
fix: validate public telemetry beacons

### DIFF
--- a/inc/routes/analytics/click.php
+++ b/inc/routes/analytics/click.php
@@ -32,6 +32,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once __DIR__ . '/telemetry-validation.php';
+
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_click_route' );
 
 function extrachill_api_register_click_route() {
@@ -55,17 +57,20 @@ function extrachill_api_register_click_route() {
 				'source_url'        => array(
 					'required'          => true,
 					'type'              => 'string',
+					'maxLength'         => 2048,
 					'sanitize_callback' => 'esc_url_raw',
 				),
 				'destination_url'   => array(
 					'required'          => false,
 					'type'              => 'string',
+					'maxLength'         => 2048,
 					'sanitize_callback' => 'esc_url_raw',
 				),
 				'element_text'      => array(
 					'required'          => false,
 					'type'              => 'string',
 					'default'           => '',
+					'maxLength'         => 200,
 					'sanitize_callback' => 'sanitize_text_field',
 				),
 				'share_destination' => array(
@@ -100,6 +105,7 @@ function extrachill_api_register_click_route() {
 					'required'          => false,
 					'type'              => 'string',
 					'default'           => '',
+					'maxLength'         => 200,
 					'sanitize_callback' => 'sanitize_text_field',
 				),
 				'dest_host'         => array(
@@ -164,8 +170,13 @@ function extrachill_api_normalize_tracked_url( $url ) {
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_click_handler( WP_REST_Request $request ) {
+	$source = extrachill_api_validate_telemetry_request( $request );
+	if ( is_wp_error( $source ) ) {
+		return $source;
+	}
+
 	$click_type        = $request->get_param( 'click_type' );
-	$source_url        = $request->get_param( 'source_url' );
+	$source_url        = $source['path'];
 	$destination_url   = $request->get_param( 'destination_url' );
 	$element_text      = $request->get_param( 'element_text' );
 	$share_destination = $request->get_param( 'share_destination' );
@@ -176,7 +187,20 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 	$term              = $request->get_param( 'term' );
 	$dest_host         = $request->get_param( 'dest_host' );
 
-	$normalized_destination = extrachill_api_normalize_tracked_url( $destination_url );
+	if ( ! extrachill_api_is_safe_telemetry_text( (string) $element_text )
+		|| ! extrachill_api_is_safe_telemetry_text( (string) $term ) ) {
+		return new WP_Error( 'unsafe_telemetry_payload', 'Telemetry text payload is not accepted.', array( 'status' => 400 ) );
+	}
+
+	$normalized_destination = '';
+	$destination            = null;
+	if ( $destination_url ) {
+		$destination = extrachill_api_normalize_telemetry_destination( $destination_url );
+		if ( is_wp_error( $destination ) ) {
+			return $destination;
+		}
+		$normalized_destination = $destination['url'];
+	}
 
 	switch ( $click_type ) {
 		case 'share':
@@ -202,7 +226,7 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 					'event_type' => 'share_click',
 					'event_data' => array(
 						'destination' => $share_destination,
-						'share_url'   => $normalized_destination ?: $source_url,
+						'share_url'   => $normalized_destination ? $normalized_destination : $source_url,
 					),
 					'source_url' => $source_url,
 				)
@@ -249,6 +273,17 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 			break;
 
 		case 'bridge':
+			$current_site = function_exists( 'ec_get_blog_slug_by_id' ) ? ec_get_blog_slug_by_id( get_current_blog_id() ) : '';
+			if ( $source_site && $current_site && $source_site !== $current_site ) {
+				return new WP_Error( 'invalid_source_site', 'source_site does not match source_url.', array( 'status' => 400 ) );
+			}
+			if ( $dest_site && function_exists( 'ec_get_blog_id' ) && ( null === ec_get_blog_id( $dest_site ) || $dest_site === $current_site ) ) {
+				return new WP_Error( 'invalid_destination_site', 'dest_site is not a valid cross-site destination.', array( 'status' => 400 ) );
+			}
+			if ( ! $source_site && $current_site ) {
+				$source_site = $current_site;
+			}
+
 			$ability = wp_get_ability( 'extrachill/track-analytics-event' );
 			if ( ! $ability ) {
 				return new WP_Error(
@@ -285,19 +320,23 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 			break;
 
 		case 'outbound':
-			if ( empty( $dest_host ) && empty( $normalized_destination ) ) {
+			if ( empty( $normalized_destination ) ) {
 				return new WP_Error(
 					'missing_destination',
-					'dest_host or destination_url is required for outbound click type.',
+					'destination_url is required for outbound click type.',
 					array( 'status' => 400 )
 				);
 			}
 
-			// Derive the host from the destination URL when the client didn't
-			// send one explicitly (defensive — the JS always sends dest_host).
-			if ( empty( $dest_host ) ) {
-				$parsed_host = wp_parse_url( $normalized_destination, PHP_URL_HOST );
-				$dest_host   = is_string( $parsed_host ) ? $parsed_host : '';
+			if ( $dest_host && strtolower( $dest_host ) !== $destination['host'] ) {
+				return new WP_Error( 'invalid_destination_host', 'dest_host does not match destination_url.', array( 'status' => 400 ) );
+			}
+			$dest_host = $destination['host'];
+
+			$network_hosts   = function_exists( 'ec_get_allowed_redirect_hosts' ) ? ec_get_allowed_redirect_hosts() : array();
+			$network_hosts[] = $source['host'];
+			if ( extrachill_api_is_network_telemetry_host( $dest_host, $network_hosts ) ) {
+				return new WP_Error( 'invalid_outbound_destination', 'Outbound destination must be off-network.', array( 'status' => 400 ) );
 			}
 
 			$ability = wp_get_ability( 'extrachill/track-analytics-event' );
@@ -312,7 +351,7 @@ function extrachill_api_click_handler( WP_REST_Request $request ) {
 			// Classify the destination once at write time so each stored row
 			// carries its category; the read ability honours the stamp and only
 			// re-classifies older/unstamped rows.
-			$category = function_exists( 'extrachill_analytics_classify_outbound_host' )
+			$category   = function_exists( 'extrachill_analytics_classify_outbound_host' )
 				? extrachill_analytics_classify_outbound_host( $dest_host )
 				: 'other';
 			$visitor_id = function_exists( 'extrachill_analytics_read_visitor_id' )

--- a/inc/routes/analytics/impression.php
+++ b/inc/routes/analytics/impression.php
@@ -22,6 +22,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once __DIR__ . '/telemetry-validation.php';
+
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_impression_route' );
 
 function extrachill_api_register_impression_route() {
@@ -45,6 +47,7 @@ function extrachill_api_register_impression_route() {
 				'source_url'      => array(
 					'required'          => true,
 					'type'              => 'string',
+					'maxLength'         => 2048,
 					'sanitize_callback' => 'esc_url_raw',
 				),
 				'source_post'     => array(
@@ -69,6 +72,7 @@ function extrachill_api_register_impression_route() {
 					'required'          => false,
 					'type'              => 'string',
 					'default'           => '',
+					'maxLength'         => 200,
 					'sanitize_callback' => 'sanitize_text_field',
 				),
 			),
@@ -83,8 +87,13 @@ function extrachill_api_register_impression_route() {
  * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_impression_handler( WP_REST_Request $request ) {
+	$source = extrachill_api_validate_telemetry_request( $request );
+	if ( is_wp_error( $source ) ) {
+		return $source;
+	}
+
 	$impression_type = $request->get_param( 'impression_type' );
-	$source_url      = $request->get_param( 'source_url' );
+	$source_url      = $source['path'];
 	$source_post     = (int) $request->get_param( 'source_post' );
 	$source_site     = $request->get_param( 'source_site' );
 	$dest_site       = $request->get_param( 'dest_site' );
@@ -96,6 +105,21 @@ function extrachill_api_impression_handler( WP_REST_Request $request ) {
 			'Unsupported impression type.',
 			array( 'status' => 400 )
 		);
+	}
+
+	if ( ! extrachill_api_is_safe_telemetry_text( (string) $term ) ) {
+		return new WP_Error( 'unsafe_telemetry_payload', 'Telemetry text payload is not accepted.', array( 'status' => 400 ) );
+	}
+
+	$current_site = function_exists( 'ec_get_blog_slug_by_id' ) ? ec_get_blog_slug_by_id( get_current_blog_id() ) : '';
+	if ( $source_site && $current_site && $source_site !== $current_site ) {
+		return new WP_Error( 'invalid_source_site', 'source_site does not match source_url.', array( 'status' => 400 ) );
+	}
+	if ( $dest_site && function_exists( 'ec_get_blog_id' ) && ( null === ec_get_blog_id( $dest_site ) || $dest_site === $current_site ) ) {
+		return new WP_Error( 'invalid_destination_site', 'dest_site is not a valid cross-site destination.', array( 'status' => 400 ) );
+	}
+	if ( ! $source_site && $current_site ) {
+		$source_site = $current_site;
 	}
 
 	$ability = wp_get_ability( 'extrachill/track-analytics-event' );

--- a/inc/routes/analytics/telemetry-validation.php
+++ b/inc/routes/analytics/telemetry-validation.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Shared admission checks for public browser telemetry adapters.
+ *
+ * Analytics owns event semantics and persistence. These helpers only enforce
+ * the HTTP trust boundary before forwarding accepted shapes to that contract.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Validate and normalize common public telemetry input.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return array|WP_Error Normalized input or an admission error.
+ */
+function extrachill_api_validate_telemetry_request( WP_REST_Request $request ) {
+	$rate_limit = extrachill_api_check_telemetry_rate_limit();
+	if ( is_wp_error( $rate_limit ) ) {
+		return $rate_limit;
+	}
+
+	$source_url = (string) $request->get_param( 'source_url' );
+	$source     = extrachill_api_normalize_telemetry_source( $source_url );
+	if ( is_wp_error( $source ) ) {
+		return $source;
+	}
+
+	$origin = $request->get_header( 'origin' );
+	if ( $origin ) {
+		$origin_host = strtolower( (string) wp_parse_url( $origin, PHP_URL_HOST ) );
+		if ( '' === $origin_host || $origin_host !== $source['host'] ) {
+			return new WP_Error(
+				'invalid_telemetry_origin',
+				'Telemetry origin does not match source_url.',
+				array( 'status' => 403 )
+			);
+		}
+	}
+
+	return $source;
+}
+
+/**
+ * Convert an accepted first-party source URL to its query-free path.
+ *
+ * @param string $url Client source URL.
+ * @return array|WP_Error Source host and normalized path.
+ */
+function extrachill_api_normalize_telemetry_source( $url ) {
+	if ( '' === $url || strlen( $url ) > 2048 ) {
+		return new WP_Error( 'invalid_source_url', 'A valid source_url is required.', array( 'status' => 400 ) );
+	}
+
+	$parts = wp_parse_url( $url );
+	if ( false === $parts || ! is_array( $parts ) ) {
+		return new WP_Error( 'invalid_source_url', 'A valid source_url is required.', array( 'status' => 400 ) );
+	}
+
+	$scheme = isset( $parts['scheme'] ) ? strtolower( $parts['scheme'] ) : '';
+	$host   = isset( $parts['host'] ) ? strtolower( rtrim( $parts['host'], '.' ) ) : '';
+	$path   = isset( $parts['path'] ) && '' !== $parts['path'] ? $parts['path'] : '/';
+
+	if ( '' === $host && 0 === strpos( $url, '/' ) ) {
+		$host = extrachill_api_telemetry_request_host();
+	} elseif ( ! in_array( $scheme, array( 'http', 'https' ), true ) || isset( $parts['user'] ) || isset( $parts['pass'] ) ) {
+		return new WP_Error( 'invalid_source_url', 'source_url must be an HTTP(S) first-party URL.', array( 'status' => 400 ) );
+	}
+
+	if ( '' === $host || ! extrachill_api_is_first_party_telemetry_host( $host ) ) {
+		return new WP_Error( 'invalid_source_host', 'source_url must belong to the current site.', array( 'status' => 403 ) );
+	}
+
+	if ( extrachill_api_is_unsafe_telemetry_path( $path ) ) {
+		return new WP_Error( 'unsafe_telemetry_path', 'Telemetry source path is not accepted.', array( 'status' => 400 ) );
+	}
+
+	$path = '/' . ltrim( $path, '/' );
+
+	return array(
+		'host' => $host,
+		'path' => $path,
+	);
+}
+
+/**
+ * Normalize a destination and remove analytics or sensitive query fields.
+ *
+ * @param string $url Client destination URL.
+ * @return array|WP_Error Destination URL and host.
+ */
+function extrachill_api_normalize_telemetry_destination( $url ) {
+	if ( '' === $url || strlen( $url ) > 2048 ) {
+		return new WP_Error( 'invalid_destination_url', 'A valid destination_url is required.', array( 'status' => 400 ) );
+	}
+
+	$parts = wp_parse_url( $url );
+	if ( false === $parts || ! is_array( $parts ) || empty( $parts['host'] ) || empty( $parts['scheme'] ) ) {
+		return new WP_Error( 'invalid_destination_url', 'destination_url must be an absolute HTTP(S) URL.', array( 'status' => 400 ) );
+	}
+
+	$scheme = strtolower( $parts['scheme'] );
+	$host   = strtolower( rtrim( $parts['host'], '.' ) );
+	$path   = isset( $parts['path'] ) && '' !== $parts['path'] ? $parts['path'] : '/';
+	if ( ! in_array( $scheme, array( 'http', 'https' ), true ) || isset( $parts['user'] ) || isset( $parts['pass'] ) ) {
+		return new WP_Error( 'invalid_destination_url', 'destination_url must be an absolute HTTP(S) URL.', array( 'status' => 400 ) );
+	}
+
+	if ( extrachill_api_is_unsafe_telemetry_path( $path ) ) {
+		return new WP_Error( 'unsafe_destination_url', 'Telemetry destination is not accepted.', array( 'status' => 400 ) );
+	}
+
+	$query = array();
+	if ( ! empty( $parts['query'] ) ) {
+		wp_parse_str( $parts['query'], $query );
+		foreach ( $query as $key => $value ) {
+			if ( extrachill_api_is_sensitive_telemetry_field( $key, $value ) ) {
+				unset( $query[ $key ] );
+			}
+		}
+	}
+
+	$normalized = $scheme . '://' . $host;
+	if ( isset( $parts['port'] ) ) {
+		$normalized .= ':' . (int) $parts['port'];
+	}
+	$normalized .= '/' . ltrim( $path, '/' );
+	if ( $query ) {
+		$normalized .= '?' . http_build_query( $query, '', '&', PHP_QUERY_RFC3986 );
+	}
+
+	return array(
+		'host' => $host,
+		'url'  => $normalized,
+	);
+}
+
+/**
+ * Determine whether a source host resolves to the current network site.
+ *
+ * @param string $host Candidate source host.
+ * @return bool
+ */
+function extrachill_api_is_first_party_telemetry_host( $host ) {
+	$current_blog_id = (int) get_current_blog_id();
+	$allowed         = array();
+
+	foreach ( array( home_url(), site_url(), rest_url() ) as $site_url ) {
+		$site_host = strtolower( (string) wp_parse_url( $site_url, PHP_URL_HOST ) );
+		if ( '' !== $site_host ) {
+			$allowed[] = $site_host;
+		}
+	}
+
+	if ( function_exists( 'ec_get_domain_map' ) ) {
+		foreach ( ec_get_domain_map() as $domain => $blog_id ) {
+			if ( $current_blog_id === (int) $blog_id ) {
+				$allowed[] = strtolower( $domain );
+			}
+		}
+	}
+
+	if ( in_array( $host, array_unique( $allowed ), true ) ) {
+		return true;
+	}
+
+	$request_host = extrachill_api_telemetry_request_host();
+	if ( $host !== $request_host || ! function_exists( 'get_site_by_path' ) ) {
+		return false;
+	}
+
+	$site = get_site_by_path( $host, '/' );
+
+	return $site && $current_blog_id === (int) $site->blog_id;
+}
+
+/**
+ * Check a host against exact network hosts and their subdomains.
+ *
+ * @param string $host          Candidate destination host.
+ * @param array  $network_hosts First-party host list.
+ * @return bool
+ */
+function extrachill_api_is_network_telemetry_host( $host, $network_hosts ) {
+	$host = strtolower( rtrim( $host, '.' ) );
+	foreach ( $network_hosts as $network_host ) {
+		$network_host = strtolower( rtrim( (string) $network_host, '.' ) );
+		if ( $host === $network_host || ( $network_host && substr( $host, -strlen( '.' . $network_host ) ) === '.' . $network_host ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Return the hostname used for the current request.
+ *
+ * @return string
+ */
+function extrachill_api_telemetry_request_host() {
+	$host = isset( $_SERVER['HTTP_HOST'] ) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized and parsed below.
+	$host = strtolower( preg_replace( '/:\d+$/', '', sanitize_text_field( $host ) ) );
+
+	return rtrim( $host, '.' );
+}
+
+/**
+ * Reject common scanner targets and encoded form/payload paths.
+ *
+ * @param string $path URL path.
+ * @return bool
+ */
+function extrachill_api_is_unsafe_telemetry_path( $path ) {
+	$decoded = extrachill_api_decode_telemetry_value( $path );
+	if ( preg_match( '/[\x00-\x1F\x7F]/', $decoded ) ) {
+		return true;
+	}
+
+	return (bool) preg_match(
+		'#(?:^|/)(?:\.env|\.git|wp-admin|wp-login\.php|xmlrpc\.php|phpmyadmin|vendor/phpunit|cgi-bin|actuator)(?:/|$)#i',
+		$decoded
+	) || (bool) preg_match( '/(?:password|passwd|access_token|authorization|session(?:id)?|api[_-]?key)\s*[=:]/i', $decoded );
+}
+
+/**
+ * Detect query fields that must never enter analytics event data.
+ *
+ * @param string $key   Query field name.
+ * @param mixed  $value Query field value.
+ * @return bool
+ */
+function extrachill_api_is_sensitive_telemetry_field( $key, $value ) {
+	$key     = strtolower( extrachill_api_decode_telemetry_value( (string) $key ) );
+	$encoded = is_scalar( $value ) ? (string) $value : wp_json_encode( $value );
+	$value   = strtolower( extrachill_api_decode_telemetry_value( $encoded ) );
+
+	if ( preg_match( '/(?:^|[_-])(?:pass(?:word|wd)?|email|e-mail|user(?:name)?|login|auth(?:orization)?|token|secret|nonce|session(?:id)?|cookie|api[_-]?key|credit|card|cvv|ssn)(?:$|[_-])/i', $key ) ) {
+		return true;
+	}
+
+	return (bool) preg_match( '/["\'{&?](?:pass(?:word|wd)?|email|authorization|token|secret|session(?:id)?|api[_-]?key)["\'}\s]*[=:]/i', $value );
+}
+
+/**
+ * Decode nested URL encoding without allowing unbounded work.
+ *
+ * @param string $value Encoded value.
+ * @return string
+ */
+function extrachill_api_decode_telemetry_value( $value ) {
+	for ( $i = 0; $i < 3; $i++ ) {
+		$decoded = rawurldecode( $value );
+		if ( $decoded === $value ) {
+			break;
+		}
+		$value = $decoded;
+	}
+
+	return $value;
+}
+
+/**
+ * Validate bounded free-text dimensions before forwarding them.
+ *
+ * @param string $value Client text dimension.
+ * @return bool
+ */
+function extrachill_api_is_safe_telemetry_text( $value ) {
+	if ( strlen( $value ) > 200 ) {
+		return false;
+	}
+
+	$decoded = extrachill_api_decode_telemetry_value( $value );
+
+	return ! preg_match( '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F{}<>]/', $decoded )
+		&& ! preg_match( '/(?:password|passwd|authorization|access_token|session(?:id)?|api[_-]?key)\s*[=:]/i', $decoded );
+}
+
+/**
+ * Apply a fixed-window per-client cap to public telemetry writes.
+ *
+ * @return true|WP_Error
+ */
+function extrachill_api_check_telemetry_rate_limit() {
+	$limit = (int) apply_filters( 'extrachill_api_telemetry_rate_limit', 240 );
+	if ( $limit < 1 ) {
+		return true;
+	}
+
+	$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+	if ( '' === $ip || false === filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+		return true;
+	}
+
+	$key   = 'ec_api_tel_' . substr( hash_hmac( 'sha256', $ip, wp_salt( 'nonce' ) ), 0, 32 );
+	$count = (int) get_transient( $key );
+	if ( $count >= $limit ) {
+		return new WP_Error(
+			'telemetry_rate_limited',
+			'Too many telemetry requests.',
+			array( 'status' => 429 )
+		);
+	}
+
+	set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
+
+	return true;
+}

--- a/tests/Unit/routes/analytics/TelemetryValidationTest.php
+++ b/tests/Unit/routes/analytics/TelemetryValidationTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Tests for the public telemetry adapter trust boundary.
+ *
+ * @package ExtraChill\API\Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__, 4 ) . '/inc/routes/analytics/telemetry-validation.php';
+
+/**
+ * Exercises sanitized request fixtures without asserting Analytics semantics.
+ */
+class TelemetryValidationTest extends TestCase {
+	/**
+	 * Disable IP admission state for deterministic validation fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$_SERVER['HTTP_HOST'] = wp_parse_url( home_url(), PHP_URL_HOST );
+		unset( $_SERVER['REMOTE_ADDR'] );
+	}
+
+	/**
+	 * First-party beacon sources become query-free paths.
+	 */
+	public function test_valid_beacon_normalizes_source_to_path() {
+		$request = new WP_REST_Request( 'POST', '/extrachill/v1/analytics/click' );
+		$request->set_param( 'source_url', home_url( '/features/story/?utm_source=bridge&email=reader%40example.test' ) );
+		$request->set_header( 'origin', home_url() );
+
+		$source = extrachill_api_validate_telemetry_request( $request );
+
+		$this->assertIsArray( $source );
+		$this->assertSame( '/features/story/', $source['path'] );
+	}
+
+	/**
+	 * A supplied browser origin cannot contradict the claimed source.
+	 */
+	public function test_cross_origin_spoofing_is_rejected() {
+		$request = new WP_REST_Request( 'POST', '/extrachill/v1/analytics/impression' );
+		$request->set_param( 'source_url', home_url( '/story/' ) );
+		$request->set_header( 'origin', 'https://attacker.example' );
+
+		$result = extrachill_api_validate_telemetry_request( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_telemetry_origin', $result->get_error_code() );
+	}
+
+	/**
+	 * Sensitive query fields are removed while benign affiliate data remains.
+	 */
+	public function test_destination_query_pii_is_removed() {
+		$result = extrachill_api_normalize_telemetry_destination(
+			'https://tickets.example/show?affiliate=extrachill&email=reader%40example.test&access_token=secret'
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'https://tickets.example/show?affiliate=extrachill', $result['url'] );
+	}
+
+	/**
+	 * Encoded credential-shaped values do not survive under generic field names.
+	 */
+	public function test_encoded_payload_query_is_removed() {
+		$result = extrachill_api_normalize_telemetry_destination(
+			'https://artist.example/listen?payload=%257B%2522password%2522%253A%2522redacted%2522%257D&campaign=summer'
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'https://artist.example/listen?campaign=summer', $result['url'] );
+	}
+
+	/**
+	 * Scanner destinations are rejected rather than retained as click evidence.
+	 *
+	 * @dataProvider scanner_destination_provider
+	 * @param string $url Scanner URL fixture.
+	 */
+	public function test_scanner_destinations_are_rejected( $url ) {
+		$result = extrachill_api_normalize_telemetry_destination( $url );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'unsafe_destination_url', $result->get_error_code() );
+	}
+
+	/**
+	 * Scanner URL fixtures.
+	 *
+	 * @return array
+	 */
+	public function scanner_destination_provider() {
+		return array(
+			'login probe'   => array( 'https://scanner.example/wp-login.php' ),
+			'env probe'     => array( 'https://scanner.example/%252eenv' ),
+			'encoded form'  => array( 'https://scanner.example/collect%253Fpassword%253Dredacted' ),
+			'phpunit probe' => array( 'https://scanner.example/vendor/phpunit/' ),
+		);
+	}
+
+	/**
+	 * Older same-site clients that send a relative source remain valid.
+	 */
+	public function test_relative_source_remains_compatible() {
+		$result = extrachill_api_normalize_telemetry_source( '/archive/page/2/?ref=legacy' );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( '/archive/page/2/', $result['path'] );
+	}
+
+	/**
+	 * Outbound compatibility derives a host when legacy clients omit dest_host.
+	 */
+	public function test_outbound_route_keeps_dest_host_optional() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source contract fixture.
+		$source = file_get_contents( dirname( __DIR__, 4 ) . '/inc/routes/analytics/click.php' );
+
+		$this->assertNotFalse( $source );
+		$this->assertStringContainsString( '$dest_host = $destination[\'host\'];', $source );
+		$this->assertStringNotContainsString( 'dest_host or destination_url is required', $source );
+	}
+
+	/**
+	 * Internal subdomains cannot be relabeled as outbound destinations.
+	 */
+	public function test_network_subdomain_is_not_outbound() {
+		$this->assertTrue( extrachill_api_is_network_telemetry_host( 'media.extrachill.com', array( 'extrachill.com' ) ) );
+		$this->assertFalse( extrachill_api_is_network_telemetry_host( 'extrachill.example', array( 'extrachill.com' ) ) );
+	}
+}


### PR DESCRIPTION
## Summary
- enforce a first-party request trust boundary for public click and impression adapters before forwarding the existing Analytics-owned event contract
- normalize source URLs to query-free paths, derive outbound hosts from sanitized destination URLs, and strip credential/PII-shaped query fields
- reject origin/source mismatches, source/destination dimension conflicts, internal destinations labeled outbound, encoded payloads, scanner paths, and oversized text while applying a bounded per-client write limit

## Trust boundary
Extra Chill API validates HTTP input only. Event names, payload semantics, identity, classification, and persistence remain owned by `extrachill/track-analytics-event` in Extra Chill Analytics, coordinated conceptually with Extra-Chill/extrachill-analytics#184.

Accepted shapes include first-party absolute or legacy relative source URLs, supported mapped/custom first-party hosts, bridge beacons with valid network dimensions, and outbound beacons whose optional `dest_host` is absent or agrees with `destination_url`.

Rejected shapes include cross-origin source spoofing, mismatched source/destination dimensions, network destinations mislabeled as outbound, scanner targets, credential-shaped text or encoded paths, and outbound host claims that disagree with the canonical destination URL. Sensitive destination query fields are removed while benign affiliate/campaign fields remain.

## Compatibility
- response bodies remain `{ \"recorded\": true }` for accepted writes and existing `WP_Error` REST responses for rejected writes
- missing legacy `source_site` is derived when the network helper is available
- missing legacy `dest_host` remains supported because the host is derived from `destination_url`
- custom/mapped first-party domains remain accepted through current-site URLs, the network domain map, and WordPress site resolution

## Tests
- PHPUnit: telemetry validation fixtures, 11 tests / 23 assertions
- PHPUnit: outbound identity regression, 4 tests / 13 assertions
- focused PHPCS on changed production files
- telemetry fixture test-file lint
- PHP syntax checks on all changed PHP files
- worktree REST registration/schema smoke for both routes
- WordPress-runtime normalization smoke
- `git diff --check`

Closes #115