### PR TITLE
fix: guard null route-affinity host normalization

### DIFF
--- a/inc/middleware/route-affinity.php
+++ b/inc/middleware/route-affinity.php
@@ -163,7 +163,7 @@ function extrachill_api_is_route_affinity_reentry( WP_REST_Request $request ) {
 
 	$timestamp = (int) $request->get_header( 'X-EC-Affinity-Timestamp' );
 	$signature = $request->get_header( 'X-EC-Affinity-Signature' );
-	$target    = strtolower( $request->get_header( 'X-EC-Affinity-Target' ) );
+	$target    = strtolower( (string) $request->get_header( 'X-EC-Affinity-Target' ) );
 	$nonce     = $request->get_header( 'X-EC-Affinity-Nonce' );
 	$host      = isset( $_SERVER['HTTP_HOST'] ) ? strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) ) : '';
 	if ( ! $timestamp || ! $signature || ! $target || ! $nonce || $target !== $host || abs( time() - $timestamp ) > 300 ) {

--- a/tests/Unit/middleware/RouteAffinityTest.php
+++ b/tests/Unit/middleware/RouteAffinityTest.php
@@ -138,6 +138,22 @@ class Route_AffinityTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A partial local token without a target host is safely rejected.
+	 */
+	public function test_local_reentry_without_target_host_is_rejected() {
+		$request                = new WP_REST_Request( 'GET', '/extrachill/v1/artists/42' );
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+		$_SERVER['HTTP_HOST']   = 'artist.example.com';
+
+		$request->set_header( 'X-EC-Affinity-Timestamp', (string) time() );
+		$request->set_header( 'X-EC-Affinity-Signature', str_repeat( 'b', 64 ) );
+		$request->set_header( 'X-EC-Affinity-Nonce', wp_generate_uuid4() );
+
+		$this->assertNull( $request->get_header( 'X-EC-Affinity-Target' ) );
+		$this->assert_reentry_rejected( $request );
+	}
+
+	/**
 	 * Signed tokens cannot be reused with altered query or body data.
 	 */
 	public function test_signature_rejects_altered_query_and_body() {


### PR DESCRIPTION
## Summary

- Normalize an absent `X-EC-Affinity-Target` header as an empty string before lowercasing it.
- Keep valid string host normalization and route-affinity signature behavior unchanged.
- Add regression coverage proving a partial local token with no target host is rejected without passing `null` to `strtolower()`.

## Production Signature

```text
[23-Jul-2026 23:45:42 UTC] PHP Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/extrachill.com/wp-content/plugins/extrachill-api/inc/middleware/route-affinity.php on line 166
```

## Root Cause

`WP_REST_Request::get_header()` returns `null` when `X-EC-Affinity-Target` is absent. The re-entry validator normalized that nullable value with `strtolower()` before its completeness check, triggering PHP's deprecation during ordinary requests without affinity headers.

## Fix Behavior

Casting the nullable header result to string turns an absent header into `''`, which follows the existing invalid-token path. Valid string targets are lowercased exactly as before.

## Tests

- `php -l inc/middleware/route-affinity.php` passed.
- `php -l tests/Unit/middleware/RouteAffinityTest.php` passed.
- `git diff --check` passed.
- Homeboy review audit passed with 0 findings.
- Homeboy review lint passed with 0 PHPCS, PHPStan, or ESLint findings.
- Homeboy PHPUnit selected `tests/Unit/middleware/RouteAffinityTest.php`, but the sandbox omitted the declared `extrachill-network` validation dependency. All existing route-affinity tests failed at the unchanged shared setup assertion because `ec_cross_site_rest_request()` was unavailable. Tracked in Extra-Chill/homeboy#9860. Review run: `2cbda190-e5f0-4779-8045-5cc542b1e01b`.

## Residual Risks

The change is limited to converting absent target headers from `null` to the empty value already rejected by the validator. Automated runtime execution of the focused regression remains blocked by the Homeboy dependency-hydration defect above; valid-host behavior remains covered by the existing route-affinity suite once that dependency loads.

Fixes #132