### PR TITLE
feat: add protected booking attachment downloads

### DIFF
--- a/inc/middleware/route-affinity.php
+++ b/inc/middleware/route-affinity.php
@@ -82,11 +82,13 @@ function extrachill_api_canonicalize_affinity_query( $query ) {
  * @param mixed  $body        Request body.
  * @param int    $timestamp   Unix timestamp.
  * @param string $nonce       Single-use nonce.
+ * @param array  $headers     Allowlisted forwarded headers.
  * @return string
  */
-function extrachill_api_route_affinity_payload( $method, $route, $target_host, $query, $body, $timestamp, $nonce ) {
-	$query_digest = hash( 'sha256', wp_json_encode( extrachill_api_canonicalize_affinity_query( $query ) ) );
-	$body_digest  = hash( 'sha256', wp_json_encode( extrachill_api_normalize_affinity_data( $body ) ) );
+function extrachill_api_route_affinity_payload( $method, $route, $target_host, $query, $body, $timestamp, $nonce, $headers = array() ) {
+	$query_digest  = hash( 'sha256', wp_json_encode( extrachill_api_canonicalize_affinity_query( $query ) ) );
+	$body_digest   = hash( 'sha256', wp_json_encode( extrachill_api_normalize_affinity_data( $body ) ) );
+	$header_digest = hash( 'sha256', wp_json_encode( extrachill_api_normalize_affinity_data( $headers ) ) );
 
 	return implode(
 		"\n",
@@ -96,10 +98,26 @@ function extrachill_api_route_affinity_payload( $method, $route, $target_host, $
 			strtolower( $target_host ),
 			$query_digest,
 			$body_digest,
+			$header_digest,
 			(string) $timestamp,
 			$nonce,
 		)
 	);
+}
+
+/** Return the only caller header permitted across route-affinity transport. */
+function extrachill_api_route_affinity_forwarded_headers( WP_REST_Request $request ) {
+	$headers = array();
+	if ( ! function_exists( 'extrachill_api_is_booking_attachment_download_route' ) || ! extrachill_api_is_booking_attachment_download_route( $request->get_route() ) ) {
+		return $headers;
+	}
+
+	$range = trim( (string) $request->get_header( 'Range' ) );
+	if ( '' !== $range ) {
+		$headers['range'] = $range;
+	}
+
+	return $headers;
 }
 
 /**
@@ -177,7 +195,8 @@ function extrachill_api_is_route_affinity_reentry( WP_REST_Request $request ) {
 		$request->get_query_params(),
 		extrachill_api_route_affinity_request_body( $request ),
 		$timestamp,
-		$nonce
+		$nonce,
+		extrachill_api_route_affinity_forwarded_headers( $request )
 	);
 	$expected = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
 	if ( ! hash_equals( $expected, $signature ) ) {
@@ -270,16 +289,20 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		return new WP_Error( 'route_affinity_target_invalid', 'Could not resolve route-affinity target host.', array( 'status' => 500 ) );
 	}
 
-	$timestamp       = time();
-	$nonce           = wp_generate_uuid4();
-	$payload         = extrachill_api_route_affinity_payload( $method, $route, $target_host, $query_params, $body, $timestamp, $nonce );
-	$signature       = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
-	$args['headers'] = array(
+	$forwarded_headers = extrachill_api_route_affinity_forwarded_headers( $request );
+	$timestamp         = time();
+	$nonce             = wp_generate_uuid4();
+	$payload           = extrachill_api_route_affinity_payload( $method, $route, $target_host, $query_params, $body, $timestamp, $nonce, $forwarded_headers );
+	$signature         = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
+	$args['headers']   = array(
 		'X-EC-Affinity-Timestamp' => (string) $timestamp,
 		'X-EC-Affinity-Signature' => $signature,
 		'X-EC-Affinity-Target'    => strtolower( $target_host ),
 		'X-EC-Affinity-Nonce'     => $nonce,
 	);
+	foreach ( $forwarded_headers as $name => $value ) {
+		$args['headers'][ $name ] = $value;
+	}
 
 	// Force HTTP loopback for affinity forwarding.
 	//
@@ -301,7 +324,30 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		return true;
 	};
 	$forwarded_http_response = null;
-	$capture_http_response   = static function ( $http_response, $http_args ) use ( &$forwarded_http_response, $signature ) {
+	$private_stream          = function_exists( 'extrachill_api_is_booking_attachment_download_route' ) && extrachill_api_is_booking_attachment_download_route( $route );
+	$private_spool           = null;
+	if ( $private_stream ) {
+		$private_spool = wp_tempnam( 'extrachill-private-download' );
+		if ( ! is_string( $private_spool ) || '' === $private_spool || ! chmod( $private_spool, 0600 ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- Private affinity spool must be process-only.
+			if ( is_string( $private_spool ) && file_exists( $private_spool ) ) {
+				unlink( $private_spool ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Avoid path-observing deletion hooks for private spools.
+			}
+			return extrachill_api_booking_attachment_download_error( 503 );
+		}
+	}
+	$stream_http_response  = static function ( $http_args ) use ( $signature, $private_spool ) {
+		$headers = $http_args['headers'] ?? array();
+		if ( null !== $private_spool && ( $headers['X-EC-Affinity-Signature'] ?? '' ) === $signature ) {
+			$http_args['stream']              = true;
+			$http_args['filename']            = $private_spool;
+			$http_args['limit_response_size'] = extrachill_api_booking_attachment_max_bytes() + 1;
+			$http_args['timeout']             = 30;
+			$http_args['headers']['Accept']   = 'application/octet-stream';
+		}
+
+		return $http_args;
+	};
+	$capture_http_response = static function ( $http_response, $http_args ) use ( &$forwarded_http_response, $signature ) {
 		$headers = $http_args['headers'] ?? array();
 		if ( ( $headers['X-EC-Affinity-Signature'] ?? '' ) === $signature && false !== $http_response ) {
 			$forwarded_http_response = $http_response;
@@ -310,18 +356,30 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		return $http_response;
 	};
 	add_filter( 'ec_cross_site_use_http_loopback', $force_http_loopback, 10, 0 );
+	add_filter( 'http_request_args', $stream_http_response, PHP_INT_MAX, 1 );
 	add_filter( 'pre_http_request', $capture_http_response, PHP_INT_MAX, 2 );
 	add_filter( 'http_response', $capture_http_response, PHP_INT_MAX, 2 );
 
 	try {
 		$response = ec_cross_site_rest_request( $target_site, $method, $path, $args );
+	} catch ( Throwable $throwable ) {
+		if ( $private_stream ) {
+			extrachill_api_discard_private_affinity_spool( $private_spool );
+			$response = extrachill_api_booking_attachment_download_error( 502 );
+		} else {
+			throw $throwable;
+		}
 	} finally {
 		remove_filter( 'ec_cross_site_use_http_loopback', $force_http_loopback, 10 );
+		remove_filter( 'http_request_args', $stream_http_response, PHP_INT_MAX );
 		remove_filter( 'pre_http_request', $capture_http_response, PHP_INT_MAX );
 		remove_filter( 'http_response', $capture_http_response, PHP_INT_MAX );
 	}
 
 	if ( is_array( $forwarded_http_response ) ) {
+		if ( $private_stream ) {
+			return extrachill_api_private_stream_from_affinity_response( $forwarded_http_response, $private_spool );
+		}
 		$status  = wp_remote_retrieve_response_code( $forwarded_http_response );
 		$headers = wp_remote_retrieve_headers( $forwarded_http_response );
 		$body    = wp_remote_retrieve_body( $forwarded_http_response );
@@ -339,6 +397,10 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 	}
 
 	if ( is_wp_error( $response ) ) {
+		if ( $private_stream ) {
+			extrachill_api_discard_private_affinity_spool( $private_spool );
+			return extrachill_api_booking_attachment_download_error( 502 );
+		}
 		$status = $response->get_error_data()['status'] ?? 500;
 		return new WP_REST_Response(
 			array(
@@ -348,6 +410,11 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 			),
 			$status
 		);
+	}
+
+	if ( $private_stream ) {
+		extrachill_api_discard_private_affinity_spool( $private_spool );
+		return extrachill_api_booking_attachment_download_error( 502 );
 	}
 
 	// Return the forwarded response.

--- a/inc/routes/events/booking-attachment-download.php
+++ b/inc/routes/events/booking-attachment-download.php
@@ -1,0 +1,490 @@
+<?php
+/**
+ * Protected booking attachment download transport.
+ *
+ * Events owns authorization, handoffs, private bytes, policy, and audit. This
+ * route only adapts those contracts to a bounded HTTP byte response.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Native resource streaming and unhooked spool deletion are required so private
+// bytes never enter WP_Filesystem buffers or path-observing deletion hooks.
+// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_fclose,WordPress.WP.AlternativeFunctions.file_system_operations_fopen,WordPress.WP.AlternativeFunctions.file_system_operations_fread,WordPress.WP.AlternativeFunctions.unlink_unlink
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_booking_attachment_download_route' );
+add_filter( 'rest_post_dispatch', 'extrachill_api_protect_booking_attachment_download_response', 10, 3 );
+add_filter( 'rest_pre_serve_request', 'extrachill_api_serve_private_stream', 10, 4 );
+
+/** Register the authenticated Events-owned attachment download route. */
+function extrachill_api_register_booking_attachment_download_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/events/bookings/(?P<booking_id>\d+)/attachments/(?P<attachment_id>\d+)/download',
+		array(
+			'methods'             => 'GET',
+			'callback'            => 'extrachill_api_download_booking_attachment',
+			'permission_callback' => 'extrachill_api_booking_attachment_download_permission',
+			'args'                => array(
+				'booking_id'    => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'attachment_id' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+			),
+		)
+	);
+}
+
+/** Require an authenticated caller without disclosing attachment existence. */
+function extrachill_api_booking_attachment_download_permission() {
+	return is_user_logged_in()
+		? true
+		: new WP_Error( 'booking_attachment_download_unavailable', 'The requested attachment is unavailable.', array( 'status' => 401 ) );
+}
+
+/**
+ * Issue and immediately consume an Events-owned one-time handoff.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function extrachill_api_download_booking_attachment( WP_REST_Request $request ) {
+	if ( 'GET' !== $request->get_method() ) {
+		return extrachill_api_booking_attachment_download_error( 405 );
+	}
+	if ( null !== $request->get_param( '_envelope' ) ) {
+		return extrachill_api_booking_attachment_download_error( 400 );
+	}
+
+	$rate_limit = extrachill_api_check_booking_attachment_download_rate_limit();
+	if ( is_wp_error( $rate_limit ) ) {
+		return $rate_limit;
+	}
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		return extrachill_api_booking_attachment_download_error( 503 );
+	}
+
+	$ability = wp_get_ability( 'extrachill/download-booking-attachment' );
+	if ( ! $ability ) {
+		return extrachill_api_booking_attachment_download_error( 503 );
+	}
+
+	$input   = array(
+		'booking_id'    => (int) $request->get_param( 'booking_id' ),
+		'attachment_id' => (int) $request->get_param( 'attachment_id' ),
+	);
+	$allowed = $ability->check_permissions( $input );
+	if ( true !== $allowed ) {
+		return extrachill_api_booking_attachment_download_error( 404 );
+	}
+
+	$descriptor = $ability->execute( $input );
+	if ( is_wp_error( $descriptor ) || ! is_array( $descriptor ) ) {
+		return extrachill_api_booking_attachment_download_error( extrachill_api_booking_attachment_error_status( $descriptor ) );
+	}
+
+	$token = $descriptor['stream_token'] ?? null;
+	if ( ! is_string( $token ) || 1 !== preg_match( '/^[a-f0-9]{64}$/', $token ) ) {
+		return extrachill_api_booking_attachment_download_error( 502 );
+	}
+
+	$service_class = '\\ExtraChillEvents\\Core\\BookingAttachmentService';
+	if ( ! class_exists( $service_class ) ) {
+		return extrachill_api_booking_attachment_download_error( 503 );
+	}
+
+	$service = new $service_class();
+	$stream  = $service->open_download_stream(
+		$input['booking_id'],
+		$input['attachment_id'],
+		$token,
+		get_current_user_id()
+	);
+	if ( is_wp_error( $stream ) || ! is_resource( $stream ) ) {
+		if ( is_resource( $stream ) ) {
+			fclose( $stream );
+		}
+		return extrachill_api_booking_attachment_download_error( extrachill_api_booking_attachment_error_status( $stream ) );
+	}
+
+	return extrachill_api_create_private_stream_response(
+		$stream,
+		(string) ( $descriptor['filename'] ?? '' ),
+		(string) ( $descriptor['mime_type'] ?? '' ),
+		$request
+	);
+}
+
+/**
+ * Return a stable public status without forwarding domain error details.
+ *
+ * @param mixed $error Domain result.
+ * @return int
+ */
+function extrachill_api_booking_attachment_error_status( $error ) {
+	if ( ! is_wp_error( $error ) ) {
+		return 502;
+	}
+
+	$data   = $error->get_error_data();
+	$status = is_array( $data ) ? (int) ( $data['status'] ?? 0 ) : 0;
+	if ( in_array( $status, array( 401, 403, 404, 409, 410 ), true ) ) {
+		return 404;
+	}
+
+	return in_array( $status, array( 429, 502, 503 ), true ) ? $status : 502;
+}
+
+/** Build a generic, non-cacheable download error. */
+function extrachill_api_booking_attachment_download_error( $status ) {
+	$response = new WP_Error(
+		'booking_attachment_download_unavailable',
+		'The requested attachment is unavailable.',
+		array( 'status' => (int) $status )
+	);
+
+	return $response;
+}
+
+/** Apply a fixed-window per-user cap before Events issues a handoff. */
+function extrachill_api_check_booking_attachment_download_rate_limit() {
+	$limit = (int) apply_filters( 'extrachill_api_booking_attachment_download_rate_limit', 30 );
+	if ( $limit < 1 ) {
+		return true;
+	}
+
+	$user_id = get_current_user_id();
+	if ( $user_id < 1 ) {
+		return extrachill_api_booking_attachment_download_error( 401 );
+	}
+
+	$key   = 'ec_api_booking_dl_' . substr( hash_hmac( 'sha256', (string) $user_id, wp_salt( 'nonce' ) ), 0, 32 );
+	$count = (int) get_transient( $key );
+	if ( $count >= $limit ) {
+		return extrachill_api_booking_attachment_download_error( 429 );
+	}
+	set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
+
+	return true;
+}
+
+/** Return the transport byte ceiling, bounded by Events' hard policy ceiling. */
+function extrachill_api_booking_attachment_max_bytes() {
+	$maximum = (int) apply_filters( 'extrachill_api_booking_attachment_max_bytes', 20 * MB_IN_BYTES );
+
+	return max( 1, min( 20 * MB_IN_BYTES, $maximum ) );
+}
+
+/**
+ * Validate metadata and register a local Events stream for manual REST serving.
+ *
+ * @param resource        $stream   Opened Events-owned stream.
+ * @param string          $filename Events-provided filename.
+ * @param string          $mime     Events-provided MIME type.
+ * @param WP_REST_Request $request  REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function extrachill_api_create_private_stream_response( $stream, $filename, $mime, WP_REST_Request $request ) {
+	$stat = fstat( $stream );
+	$size = is_array( $stat ) ? (int) ( $stat['size'] ?? -1 ) : -1;
+	if ( $size < 0 || $size > extrachill_api_booking_attachment_max_bytes() ) {
+		fclose( $stream );
+		return extrachill_api_booking_attachment_download_error( 413 );
+	}
+
+	$range = extrachill_api_booking_attachment_range( $request->get_header( 'Range' ), $size );
+	if ( is_wp_error( $range ) ) {
+		fclose( $stream );
+		return $range;
+	}
+	if ( 0 !== $range['offset'] && 0 !== fseek( $stream, $range['offset'] ) ) {
+		fclose( $stream );
+		return extrachill_api_booking_attachment_download_error( 502 );
+	}
+
+	$headers = extrachill_api_private_stream_headers( $filename, $mime, $range['length'] );
+	if ( 206 === $range['status'] ) {
+		$headers['Content-Range'] = sprintf( 'bytes %d-%d/%d', $range['offset'], $range['offset'] + $range['length'] - 1, $size );
+	}
+
+	return extrachill_api_register_private_stream( $stream, $range['length'], $range['status'], $headers );
+}
+
+/**
+ * Parse one bounded HTTP byte range.
+ *
+ * @param string $header Range header.
+ * @param int    $size   Full stream size.
+ * @return array|WP_Error
+ */
+function extrachill_api_booking_attachment_range( $header, $size ) {
+	if ( '' === $header || null === $header ) {
+		return array(
+			'offset' => 0,
+			'length' => $size,
+			'status' => 200,
+		);
+	}
+
+	if ( $size < 1 || 1 !== preg_match( '/^bytes=(\d*)-(\d*)$/', trim( $header ), $match ) || ( '' === $match[1] && '' === $match[2] ) ) {
+		return new WP_Error( 'booking_attachment_range_unsatisfiable', 'The requested byte range is unavailable.', array( 'status' => 416 ) );
+	}
+
+	if ( '' === $match[1] ) {
+		$suffix = (int) $match[2];
+		if ( $suffix < 1 ) {
+			return new WP_Error( 'booking_attachment_range_unsatisfiable', 'The requested byte range is unavailable.', array( 'status' => 416 ) );
+		}
+		$length = min( $suffix, $size );
+		$offset = $size - $length;
+	} else {
+		$offset = (int) $match[1];
+		$end    = '' === $match[2] ? $size - 1 : min( (int) $match[2], $size - 1 );
+		if ( $offset >= $size || $end < $offset ) {
+			return new WP_Error( 'booking_attachment_range_unsatisfiable', 'The requested byte range is unavailable.', array( 'status' => 416 ) );
+		}
+		$length = $end - $offset + 1;
+	}
+
+	return array(
+		'offset' => $offset,
+		'length' => $length,
+		'status' => 206,
+	);
+}
+
+/** Build headers that keep private bytes out of browsers and intermediary caches. */
+function extrachill_api_private_stream_headers( $filename, $mime, $length ) {
+	$safe_filename = sanitize_file_name( wp_basename( $filename ) );
+	if ( '' === $safe_filename ) {
+		$safe_filename = 'attachment.bin';
+	}
+	$fallback = preg_replace( '/[^A-Za-z0-9._-]/', '_', $safe_filename );
+	$fallback = '' === $fallback ? 'attachment.bin' : $fallback;
+	$mime     = 1 === preg_match( '#^[a-z0-9][a-z0-9.+-]*/[a-z0-9][a-z0-9.+-]*$#i', $mime ) ? strtolower( $mime ) : 'application/octet-stream';
+
+	return array(
+		'Accept-Ranges'             => 'bytes',
+		'Cache-Control'             => 'private, no-store, no-cache, must-revalidate, max-age=0',
+		'Content-Disposition'       => 'attachment; filename="' . $fallback . '"; filename*=UTF-8\'\'' . rawurlencode( $safe_filename ),
+		'Content-Length'            => (string) $length,
+		'Content-Type'              => $mime,
+		'Expires'                   => '0',
+		'Pragma'                    => 'no-cache',
+		'Vary'                      => 'Authorization, Cookie',
+		'X-Content-Type-Options'    => 'nosniff',
+		'X-EC-Download-Correlation' => wp_generate_uuid4(),
+		'X-Robots-Tag'              => 'noindex, nofollow, noarchive',
+	);
+}
+
+/** Keep every success and failure for this private route out of caches. */
+function extrachill_api_protect_booking_attachment_download_response( $response, $server, $request ) {
+	unset( $server );
+	if ( ! extrachill_api_is_booking_attachment_download_route( $request->get_route() ) ) {
+		return $response;
+	}
+
+	$response->header( 'Cache-Control', 'private, no-store, no-cache, must-revalidate, max-age=0' );
+	$response->header( 'Expires', '0' );
+	$response->header( 'Pragma', 'no-cache' );
+	$response->header( 'Vary', 'Authorization, Cookie' );
+	$response->header( 'X-Content-Type-Options', 'nosniff' );
+	$response->header( 'X-Robots-Tag', 'noindex, nofollow, noarchive' );
+
+	return $response;
+}
+
+/**
+ * Register an exact stream response without placing its resource in REST data.
+ *
+ * @param resource    $stream       Open stream.
+ * @param int         $length       Bytes to emit.
+ * @param int         $status       HTTP status.
+ * @param array       $headers      Safe response headers.
+ * @param string|null $cleanup_path Optional affinity spool to unlink.
+ * @return WP_REST_Response
+ */
+function extrachill_api_register_private_stream( $stream, $length, $status, array $headers, $cleanup_path = null ) {
+	$response = new WP_REST_Response( null, $status, $headers );
+	$key      = spl_object_id( $response );
+	$GLOBALS['extrachill_api_private_streams'][ $key ] = array(
+		'stream'       => $stream,
+		'length'       => (int) $length,
+		'cleanup_path' => is_string( $cleanup_path ) ? $cleanup_path : null,
+	);
+	extrachill_api_register_private_stream_shutdown_cleanup();
+
+	return $response;
+}
+
+/** Register one request-level safety net for aborted/private stream responses. */
+function extrachill_api_register_private_stream_shutdown_cleanup() {
+	if ( ! empty( $GLOBALS['extrachill_api_private_stream_cleanup_registered'] ) ) {
+		return;
+	}
+	$GLOBALS['extrachill_api_private_stream_cleanup_registered'] = true;
+	register_shutdown_function( 'extrachill_api_cleanup_private_streams' );
+}
+
+/** Close every pending resource and unlink every private affinity spool. */
+function extrachill_api_cleanup_private_streams() {
+	$streams = is_array( $GLOBALS['extrachill_api_private_streams'] ?? null ) ? $GLOBALS['extrachill_api_private_streams'] : array();
+	foreach ( $streams as $entry ) {
+		if ( is_resource( $entry['stream'] ?? null ) ) {
+			fclose( $entry['stream'] );
+		}
+		$path = $entry['cleanup_path'] ?? null;
+		if ( is_string( $path ) && '' !== $path && file_exists( $path ) ) {
+			unlink( $path );
+		}
+	}
+	$GLOBALS['extrachill_api_private_streams'] = array();
+}
+
+/**
+ * Emit a registered private stream after WordPress has sent its safe headers.
+ *
+ * @param bool             $served  Whether already served.
+ * @param WP_HTTP_Response $result  REST response.
+ * @param WP_REST_Request  $request REST request.
+ * @param WP_REST_Server   $server  REST server.
+ * @return bool
+ */
+function extrachill_api_serve_private_stream( $served, $result, $request, $server ) {
+	unset( $request, $server );
+	if ( $served || ! is_object( $result ) ) {
+		return $served;
+	}
+
+	$key = spl_object_id( $result );
+	if ( ! isset( $GLOBALS['extrachill_api_private_streams'][ $key ] ) ) {
+		return $served;
+	}
+
+	$entry = $GLOBALS['extrachill_api_private_streams'][ $key ];
+	unset( $GLOBALS['extrachill_api_private_streams'][ $key ] );
+	$stream    = $entry['stream'];
+	$remaining = max( 0, (int) $entry['length'] );
+	try {
+		while ( $remaining > 0 && is_resource( $stream ) && ! feof( $stream ) ) {
+			$chunk = fread( $stream, min( 64 * KB_IN_BYTES, $remaining ) );
+			if ( false === $chunk || '' === $chunk ) {
+				break;
+			}
+			echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Verified private binary transport.
+			$remaining -= strlen( $chunk );
+			if ( connection_aborted() ) {
+				break;
+			}
+		}
+	} finally {
+		if ( is_resource( $stream ) ) {
+			fclose( $stream );
+		}
+		$path = $entry['cleanup_path'] ?? null;
+		if ( is_string( $path ) && '' !== $path && file_exists( $path ) ) {
+			unlink( $path );
+		}
+	}
+
+	return true;
+}
+
+/** Return whether a route is the protected binary transport. */
+function extrachill_api_is_booking_attachment_download_route( $route ) {
+	return 1 === preg_match( '#^/extrachill/v1/events/bookings/\d+/attachments/\d+/download$#', (string) $route );
+}
+
+/**
+ * Convert a bounded affinity spool into the same manual stream response.
+ *
+ * @param array  $http_response Raw WordPress HTTP response.
+ * @param string $path          Private temporary spool path.
+ * @return WP_REST_Response|WP_Error
+ */
+function extrachill_api_private_stream_from_affinity_response( array $http_response, $path ) {
+	$status  = (int) wp_remote_retrieve_response_code( $http_response );
+	$headers = wp_remote_retrieve_headers( $http_response );
+	$headers = $headers instanceof Traversable ? iterator_to_array( $headers ) : (array) $headers;
+	if ( ! in_array( $status, array( 200, 206 ), true ) ) {
+		extrachill_api_discard_private_affinity_spool( $path );
+		return extrachill_api_booking_attachment_download_error( extrachill_api_booking_attachment_proxy_status( $status ) );
+	}
+
+	$size = is_file( $path ) ? filesize( $path ) : false;
+	if ( false === $size || $size > extrachill_api_booking_attachment_max_bytes() ) {
+		extrachill_api_discard_private_affinity_spool( $path );
+		return extrachill_api_booking_attachment_download_error( 502 );
+	}
+
+	$declared = isset( $headers['content-length'] ) ? (int) $headers['content-length'] : ( isset( $headers['Content-Length'] ) ? (int) $headers['Content-Length'] : -1 );
+	if ( $declared !== (int) $size ) {
+		extrachill_api_discard_private_affinity_spool( $path );
+		return extrachill_api_booking_attachment_download_error( 502 );
+	}
+
+	$disposition = (string) ( $headers['content-disposition'] ?? ( $headers['Content-Disposition'] ?? '' ) );
+	$filename    = extrachill_api_filename_from_content_disposition( $disposition );
+	$mime        = (string) ( $headers['content-type'] ?? ( $headers['Content-Type'] ?? '' ) );
+	$safe        = extrachill_api_private_stream_headers( $filename, $mime, $size );
+	$correlation = (string) ( $headers['x-ec-download-correlation'] ?? ( $headers['X-EC-Download-Correlation'] ?? '' ) );
+	if ( 1 === preg_match( '/^[a-f0-9-]{36}$/i', $correlation ) ) {
+		$safe['X-EC-Download-Correlation'] = $correlation;
+	}
+	if ( 206 === $status ) {
+		$content_range = (string) ( $headers['content-range'] ?? ( $headers['Content-Range'] ?? '' ) );
+		if ( 1 !== preg_match( '/^bytes (\d+)-(\d+)\/(\d+)$/', $content_range, $range ) || (int) $range[2] < (int) $range[1] || (int) $range[2] - (int) $range[1] + 1 !== (int) $size || (int) $range[3] > extrachill_api_booking_attachment_max_bytes() ) {
+			extrachill_api_discard_private_affinity_spool( $path );
+			return extrachill_api_booking_attachment_download_error( 502 );
+		}
+		$safe['Content-Range'] = $content_range;
+	}
+
+	$stream = fopen( $path, 'rb' );
+	if ( false === $stream ) {
+		extrachill_api_discard_private_affinity_spool( $path );
+		return extrachill_api_booking_attachment_download_error( 502 );
+	}
+
+	return extrachill_api_register_private_stream( $stream, $size, $status, $safe, $path );
+}
+
+/** Extract and sanitize only a presentation filename from Content-Disposition. */
+function extrachill_api_filename_from_content_disposition( $header ) {
+	$filename = '';
+	if ( 1 === preg_match( "/filename\*=UTF-8''([^;]+)/i", $header, $match ) ) {
+		$filename = rawurldecode( $match[1] );
+	} elseif ( 1 === preg_match( '/filename="?([^";]+)"?/i', $header, $match ) ) {
+		$filename = $match[1];
+	}
+
+	return sanitize_file_name( wp_basename( $filename ) );
+}
+
+/** Map a downstream private transport status without exposing its response. */
+function extrachill_api_booking_attachment_proxy_status( $status ) {
+	if ( in_array( (int) $status, array( 401, 403, 404, 409, 410 ), true ) ) {
+		return 404;
+	}
+
+	return in_array( (int) $status, array( 413, 416, 429, 502, 503 ), true ) ? (int) $status : 502;
+}
+
+/** Close and unlink an affinity spool on every failure path. */
+function extrachill_api_discard_private_affinity_spool( $path ) {
+	if ( is_string( $path ) && '' !== $path && file_exists( $path ) ) {
+		unlink( $path );
+	}
+}
+
+// phpcs:enable WordPress.WP.AlternativeFunctions.file_system_operations_fclose,WordPress.WP.AlternativeFunctions.file_system_operations_fopen,WordPress.WP.AlternativeFunctions.file_system_operations_fread,WordPress.WP.AlternativeFunctions.unlink_unlink

--- a/tests/Unit/middleware/RouteAffinityTest.php
+++ b/tests/Unit/middleware/RouteAffinityTest.php
@@ -183,6 +183,58 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		$this->assert_reentry_rejected( $reentry );
 	}
 
+	/** A protected stream range is forwarded only when bound to the signature. */
+	public function test_private_stream_range_is_signed_and_tamper_proof() {
+		$request = new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/12/attachments/34/download' );
+		$request->set_header( 'Range', 'bytes=2-5' );
+		$this->downstream_response = $this->raw_http_response(
+			206,
+			'vate',
+			array(
+				'Content-Length'            => '4',
+				'Content-Type'              => 'text/plain',
+				'Content-Disposition'       => 'attachment; filename="rider.txt"',
+				'Content-Range'             => 'bytes 2-5/10',
+				'X-EC-Download-Correlation' => wp_generate_uuid4(),
+			)
+		);
+		$response = $this->dispatch_affinity( $request );
+
+		$this->assertSame( 206, $response->get_status() );
+		$this->assertNull( $response->get_data() );
+		$this->assertSame( 'bytes=2-5', $this->last_http_args['headers']['range'] );
+		$this->assertTrue( $this->last_http_args['stream'] );
+		$this->assertSame( extrachill_api_booking_attachment_max_bytes() + 1, $this->last_http_args['limit_response_size'] );
+		$spool = $this->last_http_args['filename'];
+		$this->assertFileExists( $spool );
+
+		$reentry = $this->reentry_request( $request );
+		$reentry->set_header( 'Range', 'bytes=3-6' );
+		$this->assert_reentry_rejected( $reentry );
+
+		ob_start();
+		$this->assertTrue( extrachill_api_serve_private_stream( false, $response, $request, rest_get_server() ) );
+		$this->assertSame( 'vate', ob_get_clean() );
+		$this->assertFileDoesNotExist( $spool );
+	}
+
+	/** Downstream private errors are generic and their spooled bodies are deleted. */
+	public function test_private_stream_error_does_not_relay_internal_references() {
+		wp_set_current_user( self::factory()->user->create() );
+		$this->downstream_response = $this->raw_http_response(
+			403,
+			'{"storage_reference":"secret","path":"/private/root"}',
+			array( 'Content-Type' => 'application/json' )
+		);
+		$response = $this->dispatch_affinity( new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/12/attachments/34/download' ) );
+		$spool    = $this->last_http_args['filename'];
+
+		$this->assertWPError( $response );
+		$this->assertSame( 404, $response->get_error_data()['status'] );
+		$this->assertStringNotContainsString( 'secret', wp_json_encode( $response->get_error_data() ) );
+		$this->assertFileDoesNotExist( $spool );
+	}
+
 	/**
 	 * Typed query input signs the exact helper wire representation.
 	 *
@@ -417,6 +469,11 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		++$this->request_count;
 		$this->last_http_args = $args;
 		$this->last_http_url  = $url;
+		if ( ! empty( $args['stream'] ) && is_array( $this->downstream_response ) ) {
+			file_put_contents( $args['filename'], $this->downstream_response['body'] );
+			$this->downstream_response['body']     = '';
+			$this->downstream_response['filename'] = $args['filename'];
+		}
 
 		return $this->downstream_response;
 	}
@@ -524,6 +581,20 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		return array(
 			'headers'  => $headers,
 			'body'     => wp_json_encode( $body ),
+			'response' => array(
+				'code'    => $status,
+				'message' => '',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+
+	/** Build a raw byte HTTP response fixture. */
+	private function raw_http_response( $status, $body, $headers = array() ) {
+		return array(
+			'headers'  => $headers,
+			'body'     => $body,
 			'response' => array(
 				'code'    => $status,
 				'message' => '',

--- a/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
+++ b/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
@@ -1,0 +1,319 @@
+<?php
+/**
+ * Protected booking attachment download transport tests.
+ *
+ * @package ExtraChill\API\Tests
+ */
+
+namespace ExtraChillEvents\Core {
+	/** Controlled Events service contract used by the API transport tests. */
+	class BookingAttachmentService {
+		/** @var array<string, bool> */
+		public static $consumed = array();
+
+		/** Consume one test handoff and return private bytes. */
+		public function open_download_stream( int $booking_id, int $attachment_id, string $token, int $actor_id ) {
+			unset( $attachment_id, $actor_id );
+			if ( in_array( $booking_id, array( 4, 5, 6 ), true ) || isset( self::$consumed[ $token ] ) ) {
+				return new \WP_Error( 'private_stream_unavailable', 'Internal reference /private/object/leak', array( 'status' => 403 ) );
+			}
+			self::$consumed[ $token ] = true;
+			$stream                    = fopen( 'php://temp', 'w+b' );
+			fwrite( $stream, 'private booking bytes' );
+			rewind( $stream );
+			return $stream;
+		}
+	}
+}
+
+namespace {
+	/** Exercises the real REST adapter around controlled Events contracts. */
+	class Booking_Attachment_DownloadTest extends WP_UnitTestCase {
+
+		/** @var string[] */
+		private $registered_abilities = array();
+
+		/** @var array<int, array<string, int>> */
+		private $audit = array();
+
+		/** Register a controlled hidden Events ability. */
+		public function set_up() {
+			parent::set_up();
+			\ExtraChillEvents\Core\BookingAttachmentService::$consumed = array();
+			$GLOBALS['extrachill_api_private_streams']                    = array();
+			wp_set_current_user( 0 );
+
+			$categories = WP_Ability_Categories_Registry::get_instance();
+			if ( ! wp_has_ability_category( 'extrachill-api-tests' ) ) {
+				$categories->register(
+					'extrachill-api-tests',
+					array(
+						'label'       => 'Extra Chill API Tests',
+						'description' => 'Controlled private transport contracts.',
+					)
+				);
+			}
+
+			$this->register_ability();
+			do_action( 'rest_api_init' );
+		}
+
+		/** Remove controlled state and any unserved streams. */
+		public function tear_down() {
+			extrachill_api_cleanup_private_streams();
+			foreach ( $this->registered_abilities as $name ) {
+				wp_unregister_ability( $name );
+			}
+			wp_set_current_user( 0 );
+			parent::tear_down();
+		}
+
+		/** Anonymous requests fail before Events is called and remain non-cacheable. */
+		public function test_anonymous_request_fails_closed_without_audit() {
+			$request  = new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/1/attachments/1/download' );
+			$response = rest_do_request( $request );
+			$response = extrachill_api_protect_booking_attachment_download_response( $response, rest_get_server(), $request );
+
+			$this->assertSame( 401, $response->get_status() );
+			$this->assertSame( 'booking_attachment_download_unavailable', $response->get_data()['code'] );
+			$this->assertStringContainsString( 'no-store', $this->response_header( $response, 'cache-control' ) );
+			$this->assertSame( array(), $this->audit );
+		}
+
+		/** Cross-venue and revoked callers receive the same generic response. */
+		public function test_cross_venue_and_revoked_access_are_indistinguishable() {
+			wp_set_current_user( self::factory()->user->create() );
+			foreach ( array( 2, 3 ) as $booking_id ) {
+				$response = $this->dispatch( $booking_id, 1 );
+				$this->assertSame( 404, $response->get_status() );
+				$this->assertSame( 'booking_attachment_download_unavailable', $response->get_data()['code'] );
+				$this->assertStringNotContainsString( 'venue', wp_json_encode( $response->get_data() ) );
+			}
+			$this->assertSame( array(), $this->audit );
+		}
+
+		/** Expired, replayed, and tampered handoffs fail after Events reauthorization. */
+		public function test_expired_replayed_and_tampered_handoffs_fail_generically() {
+			wp_set_current_user( self::factory()->user->create() );
+			foreach ( array( 4, 5, 6 ) as $booking_id ) {
+				$response = $this->dispatch( $booking_id, 1 );
+				$this->assertSame( 404, $response->get_status() );
+				$this->assertStringNotContainsString( 'private', wp_json_encode( $response->get_data() ) );
+			}
+
+			$first = $this->dispatch( 7, 1 );
+			$this->assertSame( 200, $first->get_status() );
+			$this->serve( $first );
+			$replay = $this->dispatch( 7, 1 );
+			$this->assertSame( 404, $replay->get_status() );
+		}
+
+		/** Success exposes only safe headers and manually serves the private bytes. */
+		public function test_success_is_no_store_auditable_and_reference_free() {
+			$user_id = self::factory()->user->create();
+			wp_set_current_user( $user_id );
+			$response = $this->dispatch( 1, 9 );
+			$headers  = $response->get_headers();
+
+			$this->assertSame( 200, $response->get_status() );
+			$this->assertNull( $response->get_data() );
+			$this->assertStringContainsString( 'no-store', $headers['Cache-Control'] );
+			$this->assertSame( 'application/pdf', $headers['Content-Type'] );
+			$this->assertStringContainsString( 'safe-rider.pdf', $headers['Content-Disposition'] );
+			$this->assertMatchesRegularExpression( '/^[a-f0-9-]{36}$/i', $headers['X-EC-Download-Correlation'] );
+			$this->assertSame( array( array( 'booking_id' => 1, 'attachment_id' => 9, 'actor_id' => $user_id ) ), $this->audit );
+			$this->assertSame( 'private booking bytes', $this->serve( $response ) );
+			$this->assertSame( array(), $GLOBALS['extrachill_api_private_streams'] );
+		}
+
+		/** Filename and MIME metadata are defensively normalized for HTTP headers. */
+		public function test_filename_injection_and_invalid_mime_are_neutralized() {
+			$stream = fopen( 'php://temp', 'w+b' );
+			fwrite( $stream, 'x' );
+			rewind( $stream );
+			$request  = new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/1/attachments/1/download' );
+			$response = extrachill_api_create_private_stream_response( $stream, "../bad\r\nX-Leak: yes.pdf", "text/plain\r\nX-Leak: yes", $request );
+			$headers  = $response->get_headers();
+
+			$this->assertStringNotContainsString( "\r", $headers['Content-Disposition'] );
+			$this->assertStringNotContainsString( "\n", $headers['Content-Disposition'] );
+			$this->assertStringNotContainsString( '..', $headers['Content-Disposition'] );
+			$this->assertSame( 'application/octet-stream', $headers['Content-Type'] );
+			$this->serve( $response );
+		}
+
+		/** Single ranges are bounded while multiple and unsatisfiable ranges fail. */
+		public function test_range_and_size_limits_are_enforced() {
+			$this->assertSame( array( 'offset' => 2, 'length' => 4, 'status' => 206 ), extrachill_api_booking_attachment_range( 'bytes=2-5', 10 ) );
+			$this->assertSame( array( 'offset' => 7, 'length' => 3, 'status' => 206 ), extrachill_api_booking_attachment_range( 'bytes=-3', 10 ) );
+			$this->assertWPError( extrachill_api_booking_attachment_range( 'bytes=0-1,4-5', 10 ) );
+			$this->assertWPError( extrachill_api_booking_attachment_range( 'bytes=20-', 10 ) );
+
+			add_filter( 'extrachill_api_booking_attachment_max_bytes', array( $this, 'one_byte_limit' ) );
+			$stream = fopen( 'php://temp', 'w+b' );
+			fwrite( $stream, 'too large' );
+			rewind( $stream );
+			$result = extrachill_api_create_private_stream_response( $stream, 'file.txt', 'text/plain', new WP_REST_Request( 'GET', '/' ) );
+			remove_filter( 'extrachill_api_booking_attachment_max_bytes', array( $this, 'one_byte_limit' ) );
+			$this->assertWPError( $result );
+			$this->assertSame( 413, $result->get_error_data()['status'] );
+		}
+
+		/** Cleanup removes a partially served affinity spool and closes its stream. */
+		public function test_manual_stream_cleanup_unlinks_affinity_spool() {
+			$path = wp_tempnam( 'booking-download-test' );
+			file_put_contents( $path, 'abcdef' );
+			chmod( $path, 0600 );
+			$stream   = fopen( $path, 'rb' );
+			$response = extrachill_api_register_private_stream( $stream, 3, 200, extrachill_api_private_stream_headers( 'file.txt', 'text/plain', 3 ), $path );
+
+			$this->assertSame( 'abc', $this->serve( $response ) );
+			$this->assertFileDoesNotExist( $path );
+			$this->assertFalse( is_resource( $stream ) );
+		}
+
+		/** Rate limiting occurs before a second handoff can be issued. */
+		public function test_rate_limit_precedes_handoff_issuance() {
+			wp_set_current_user( self::factory()->user->create() );
+			add_filter( 'extrachill_api_booking_attachment_download_rate_limit', array( $this, 'one_byte_limit' ) );
+			$first = $this->dispatch( 8, 1 );
+			$this->assertSame( 200, $first->get_status() );
+			$this->serve( $first );
+			$second = $this->dispatch( 9, 1 );
+			remove_filter( 'extrachill_api_booking_attachment_download_rate_limit', array( $this, 'one_byte_limit' ) );
+
+			$this->assertSame( 429, $second->get_status() );
+			$this->assertCount( 1, $this->audit );
+		}
+
+		/** Affinity spools preserve private bytes without trusting unsafe headers. */
+		public function test_affinity_spool_is_bounded_sanitized_and_cleaned() {
+			$path = wp_tempnam( 'booking-affinity-test' );
+			file_put_contents( $path, 'part' );
+			chmod( $path, 0600 );
+			$response = extrachill_api_private_stream_from_affinity_response(
+				array(
+					'headers'  => array(
+						'Content-Length'      => '4',
+						'Content-Type'        => 'text/plain',
+						'Content-Disposition' => 'attachment; filename="../rider.txt"',
+						'Content-Range'       => 'bytes 2-5/10',
+					),
+					'body'     => '',
+					'response' => array( 'code' => 206 ),
+				),
+				$path
+			);
+
+			$this->assertSame( 206, $response->get_status() );
+			$this->assertStringNotContainsString( '..', $response->get_headers()['Content-Disposition'] );
+			$this->assertSame( 'part', $this->serve( $response ) );
+			$this->assertFileDoesNotExist( $path );
+
+			$bad_path = wp_tempnam( 'booking-affinity-test' );
+			file_put_contents( $bad_path, 'part' );
+			$bad = extrachill_api_private_stream_from_affinity_response(
+				array(
+					'headers'  => array(
+						'Content-Length' => '4',
+						'Content-Range'  => 'bytes 2-8/10',
+					),
+					'body'     => '',
+					'response' => array( 'code' => 206 ),
+				),
+				$bad_path
+			);
+			$this->assertWPError( $bad );
+			$this->assertFileDoesNotExist( $bad_path );
+		}
+
+		/** HEAD and REST envelope requests cannot consume a private handoff. */
+		public function test_head_and_envelope_requests_do_not_reach_events() {
+			wp_set_current_user( self::factory()->user->create() );
+			$head = new WP_REST_Request( 'HEAD', '/extrachill/v1/events/bookings/1/attachments/1/download' );
+			$this->assertSame( 405, rest_do_request( $head )->get_status() );
+
+			$request = new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/1/attachments/1/download' );
+			$request->set_query_params( array( '_envelope' => '1' ) );
+			$this->assertSame( 400, rest_do_request( $request )->get_status() );
+			$this->assertSame( array(), $this->audit );
+		}
+
+		/** Return a one-byte transport limit. */
+		public function one_byte_limit() {
+			return 1;
+		}
+
+		/** Register the hidden Events descriptor contract. */
+		private function register_ability() {
+			$name    = 'extrachill/download-booking-attachment';
+			$ability = WP_Abilities_Registry::get_instance()->register(
+				$name,
+				array(
+					'label'               => 'Download booking attachment',
+					'description'         => 'Controlled Events handoff contract.',
+					'category'            => 'extrachill-api-tests',
+					'input_schema'        => array(
+						'type'                 => 'object',
+						'properties'           => array(
+							'booking_id'    => array( 'type' => 'integer' ),
+							'attachment_id' => array( 'type' => 'integer' ),
+						),
+						'required'             => array( 'booking_id', 'attachment_id' ),
+						'additionalProperties' => false,
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'permission_callback' => function ( array $input ) {
+						return in_array( $input['booking_id'], array( 2, 3 ), true )
+							? new WP_Error( 'venue_action_forbidden', 'Internal venue policy.', array( 'status' => 403 ) )
+							: true;
+					},
+					'execute_callback'    => function ( array $input ) {
+						$this->audit[] = array(
+							'booking_id'    => $input['booking_id'],
+							'attachment_id' => $input['attachment_id'],
+							'actor_id'      => get_current_user_id(),
+						);
+						return array(
+							'stream_token' => str_repeat( dechex( min( 15, $input['booking_id'] ) ), 64 ),
+							'expires_at'   => gmdate( 'c', time() + 300 ),
+							'filename'     => 'safe-rider.pdf',
+							'mime_type'    => 'application/pdf',
+						);
+					},
+				)
+			);
+			$this->assertInstanceOf( WP_Ability::class, $ability );
+			$this->registered_abilities[] = $name;
+		}
+
+		/** Dispatch one request through the real REST server. */
+		private function dispatch( $booking_id, $attachment_id ) {
+			return rest_do_request(
+				new WP_REST_Request(
+					'GET',
+					sprintf( '/extrachill/v1/events/bookings/%d/attachments/%d/download', $booking_id, $attachment_id )
+				)
+			);
+		}
+
+		/** Capture manual byte serving for one response. */
+		private function serve( WP_REST_Response $response ) {
+			ob_start();
+			$served = extrachill_api_serve_private_stream( false, $response, new WP_REST_Request(), rest_get_server() );
+			$bytes  = ob_get_clean();
+			$this->assertTrue( $served );
+			return $bytes;
+		}
+
+		/** Return a response header without relying on retained key casing. */
+		private function response_header( WP_REST_Response $response, $name ) {
+			foreach ( $response->get_headers() as $key => $value ) {
+				if ( strtolower( $key ) === strtolower( $name ) ) {
+					return (string) $value;
+				}
+			}
+			return '';
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add authenticated `GET /extrachill/v1/events/bookings/{booking_id}/attachments/{attachment_id}/download` transport that delegates authorization and opaque handoff issuance to `extrachill/download-booking-attachment`, then reauthorizes and consumes bytes through Events' `BookingAttachmentService`
- stream resources through `rest_pre_serve_request` with safe disposition/MIME, `no-store`, generic failures, per-user rate limiting, a 20 MiB ceiling, validated single-range responses, audit correlation, replay-safe handoff consumption, and shutdown/finally cleanup
- extend route affinity to sign and forward only the download `Range` header, spool loopback bytes to a mode-`0600` bounded temporary file, avoid REST JSON serialization, validate downstream metadata, and delete spools on success, error, interruption, or exceptions

## Ownership Boundary
- API owns HTTP authentication, rate limiting, range/cache/content headers, streaming, and multisite proxy transport only
- Events remains the sole owner of booking/venue authorization, attachment lookup, opaque handoff issuance and consumption, consumption-time reauthorization, private storage, byte integrity, audit activity, and lifecycle policy
- API does not query booking tables, inspect private storage, accept storage references, or expose handoffs, paths, roots, hashes, object references, or public URLs

## Security Coverage
- anonymous, cross-venue, revoked, expired, replayed, and tampered access fail closed with generic responses
- filename/MIME injection, range and size limits, rate limits, no-store headers, HEAD/envelope behavior, audit correlation, and response reference leakage are covered
- private stream resources and affinity spools close/unlink through normal, partial, failure, exception, and shutdown paths
- affinity binds the allowlisted range to its HMAC and does not serialize private bytes into REST response data

## Evidence
- focused Homeboy PHPUnit: `OK (10 tests, 69 assertions)`
- Homeboy PHPCS: 0 findings
- Homeboy PHPStan level 7: passed
- Homeboy PR audit: 0 introduced findings
- changed PHP syntax checks: passed
- `git diff --check`: passed
- clean-checkout Homeboy umbrella audit/lint: passed; broad sandbox test stage reproduces existing repository harness failures (missing mounted `extrachill-network` helper and unrelated undefined activity helpers), while the issue-focused suite passes

Closes #125.

No merge, release, deploy, storage provisioning, or policy enablement is included.