### PR TITLE
feat: expose concert privacy settings

### DIFF
--- a/inc/routes/users/settings.php
+++ b/inc/routes/users/settings.php
@@ -18,6 +18,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_user_settings_routes' );
 
+/**
+ * Register account settings routes.
+ */
 function extrachill_api_register_user_settings_routes() {
 	// Settings (GET + POST).
 	register_rest_route(
@@ -34,28 +37,38 @@ function extrachill_api_register_user_settings_routes() {
 				'callback'            => 'extrachill_api_user_settings_update',
 				'permission_callback' => 'extrachill_api_user_settings_permission',
 				'args'                => array(
-					'first_name'             => array(
+					'first_name'                  => array(
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'last_name'              => array(
+					'last_name'                   => array(
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'display_name'           => array(
+					'display_name'                => array(
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'local_scene'            => array(
+					'local_scene'                 => array(
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_title',
 					),
-					'local_scene_visibility' => array(
+					'local_scene_visibility'      => array(
 						'type'              => 'string',
 						'enum'              => array( 'public', 'private' ),
 						'sanitize_callback' => 'sanitize_key',
 					),
-					'default_event_location' => array(
+					'concert_history_visibility'  => array(
+						'type'              => 'string',
+						'enum'              => array( 'public', 'private' ),
+						'sanitize_callback' => 'sanitize_key',
+					),
+					'event_attendance_visibility' => array(
+						'type'              => 'string',
+						'enum'              => array( 'public', 'private' ),
+						'sanitize_callback' => 'sanitize_key',
+					),
+					'default_event_location'      => array(
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_title',
 					),
@@ -110,8 +123,13 @@ function extrachill_api_register_user_settings_routes() {
 
 /**
  * Permission check — must be logged in.
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return true|WP_Error
  */
 function extrachill_api_user_settings_permission( WP_REST_Request $request ) {
+	unset( $request );
+
 	if ( ! is_user_logged_in() ) {
 		return new WP_Error(
 			'rest_forbidden',
@@ -124,15 +142,20 @@ function extrachill_api_user_settings_permission( WP_REST_Request $request ) {
 
 /**
  * GET /users/me/settings
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_user_settings_get( WP_REST_Request $request ) {
+	unset( $request );
+
 	$ability = wp_get_ability( 'extrachill/get-user-settings' );
 
 	if ( ! $ability ) {
 		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$result = $ability->execute( array( 'user_id' => get_current_user_id() ) );
+	$result = $ability->execute( array() );
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
@@ -143,6 +166,9 @@ function extrachill_api_user_settings_get( WP_REST_Request $request ) {
 
 /**
  * POST /users/me/settings
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_user_settings_update( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/update-user-settings' );
@@ -151,9 +177,9 @@ function extrachill_api_user_settings_update( WP_REST_Request $request ) {
 		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$input = array( 'user_id' => get_current_user_id() );
+	$input = array();
 
-	$fields = array( 'first_name', 'last_name', 'display_name', 'local_scene', 'local_scene_visibility', 'default_event_location' );
+	$fields = array( 'first_name', 'last_name', 'display_name', 'local_scene', 'local_scene_visibility', 'concert_history_visibility', 'event_attendance_visibility', 'default_event_location' );
 	foreach ( $fields as $field ) {
 		if ( null !== $request->get_param( $field ) ) {
 			$input[ $field ] = $request->get_param( $field );
@@ -171,6 +197,9 @@ function extrachill_api_user_settings_update( WP_REST_Request $request ) {
 
 /**
  * POST /users/me/email
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_user_email_change( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/change-user-email' );
@@ -195,6 +224,9 @@ function extrachill_api_user_email_change( WP_REST_Request $request ) {
 
 /**
  * POST /users/me/password
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response|WP_Error
  */
 function extrachill_api_user_password_change( WP_REST_Request $request ) {
 	$ability = wp_get_ability( 'extrachill/change-user-password' );

--- a/tests/Unit/routes/events/ConcertTrackingRoutesTest.php
+++ b/tests/Unit/routes/events/ConcertTrackingRoutesTest.php
@@ -10,16 +10,39 @@
  */
 class Concert_Tracking_RoutesTest extends WP_UnitTestCase {
 
-	/** @var array<int, array<string, mixed>> */
+	/**
+	 * History ability inputs.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
 	private $history_inputs = array();
 
-	/** @var array<int, array<string, mixed>> */
+	/**
+	 * Attendance ability inputs.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
 	private $attendance_inputs = array();
 
-	/** @var bool */
+	/**
+	 * Stats ability inputs.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private $stats_inputs = array();
+
+	/**
+	 * Whether the test registered its ability category.
+	 *
+	 * @var bool
+	 */
 	private $registered_category = false;
 
-	/** @var string[] */
+	/**
+	 * Ability names registered by the test.
+	 *
+	 * @var string[]
+	 */
 	private $registered_abilities = array();
 
 	/**
@@ -62,6 +85,16 @@ class Concert_Tracking_RoutesTest extends WP_UnitTestCase {
 			),
 			array( $this, 'execute_attendance' )
 		);
+		$this->register_test_ability(
+			'extrachill/get-user-concert-stats',
+			array(
+				'user_id'   => array( 'type' => 'integer' ),
+				'year'      => array( 'type' => 'integer' ),
+				'date_from' => array( 'type' => 'string' ),
+				'date_to'   => array( 'type' => 'string' ),
+			),
+			array( $this, 'execute_stats' )
+		);
 
 		do_action( 'rest_api_init' );
 	}
@@ -84,8 +117,8 @@ class Concert_Tracking_RoutesTest extends WP_UnitTestCase {
 	 * Route schemas mirror the canonical Users bounds without coercive sanitizers.
 	 */
 	public function test_route_schemas_mirror_canonical_bounds() {
-		$routes = rest_get_server()->get_routes();
-		$history_schema = $routes['/extrachill/v1/concert-tracking/user/(?P<user_id>\d+)/shows'][0]['args']['per_page'];
+		$routes          = rest_get_server()->get_routes();
+		$history_schema  = $routes['/extrachill/v1/concert-tracking/user/(?P<user_id>\d+)/shows'][0]['args']['per_page'];
 		$attendee_schema = $routes['/extrachill/v1/concert-tracking/event/(?P<event_id>\d+)'][0]['args']['limit'];
 
 		$this->assertSame( array( 1, 20, 100 ), array( $history_schema['minimum'], $history_schema['default'], $history_schema['maximum'] ) );
@@ -99,7 +132,7 @@ class Concert_Tracking_RoutesTest extends WP_UnitTestCase {
 	 */
 	public function test_history_route_forwards_default_minimum_and_maximum() {
 		foreach ( array( null, 1, 100 ) as $per_page ) {
-			$params = null === $per_page ? array() : array( 'per_page' => $per_page );
+			$params   = null === $per_page ? array() : array( 'per_page' => $per_page );
 			$response = $this->dispatch( '/extrachill/v1/concert-tracking/user/7/shows', $params );
 
 			$this->assertSame( 200, $response->get_status() );
@@ -131,7 +164,7 @@ class Concert_Tracking_RoutesTest extends WP_UnitTestCase {
 	 */
 	public function test_history_route_rejects_invalid_values_before_ability( $value ) {
 		$calls_before = count( $this->history_inputs );
-		$response = $this->dispatch(
+		$response     = $this->dispatch(
 			'/extrachill/v1/concert-tracking/user/7/shows',
 			array( 'per_page' => $value )
 		);
@@ -149,7 +182,7 @@ class Concert_Tracking_RoutesTest extends WP_UnitTestCase {
 	 */
 	public function test_attendance_route_rejects_invalid_values_before_ability( $value ) {
 		$calls_before = count( $this->attendance_inputs );
-		$response = $this->dispatch(
+		$response     = $this->dispatch(
 			'/extrachill/v1/concert-tracking/event/42',
 			array(
 				'include_attendees' => true,
@@ -160,6 +193,76 @@ class Concert_Tracking_RoutesTest extends WP_UnitTestCase {
 		$this->assertSame( 400, $response->get_status() );
 		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] );
 		$this->assertCount( $calls_before, $this->attendance_inputs );
+	}
+
+	/**
+	 * Private-history errors retain the canonical code and HTTP status.
+	 *
+	 * @dataProvider private_history_route_provider
+	 * @param string $route Private history or stats route.
+	 */
+	public function test_private_history_errors_propagate_unchanged( $route ) {
+		$response = $this->dispatch( $route, array() );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'concert_history_private', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Private-history route paths.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function private_history_route_provider() {
+		return array(
+			'history' => array( '/extrachill/v1/concert-tracking/user/99/shows' ),
+			'stats'   => array( '/extrachill/v1/concert-tracking/user/99/stats' ),
+		);
+	}
+
+	/**
+	 * Public history remains ability-owned and past-only through the wrapper.
+	 */
+	public function test_public_history_is_past_only_without_wrapper_policy() {
+		$response = $this->dispatch(
+			'/extrachill/v1/concert-tracking/user/8/shows',
+			array( 'period' => 'all' )
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'all', end( $this->history_inputs )['period'] );
+		$this->assertSame( array( 'Past Show' ), wp_list_pluck( $response->get_data()['shows'], 'title' ) );
+	}
+
+	/**
+	 * Public stats remain ability-owned and past-only through the wrapper.
+	 */
+	public function test_public_stats_are_past_only_without_wrapper_policy() {
+		$response = $this->dispatch(
+			'/extrachill/v1/concert-tracking/user/8/stats',
+			array( 'date_to' => '2099-12-31' )
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( '2099-12-31', end( $this->stats_inputs )['date_to'] );
+		$this->assertSame( 'past', $response->get_data()['latest_show']['timing'] );
+	}
+
+	/**
+	 * Filtered attendee identities do not alter aggregate counts or owner state.
+	 */
+	public function test_attendee_filtering_preserves_count_parity() {
+		$response = $this->dispatch(
+			'/extrachill/v1/concert-tracking/event/77',
+			array( 'include_attendees' => true )
+		);
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 3, $data['count'] );
+		$this->assertCount( 2, $data['attendees'] );
+		$this->assertTrue( $data['user_marked'] );
+		$this->assertSame( '3 were there', $data['count_label'] );
 	}
 
 	/**
@@ -181,10 +284,27 @@ class Concert_Tracking_RoutesTest extends WP_UnitTestCase {
 	 * Controlled history ability callback.
 	 *
 	 * @param array $input Ability input.
-	 * @return array
+	 * @return array|WP_Error
 	 */
 	public function execute_history( array $input ) {
 		$this->history_inputs[] = $input;
+		if ( 99 === $input['user_id'] ) {
+			return new WP_Error( 'concert_history_private', 'This concert history is private.', array( 'status' => 403 ) );
+		}
+		if ( 8 === $input['user_id'] ) {
+			return array(
+				'shows'    => array(
+					array(
+						'title'  => 'Past Show',
+						'timing' => 'past',
+					),
+				),
+				'total'    => 1,
+				'pages'    => 1,
+				'page'     => $input['page'],
+				'per_page' => $input['per_page'],
+			);
+		}
 
 		return array(
 			'shows'    => array(),
@@ -203,6 +323,25 @@ class Concert_Tracking_RoutesTest extends WP_UnitTestCase {
 	 */
 	public function execute_attendance( array $input ) {
 		$this->attendance_inputs[] = $input;
+		if ( 77 === $input['event_id'] ) {
+			return array(
+				'count'       => 3,
+				'count_label' => '3 were there',
+				'timing'      => 'past',
+				'user_marked' => true,
+				'attendees'   => array(
+					array(
+						'user_id'      => 1,
+						'display_name' => 'Public One',
+					),
+					array(
+						'user_id'      => 3,
+						'display_name' => 'Public Two',
+					),
+				),
+				'limit'       => $input['limit'],
+			);
+		}
 
 		return array(
 			'count'       => 0,
@@ -212,6 +351,30 @@ class Concert_Tracking_RoutesTest extends WP_UnitTestCase {
 			'attendees'   => array(),
 			'limit'       => $input['limit'],
 		);
+	}
+
+	/**
+	 * Controlled stats ability callback.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|WP_Error
+	 */
+	public function execute_stats( array $input ) {
+		$this->stats_inputs[] = $input;
+		if ( 99 === $input['user_id'] ) {
+			return new WP_Error( 'concert_history_private', 'This concert history is private.', array( 'status' => 403 ) );
+		}
+		if ( 8 === $input['user_id'] ) {
+			return array(
+				'total_shows' => 1,
+				'latest_show' => array(
+					'title'  => 'Past Show',
+					'timing' => 'past',
+				),
+			);
+		}
+
+		return array( 'total_shows' => 1 );
 	}
 
 	/**

--- a/tests/Unit/routes/users/UserSettingsPrivacyRoutesTest.php
+++ b/tests/Unit/routes/users/UserSettingsPrivacyRoutesTest.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * REST transport tests for Users-owned concert privacy settings.
+ *
+ * @package ExtraChill\API\Tests
+ */
+
+/**
+ * Exercises schema, authentication, and canonical ability forwarding.
+ */
+class User_Settings_Privacy_RoutesTest extends WP_UnitTestCase {
+
+	/**
+	 * Canonical settings state by user ID.
+	 *
+	 * @var array<int, array<string, string>>
+	 */
+	private $settings_by_user = array();
+
+	/**
+	 * Inputs received by the get-settings ability.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private $get_inputs = array();
+
+	/**
+	 * Inputs received by the update-settings ability.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private $update_inputs = array();
+
+	/**
+	 * Whether the test registered its ability category.
+	 *
+	 * @var bool
+	 */
+	private $registered_category = false;
+
+	/**
+	 * Ability names registered by the test.
+	 *
+	 * @var string[]
+	 */
+	private $registered_abilities = array();
+
+	/**
+	 * Register controlled canonical settings abilities.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$category_registry = WP_Ability_Categories_Registry::get_instance();
+		if ( ! wp_has_ability_category( 'extrachill-api-settings-tests' ) ) {
+			$category_registry->register(
+				'extrachill-api-settings-tests',
+				array(
+					'label'       => 'Extra Chill API Settings Tests',
+					'description' => 'Controlled abilities for settings adapter tests.',
+				)
+			);
+			$this->registered_category = true;
+		}
+
+		$properties = array(
+			'concert_history_visibility'  => array(
+				'type' => 'string',
+				'enum' => array( 'public', 'private' ),
+			),
+			'event_attendance_visibility' => array(
+				'type' => 'string',
+				'enum' => array( 'public', 'private' ),
+			),
+		);
+		$this->register_test_ability( 'extrachill/get-user-settings', array(), array( $this, 'execute_get_settings' ) );
+		$this->register_test_ability( 'extrachill/update-user-settings', $properties, array( $this, 'execute_update_settings' ) );
+
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Remove test registry entries and authentication state.
+	 */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+		foreach ( $this->registered_abilities as $ability_name ) {
+			wp_unregister_ability( $ability_name );
+		}
+		if ( $this->registered_category ) {
+			wp_unregister_ability_category( 'extrachill-api-settings-tests' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Both settings round-trip through POST and GET route dispatch.
+	 */
+	public function test_privacy_settings_round_trip() {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+
+		$update = $this->dispatch(
+			'POST',
+			array(
+				'concert_history_visibility'  => 'private',
+				'event_attendance_visibility' => 'private',
+			)
+		);
+		$this->assertSame( 200, $update->get_status() );
+		$this->assertSame( $user_id, $update->get_data()['user_id'] );
+		$this->assertSame( 'private', $update->get_data()['concert_history_visibility'] );
+		$this->assertSame( 'private', $update->get_data()['event_attendance_visibility'] );
+
+		$read = $this->dispatch( 'GET', array() );
+		$this->assertSame( 200, $read->get_status() );
+		$this->assertSame( $update->get_data(), $read->get_data() );
+	}
+
+	/**
+	 * REST schema rejects invalid visibility before canonical execution.
+	 *
+	 * @dataProvider invalid_visibility_provider
+	 * @param string $field Settings field.
+	 */
+	public function test_invalid_visibility_is_rejected( $field ) {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		$response = $this->dispatch( 'POST', array( $field => 'friends' ) );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertSame( 'public', $this->get_user_settings( $user_id )[ $field ] );
+		$this->assertEmpty( $this->update_inputs );
+	}
+
+	/**
+	 * A supplied user ID cannot redirect an update to another account.
+	 */
+	public function test_supplied_user_id_cannot_modify_another_account() {
+		$actor_id  = self::factory()->user->create();
+		$target_id = self::factory()->user->create();
+		wp_set_current_user( $actor_id );
+
+		$response = $this->dispatch(
+			'POST',
+			array(
+				'user_id'                    => $target_id,
+				'concert_history_visibility' => 'private',
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $actor_id, $response->get_data()['user_id'] );
+		$this->assertSame(
+			array( 'concert_history_visibility' => 'private' ),
+			end( $this->update_inputs )
+		);
+		$this->assertArrayNotHasKey( 'user_id', end( $this->update_inputs ) );
+		$this->assertSame( 'private', $this->get_user_settings( $actor_id )['concert_history_visibility'] );
+		$this->assertSame( 'public', $this->get_user_settings( $target_id )['concert_history_visibility'] );
+	}
+
+	/**
+	 * A supplied user ID cannot redirect a settings read to another account.
+	 */
+	public function test_supplied_user_id_cannot_read_another_account() {
+		$private_user_id = self::factory()->user->create();
+		$actor_id        = self::factory()->user->create();
+
+		$this->settings_by_user[ $private_user_id ] = array(
+			'concert_history_visibility'  => 'private',
+			'event_attendance_visibility' => 'private',
+		);
+		wp_set_current_user( $actor_id );
+
+		$response = $this->dispatch( 'GET', array( 'user_id' => $private_user_id ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $actor_id, $response->get_data()['user_id'] );
+		$this->assertSame( 'public', $response->get_data()['concert_history_visibility'] );
+		$this->assertSame( 'public', $response->get_data()['event_attendance_visibility'] );
+		$this->assertSame( array(), end( $this->get_inputs ) );
+	}
+
+	/**
+	 * Visibility fields rejected by schema.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function invalid_visibility_provider() {
+		return array(
+			'concert history'  => array( 'concert_history_visibility' ),
+			'event attendance' => array( 'event_attendance_visibility' ),
+		);
+	}
+
+	/**
+	 * Logged-out callers cannot read or update account settings.
+	 *
+	 * @dataProvider settings_method_provider
+	 * @param string $method HTTP method.
+	 */
+	public function test_settings_require_authentication( $method ) {
+		$response = $this->dispatch( $method, array( 'concert_history_visibility' => 'private' ) );
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Settings route methods.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function settings_method_provider() {
+		return array(
+			'get'  => array( 'GET' ),
+			'post' => array( 'POST' ),
+		);
+	}
+
+	/**
+	 * Return controlled settings.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string, int|string>
+	 */
+	public function execute_get_settings( array $input ) {
+		$this->get_inputs[] = $input;
+
+		return array_merge(
+			array( 'user_id' => get_current_user_id() ),
+			$this->get_user_settings( get_current_user_id() )
+		);
+	}
+
+	/**
+	 * Update controlled settings and return their canonical representation.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string, int|string>
+	 */
+	public function execute_update_settings( array $input ) {
+		$this->update_inputs[] = $input;
+		$user_id               = get_current_user_id();
+		$settings              = $this->get_user_settings( $user_id );
+		foreach ( array_keys( $settings ) as $field ) {
+			if ( isset( $input[ $field ] ) ) {
+				$settings[ $field ] = $input[ $field ];
+			}
+		}
+		$this->settings_by_user[ $user_id ] = $settings;
+
+		return array_merge( array( 'user_id' => $user_id ), $settings );
+	}
+
+	/**
+	 * Get deterministic canonical settings for a test user.
+	 *
+	 * @param int $user_id User ID.
+	 * @return array<string, string>
+	 */
+	private function get_user_settings( $user_id ) {
+		if ( ! isset( $this->settings_by_user[ $user_id ] ) ) {
+			$this->settings_by_user[ $user_id ] = array(
+				'concert_history_visibility'  => 'public',
+				'event_attendance_visibility' => 'public',
+			);
+		}
+
+		return $this->settings_by_user[ $user_id ];
+	}
+
+	/**
+	 * Register a controlled ability directly in the initialized registry.
+	 *
+	 * @param string   $name Ability name.
+	 * @param array    $properties Input properties.
+	 * @param callable $callback Execute callback.
+	 */
+	private function register_test_ability( $name, array $properties, $callback ) {
+		if ( wp_has_ability( $name ) ) {
+			$this->fail( 'Unexpected ability dependency already registered: ' . $name );
+		}
+
+		$ability = WP_Abilities_Registry::get_instance()->register(
+			$name,
+			array(
+				'label'               => 'Test ' . $name,
+				'description'         => 'Controlled ability for API settings transport tests.',
+				'category'            => 'extrachill-api-settings-tests',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => $properties,
+				),
+				'execute_callback'    => $callback,
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Ability::class, $ability );
+		$this->registered_abilities[] = $name;
+	}
+
+	/**
+	 * Dispatch a settings request through the actual REST namespace.
+	 *
+	 * @param string $method HTTP method.
+	 * @param array  $params Request body parameters.
+	 * @return WP_REST_Response
+	 */
+	private function dispatch( $method, array $params ) {
+		$request = new WP_REST_Request( $method, '/extrachill/v1/users/me/settings' );
+		if ( 'GET' === $method ) {
+			$request->set_query_params( $params );
+		} else {
+			$request->set_body_params( $params );
+		}
+
+		return rest_do_request( $request );
+	}
+}

--- a/tests/unit/UserLocalSceneAdaptersTest.php
+++ b/tests/unit/UserLocalSceneAdaptersTest.php
@@ -33,7 +33,7 @@ class UserLocalSceneAdaptersTest extends TestCase {
 		$source = file_get_contents( dirname( __DIR__, 2 ) . '/inc/routes/users/settings.php' );
 
 		$this->assertStringContainsString(
-			"array( 'first_name', 'last_name', 'display_name', 'local_scene', 'local_scene_visibility', 'default_event_location' )",
+			"array( 'first_name', 'last_name', 'display_name', 'local_scene', 'local_scene_visibility', 'concert_history_visibility', 'event_attendance_visibility', 'default_event_location' )",
 			$source
 		);
 	}


### PR DESCRIPTION
## Summary
- expose both visibility fields through the self-only settings adapter
- forward only declared ability inputs and ignore supplied user IDs
- preserve canonical private-history 403 responses
- add real REST route privacy and isolation coverage

## Verification
- PHPCS and PHP syntax passed
- diff checks passed
- final independent review: merge

Depends on the Extra Chill Users privacy contract.