### PR TITLE
fix: harden public REST input validation

### DIFF
--- a/inc/routes/auth/browser-handoff.php
+++ b/inc/routes/auth/browser-handoff.php
@@ -49,9 +49,10 @@ function extrachill_api_auth_browser_handoff_handler( WP_REST_Request $request )
 		return new WP_Error( 'missing_redirect_url', 'redirect_url is required.', array( 'status' => 400 ) );
 	}
 
-	$redirect_host = wp_parse_url( $redirect_url, PHP_URL_HOST );
-	if ( ! is_string( $redirect_host ) || '' === $redirect_host ) {
-		return new WP_Error( 'invalid_redirect_url', 'redirect_url must be an absolute URL.', array( 'status' => 400 ) );
+	$redirect_scheme = wp_parse_url( $redirect_url, PHP_URL_SCHEME );
+	$redirect_host   = wp_parse_url( $redirect_url, PHP_URL_HOST );
+	if ( 'https' !== $redirect_scheme || ! is_string( $redirect_host ) || '' === $redirect_host ) {
+		return new WP_Error( 'invalid_redirect_url', 'redirect_url must be an absolute HTTPS URL.', array( 'status' => 400 ) );
 	}
 
 	$redirect_host = strtolower( $redirect_host );

--- a/inc/routes/auth/register.php
+++ b/inc/routes/auth/register.php
@@ -32,6 +32,7 @@ function extrachill_api_register_auth_register_route() {
 					'required'          => true,
 					'type'              => 'string',
 					'format'            => 'email',
+					'maxLength'         => 254,
 					'validate_callback' => 'rest_validate_request_arg',
 					'sanitize_callback' => 'sanitize_email',
 				),

--- a/inc/routes/auth/register.php
+++ b/inc/routes/auth/register.php
@@ -32,6 +32,7 @@ function extrachill_api_register_auth_register_route() {
 					'required'          => true,
 					'type'              => 'string',
 					'format'            => 'email',
+					'validate_callback' => 'rest_validate_request_arg',
 					'sanitize_callback' => 'sanitize_email',
 				),
 				'password'             => array(

--- a/inc/routes/auth/register.php
+++ b/inc/routes/auth/register.php
@@ -31,7 +31,7 @@ function extrachill_api_register_auth_register_route() {
 				'email'                => array(
 					'required'          => true,
 					'type'              => 'string',
-					'validate_callback' => 'is_email',
+					'format'            => 'email',
 					'sanitize_callback' => 'sanitize_email',
 				),
 				'password'             => array(

--- a/inc/routes/contact/submit.php
+++ b/inc/routes/contact/submit.php
@@ -43,6 +43,7 @@ function extrachill_api_register_contact_submit_route() {
 					'required'          => true,
 					'type'              => 'string',
 					'format'            => 'email',
+					'validate_callback' => 'rest_validate_request_arg',
 					'sanitize_callback' => 'sanitize_email',
 				),
 				'subject'            => array(

--- a/inc/routes/contact/submit.php
+++ b/inc/routes/contact/submit.php
@@ -42,7 +42,7 @@ function extrachill_api_register_contact_submit_route() {
 				'email'              => array(
 					'required'          => true,
 					'type'              => 'string',
-					'validate_callback' => 'is_email',
+					'format'            => 'email',
 					'sanitize_callback' => 'sanitize_email',
 				),
 				'subject'            => array(

--- a/inc/routes/contact/submit.php
+++ b/inc/routes/contact/submit.php
@@ -43,6 +43,7 @@ function extrachill_api_register_contact_submit_route() {
 					'required'          => true,
 					'type'              => 'string',
 					'format'            => 'email',
+					'maxLength'         => 254,
 					'validate_callback' => 'rest_validate_request_arg',
 					'sanitize_callback' => 'sanitize_email',
 				),

--- a/inc/routes/content-blocks/image-voting-vote.php
+++ b/inc/routes/content-blocks/image-voting-vote.php
@@ -37,7 +37,7 @@ function extrachill_api_register_content_blocks_image_voting_vote_route() {
 				'email_address' => array(
 					'required'          => true,
 					'type'              => 'string',
-					'validate_callback' => 'is_email',
+					'format'            => 'email',
 					'sanitize_callback' => 'sanitize_email',
 				),
 			),

--- a/inc/routes/content-blocks/image-voting-vote.php
+++ b/inc/routes/content-blocks/image-voting-vote.php
@@ -38,6 +38,7 @@ function extrachill_api_register_content_blocks_image_voting_vote_route() {
 					'required'          => true,
 					'type'              => 'string',
 					'format'            => 'email',
+					'validate_callback' => 'rest_validate_request_arg',
 					'sanitize_callback' => 'sanitize_email',
 				),
 			),

--- a/inc/routes/content-blocks/image-voting-vote.php
+++ b/inc/routes/content-blocks/image-voting-vote.php
@@ -38,6 +38,7 @@ function extrachill_api_register_content_blocks_image_voting_vote_route() {
 					'required'          => true,
 					'type'              => 'string',
 					'format'            => 'email',
+					'maxLength'         => 254,
 					'validate_callback' => 'rest_validate_request_arg',
 					'sanitize_callback' => 'sanitize_email',
 				),


### PR DESCRIPTION
## Summary
- validate public email arguments through the native REST schema before scalar sanitizers run
- reject email inputs over 254 bytes across registration, contact, and image voting
- require absolute HTTPS Extra Chill destinations for browser handoff

## Evidence
- tracks #128
- WordPress 7.0.2 adversarial campaign: Homeboy run `064057b5-5e24-4232-9ae7-d768618da702`
- 83 backend assertions, both fail-closed browser scenarios, cross-site identity, and analytics checks passed
- PHP syntax checks passed for every changed route

No release or deployment performed.