### PR TITLE
Fix onboarding without a Local Scene

### DIFF
--- a/inc/routes/users/onboarding.php
+++ b/inc/routes/users/onboarding.php
@@ -107,16 +107,19 @@ function extrachill_api_onboarding_post_handler( WP_REST_Request $request ) {
 		return new WP_Error( 'ability_not_found', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$result = $ability->execute(
-		array(
-			'user_id'                => get_current_user_id(),
-			'username'               => $request->get_param( 'username' ),
-			'user_is_artist'         => $request->get_param( 'user_is_artist' ),
-			'user_is_professional'   => $request->get_param( 'user_is_professional' ),
-			'local_scene_visibility' => $request->get_param( 'local_scene_visibility' ),
-			'local_scene'            => $request->get_param( 'local_scene' ),
-		)
+	$input = array(
+		'user_id'                => get_current_user_id(),
+		'username'               => $request->get_param( 'username' ),
+		'user_is_artist'         => $request->get_param( 'user_is_artist' ),
+		'user_is_professional'   => $request->get_param( 'user_is_professional' ),
+		'local_scene_visibility' => $request->get_param( 'local_scene_visibility' ),
 	);
+	$local_scene = $request->get_param( 'local_scene' );
+	if ( is_string( $local_scene ) && '' !== $local_scene ) {
+		$input['local_scene'] = $local_scene;
+	}
+
+	$result = $ability->execute( $input );
 
 	if ( is_wp_error( $result ) ) {
 		return new WP_Error(

--- a/tests/unit/UserLocalSceneAdaptersTest.php
+++ b/tests/unit/UserLocalSceneAdaptersTest.php
@@ -60,4 +60,16 @@ class UserLocalSceneAdaptersTest extends TestCase {
 		$this->assertStringContainsString( "'local_city'", $source );
 		$this->assertStringContainsString( "\$input['local_city']", $source );
 	}
+
+	/**
+	 * Optional onboarding scenes are omitted instead of forwarded as null.
+	 */
+	public function test_onboarding_adapter_only_forwards_a_supplied_local_scene() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local fixture.
+		$source = file_get_contents( dirname( __DIR__, 2 ) . '/inc/routes/users/onboarding.php' );
+
+		$this->assertStringContainsString( "is_string( \$local_scene ) && '' !== \$local_scene", $source );
+		$this->assertStringContainsString( "\$input['local_scene'] = \$local_scene", $source );
+		$this->assertStringNotContainsString( "'local_scene'            => \$request->get_param( 'local_scene' )", $source );
+	}
 }


### PR DESCRIPTION
## Summary
- omit `local_scene` from the Users ability input when the optional field was not supplied
- preserve strict ability validation and continue forwarding valid scene slugs
- add the adapter contract to the existing Local Scene unit suite

The browser correctly omits an empty optional Local Scene. The API adapter previously converted that omission into `null`, causing the strict `extrachill/complete-onboarding` ability to reject every such request.

Fixes #126.

## Verification
- `vendor/bin/phpunit tests/unit/UserLocalSceneAdaptersTest.php` (5 tests, 13 assertions)
- production-shaped auth fuzz seed `auth-campaign-009`
- Homeboy run `abb23cc9-ff78-4870-8cac-3d8407a9f3ee`
- Homeboy audit/lint: 0 findings

Homeboy's generic PHPUnit runtime remains blocked by existing `Automattic/wp-codebox#1903`; the direct unit suite and full WP Codebox browser integration both pass.

## AI assistance
- **AI assistance:** Yes
- **Tool:** OpenCode with GPT-5.6 Sol
- **Used for:** Reproducing the onboarding failure through a real browser, isolating the adapter mismatch, implementing the fix, and verifying it.