### PR TITLE
feat: protect public venue booking inquiries

### DIFF
--- a/inc/middleware/public-write-admission.php
+++ b/inc/middleware/public-write-admission.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Shared fixed-window admission for public REST writes.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Apply the existing per-client transient limiter to one public-write scope.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @param string          $scope   Stable limiter scope.
+ * @param int             $limit   Maximum writes per minute.
+ * @return true|WP_Error
+ */
+function extrachill_api_check_public_write_rate_limit( WP_REST_Request $request, $scope, $limit ) {
+	$limit = (int) $limit;
+	if ( $limit < 1 ) {
+		return true;
+	}
+
+	$client = '';
+	if ( '1' === $request->get_header( 'X-EC-Affinity-Verified' ) ) {
+		$client = sanitize_text_field( (string) $request->get_param( '_ec_affinity_client' ) );
+	}
+	if ( '' === $client ) {
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+		if ( '' === $ip || false === filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+			return true;
+		}
+		$client = hash_hmac( 'sha256', $ip, wp_salt( 'nonce' ) );
+	}
+
+	$key   = 'ec_api_write_' . substr( hash( 'sha256', sanitize_key( $scope ) . ':' . $client ), 0, 32 );
+	$count = (int) get_transient( $key );
+	if ( $count >= $limit ) {
+		return new WP_Error(
+			'public_write_rate_limited',
+			__( 'Too many requests. Please try again later.', 'extrachill-api' ),
+			array( 'status' => 429 )
+		);
+	}
+
+	set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
+
+	return true;
+}

--- a/inc/middleware/route-affinity.php
+++ b/inc/middleware/route-affinity.php
@@ -114,13 +114,18 @@ function extrachill_api_route_affinity_request_body( WP_REST_Request $request ) 
 	}
 
 	$body = $request->get_json_params();
-	if ( ! empty( $body ) ) {
-		return $body;
+	if ( empty( $body ) ) {
+		$body = $request->get_body_params();
 	}
+	$body = ! empty( $body ) ? $body : array();
 
-	$body = $request->get_body_params();
-
-	return ! empty( $body ) ? $body : array();
+	/**
+	 * Filters the signed body representation for transport-only request data.
+	 *
+	 * @param array           $body    Parsed request body.
+	 * @param WP_REST_Request $request Request being forwarded or verified.
+	 */
+	return apply_filters( 'extrachill_api_route_affinity_signature_body', $body, $request );
 }
 
 /**
@@ -187,7 +192,12 @@ function extrachill_api_is_route_affinity_reentry( WP_REST_Request $request ) {
 	// Persistent object caches make this single-use across loopback workers.
 	// Without one, localhost and the five-minute signature window remain the
 	// residual replay boundary.
-	return wp_cache_add( 'route_affinity_' . hash( 'sha256', $nonce ), 1, 'extrachill_api', 300 );
+	$verified = wp_cache_add( 'route_affinity_' . hash( 'sha256', $nonce ), 1, 'extrachill_api', 300 );
+	if ( $verified ) {
+		$request->set_header( 'X-EC-Affinity-Verified', '1' );
+	}
+
+	return $verified;
 }
 
 /**
@@ -314,7 +324,20 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 	add_filter( 'http_response', $capture_http_response, PHP_INT_MAX, 2 );
 
 	try {
-		$response = ec_cross_site_rest_request( $target_site, $method, $path, $args );
+		/**
+		 * Allows a route owner to preserve admitted files over the HTTP hop.
+		 * A null result falls through to the standard JSON transport.
+		 *
+		 * @param mixed           $response    Forwarded result or null.
+		 * @param string          $target_site Target site key.
+		 * @param string          $path        Namespace-relative path.
+		 * @param array           $args        Signed forwarding arguments.
+		 * @param WP_REST_Request $request     Original request.
+		 */
+		$response = apply_filters( 'extrachill_api_route_affinity_file_forward', null, $target_site, $path, $args, $request );
+		if ( null === $response ) {
+			$response = ec_cross_site_rest_request( $target_site, $method, $path, $args );
+		}
 	} finally {
 		remove_filter( 'ec_cross_site_use_http_loopback', $force_http_loopback, 10 );
 		remove_filter( 'pre_http_request', $capture_http_response, PHP_INT_MAX );

--- a/inc/routes/analytics/telemetry-validation.php
+++ b/inc/routes/analytics/telemetry-validation.php
@@ -10,6 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! function_exists( 'extrachill_api_check_public_write_rate_limit' ) ) {
+	require_once dirname( __DIR__, 2 ) . '/middleware/public-write-admission.php';
+}
+
 /**
  * Validate and normalize common public telemetry input.
  *
@@ -285,27 +289,12 @@ function extrachill_api_is_safe_telemetry_text( $value ) {
  * @return true|WP_Error
  */
 function extrachill_api_check_telemetry_rate_limit() {
-	$limit = (int) apply_filters( 'extrachill_api_telemetry_rate_limit', 240 );
-	if ( $limit < 1 ) {
-		return true;
+	$limit   = (int) apply_filters( 'extrachill_api_telemetry_rate_limit', 240 );
+	$request = new WP_REST_Request();
+	$result  = extrachill_api_check_public_write_rate_limit( $request, 'telemetry', $limit );
+	if ( is_wp_error( $result ) ) {
+		return new WP_Error( 'telemetry_rate_limited', 'Too many telemetry requests.', array( 'status' => 429 ) );
 	}
 
-	$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
-	if ( '' === $ip || false === filter_var( $ip, FILTER_VALIDATE_IP ) ) {
-		return true;
-	}
-
-	$key   = 'ec_api_tel_' . substr( hash_hmac( 'sha256', $ip, wp_salt( 'nonce' ) ), 0, 32 );
-	$count = (int) get_transient( $key );
-	if ( $count >= $limit ) {
-		return new WP_Error(
-			'telemetry_rate_limited',
-			'Too many telemetry requests.',
-			array( 'status' => 429 )
-		);
-	}
-
-	set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
-
-	return true;
+	return $result;
 }

--- a/inc/routes/events/booking-inquiries.php
+++ b/inc/routes/events/booking-inquiries.php
@@ -1,0 +1,477 @@
+<?php
+/**
+ * Protected public venue booking inquiry admission.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const EXTRACHILL_API_BOOKING_ABILITY = 'extrachill/create-booking-inquiry';
+const EXTRACHILL_API_BOOKING_FILES   = '_ec_affinity_files';
+
+add_filter( 'ec_route_site_affinity_map', 'extrachill_api_add_booking_route_affinity' );
+add_filter( 'extrachill_api_route_affinity_signature_body', 'extrachill_api_booking_affinity_signature_body', 10, 2 );
+add_filter( 'extrachill_api_route_affinity_file_forward', 'extrachill_api_booking_affinity_file_forward', 10, 5 );
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_booking_inquiry_route' );
+
+/** Route booking inquiries to the Events site on a segment boundary. */
+function extrachill_api_add_booking_route_affinity( $affinity_map ) {
+	$affinity_map['/extrachill/v1/venues/'] = 'events';
+	return $affinity_map;
+}
+
+/** Register the protected public facade. */
+function extrachill_api_register_booking_inquiry_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/venues/(?P<venue>\d+)/booking-inquiries',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_handle_booking_inquiry',
+			'permission_callback' => 'extrachill_api_booking_inquiry_permission',
+			'args'                => extrachill_api_booking_inquiry_args(),
+		)
+	);
+}
+
+/** Return the facade schema, including transport-only fields. */
+function extrachill_api_booking_inquiry_args() {
+	$nullable_text = array(
+		'required'          => false,
+		'type'              => array( 'string', 'null' ),
+		'sanitize_callback' => 'sanitize_text_field',
+	);
+
+	return array(
+		'venue'               => array(
+			'required' => true,
+			'type'     => 'integer',
+			'minimum'  => 1,
+		),
+		'idempotency_key'     => array(
+			'required'          => true,
+			'type'              => 'string',
+			'minLength'         => 1,
+			'maxLength'         => 191,
+			'sanitize_callback' => 'sanitize_text_field',
+		),
+		'artist_term_id'      => array(
+			'required' => false,
+			'type'     => array( 'integer', 'null' ),
+			'minimum'  => 1,
+		),
+		'artist_profile_id'   => array(
+			'required' => false,
+			'type'     => array( 'integer', 'null' ),
+			'minimum'  => 1,
+		),
+		'artist_name'         => array(
+			'required'          => false,
+			'type'              => 'string',
+			'minLength'         => 1,
+			'maxLength'         => 255,
+			'sanitize_callback' => 'sanitize_text_field',
+		),
+		'contact_name'        => array_merge( $nullable_text, array( 'maxLength' => 255 ) ),
+		'contact_email'       => array_merge(
+			$nullable_text,
+			array(
+				'format'            => 'email',
+				'maxLength'         => 255,
+				'sanitize_callback' => 'sanitize_email',
+			)
+		),
+		'contact_phone'       => array_merge( $nullable_text, array( 'maxLength' => 64 ) ),
+		'requested_space_key' => array_merge( $nullable_text, array( 'maxLength' => 64 ) ),
+		'requested_start_at'  => array_merge( $nullable_text, array( 'pattern' => '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$' ) ),
+		'requested_end_at'    => array_merge( $nullable_text, array( 'pattern' => '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$' ) ),
+		'intake'              => array(
+			'required'          => true,
+			'type'              => array( 'object', 'string' ),
+			'validate_callback' => 'extrachill_api_validate_booking_intake',
+		),
+		'attachment_purposes' => array(
+			'required'          => false,
+			'type'              => array( 'array', 'string' ),
+			'validate_callback' => 'extrachill_api_validate_booking_attachment_purposes',
+		),
+		'turnstile_response'  => array(
+			'required'          => true,
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+		),
+	);
+}
+
+/** Validate JSON-or-object intake used by JSON and multipart clients. */
+function extrachill_api_validate_booking_intake( $value ) {
+	if ( is_array( $value ) ) {
+		return true;
+	}
+	if ( ! is_string( $value ) || '' === $value ) {
+		return false;
+	}
+	$decoded = json_decode( $value, true );
+	return is_array( $decoded ) && JSON_ERROR_NONE === json_last_error();
+}
+
+/** Validate the declared purpose list without duplicating Events policy. */
+function extrachill_api_validate_booking_attachment_purposes( $value ) {
+	if ( is_string( $value ) ) {
+		$value = json_decode( $value, true );
+	}
+	if ( ! is_array( $value ) ) {
+		return false;
+	}
+	foreach ( $value as $purpose ) {
+		if ( ! is_string( $purpose ) || '' === sanitize_key( $purpose ) ) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/** Enforce Turnstile before consuming the public-write rate budget. */
+function extrachill_api_booking_inquiry_permission( WP_REST_Request $request ) {
+	if ( ! function_exists( 'ec_turnstile_check_request' ) ) {
+		return new WP_Error( 'booking_security_unavailable', __( 'Security verification is unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
+	}
+	$original_remote_addr = $_SERVER['REMOTE_ADDR'] ?? null;
+	$affinity_remote_addr = '1' === $request->get_header( 'X-EC-Affinity-Verified' ) ? (string) $request->get_param( '_ec_affinity_remote_addr' ) : '';
+	if ( '' !== $affinity_remote_addr && false !== filter_var( $affinity_remote_addr, FILTER_VALIDATE_IP ) ) {
+		$_SERVER['REMOTE_ADDR'] = $affinity_remote_addr;
+	}
+	try {
+		$turnstile = ec_turnstile_check_request( $request );
+	} finally {
+		if ( null === $original_remote_addr ) {
+			unset( $_SERVER['REMOTE_ADDR'] );
+		} else {
+			$_SERVER['REMOTE_ADDR'] = $original_remote_addr;
+		}
+	}
+	if ( is_wp_error( $turnstile ) ) {
+		return extrachill_api_booking_public_error( $turnstile );
+	}
+	$limit = (int) apply_filters( 'extrachill_api_booking_inquiry_rate_limit', 10 );
+	return extrachill_api_check_public_write_rate_limit( $request, 'booking-inquiry', $limit );
+}
+
+/** Normalize and invoke the Events-owned inquiry and attachment contracts. */
+function extrachill_api_handle_booking_inquiry( WP_REST_Request $request ) {
+	$abilities = wp_get_abilities();
+	$ability   = $abilities[ EXTRACHILL_API_BOOKING_ABILITY ] ?? null;
+	if ( ! $ability || $ability->get_meta_item( 'show_in_rest' ) ) {
+		return new WP_Error( 'booking_inquiry_unavailable', __( 'Booking inquiry processing is unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
+	}
+
+	$files = extrachill_api_normalize_booking_files( $request );
+	if ( is_wp_error( $files ) ) {
+		return $files;
+	}
+	$input = extrachill_api_booking_ability_input( $request, $files );
+	if ( is_wp_error( $input ) ) {
+		return $input;
+	}
+	$result = $ability->execute( $input );
+	if ( is_wp_error( $result ) ) {
+		return extrachill_api_booking_public_error( $result );
+	}
+	if ( ! is_array( $result ) || empty( $result['public_id'] ) ) {
+		return new WP_Error( 'booking_inquiry_invalid_response', __( 'Booking inquiry processing returned an invalid response.', 'extrachill-api' ), array( 'status' => 502 ) );
+	}
+
+	$attached = extrachill_api_attach_booking_files( $result, $files, (string) $input['idempotency_key'] );
+	if ( is_wp_error( $attached ) ) {
+		return $attached;
+	}
+
+	return new WP_REST_Response( $result, 201 );
+}
+
+/** Build only fields accepted by the hidden ability schema. */
+function extrachill_api_booking_ability_input( WP_REST_Request $request, array $files ) {
+	$intake = $request->get_param( 'intake' );
+	if ( is_string( $intake ) ) {
+		$intake = json_decode( $intake, true );
+	}
+	if ( ! is_array( $intake ) ) {
+		return new WP_Error( 'booking_inquiry_invalid_intake', __( 'A valid intake object is required.', 'extrachill-api' ), array( 'status' => 400 ) );
+	}
+	if ( $files ) {
+		$intake['_attachment_admission'] = array(
+			'version'     => 1,
+			'count'       => count( $files ),
+			'fingerprint' => extrachill_api_booking_file_fingerprint( $files ),
+		);
+	}
+
+	$input = array(
+		'idempotency_key' => sanitize_text_field( (string) $request->get_param( 'idempotency_key' ) ),
+		'venue_term_id'   => absint( $request->get_param( 'venue' ) ),
+		'intake'          => $intake,
+	);
+	foreach ( array( 'artist_term_id', 'artist_profile_id' ) as $key ) {
+		$value = $request->get_param( $key );
+		if ( null !== $value && '' !== $value ) {
+			$input[ $key ] = absint( $value );
+		}
+	}
+	foreach ( array( 'artist_name', 'contact_name', 'contact_email', 'contact_phone', 'requested_space_key', 'requested_start_at', 'requested_end_at' ) as $key ) {
+		$value = $request->get_param( $key );
+		if ( null !== $value ) {
+			$input[ $key ] = '' === $value ? null : $value;
+		}
+	}
+
+	return $input;
+}
+
+/** Normalize PHP's single/multiple file shapes and bind declared purposes. */
+function extrachill_api_normalize_booking_files( WP_REST_Request $request ) {
+	$raw = $request->get_file_params();
+	if ( empty( $raw['attachments'] ) ) {
+		return array();
+	}
+	$upload = $raw['attachments'];
+	$names  = is_array( $upload['name'] ?? null ) ? $upload['name'] : array( $upload['name'] ?? '' );
+	$files  = array();
+	foreach ( array_keys( $names ) as $index ) {
+		$file = array();
+		foreach ( array( 'name', 'type', 'tmp_name', 'error', 'size' ) as $key ) {
+			$file[ $key ] = is_array( $upload[ $key ] ?? null ) ? ( $upload[ $key ][ $index ] ?? null ) : ( $upload[ $key ] ?? null );
+		}
+		if ( UPLOAD_ERR_NO_FILE === (int) $file['error'] ) {
+			continue;
+		}
+		if ( UPLOAD_ERR_OK !== (int) $file['error'] || '' === (string) $file['tmp_name'] || ! is_readable( $file['tmp_name'] ) || ( ! is_uploaded_file( $file['tmp_name'] ) && ! apply_filters( 'extrachill_api_allow_test_booking_file', false, $file ) ) ) {
+			return new WP_Error( 'booking_attachment_upload_failed', __( 'A booking attachment could not be received.', 'extrachill-api' ), array( 'status' => 400 ) );
+		}
+		$file['sha256'] = hash_file( 'sha256', $file['tmp_name'] );
+		if ( false === $file['sha256'] ) {
+			return new WP_Error( 'booking_attachment_upload_failed', __( 'A booking attachment could not be received.', 'extrachill-api' ), array( 'status' => 400 ) );
+		}
+		$files[] = $file;
+	}
+
+	$purposes = $request->get_param( 'attachment_purposes' );
+	if ( is_string( $purposes ) ) {
+		$purposes = json_decode( $purposes, true );
+	}
+	if ( count( $files ) !== count( (array) $purposes ) ) {
+		return new WP_Error( 'booking_attachment_purpose_mismatch', __( 'Each booking attachment requires one purpose.', 'extrachill-api' ), array( 'status' => 400 ) );
+	}
+	foreach ( $files as $index => &$file ) {
+		$file['purpose'] = sanitize_key( $purposes[ $index ] );
+	}
+	unset( $file );
+	if ( '1' === $request->get_header( 'X-EC-Affinity-Verified' ) ) {
+		$expected = json_decode( (string) $request->get_param( EXTRACHILL_API_BOOKING_FILES ), true );
+		if ( ! is_array( $expected ) || extrachill_api_booking_file_descriptors( $files ) !== $expected ) {
+			return new WP_Error( 'booking_attachment_transport_invalid', __( 'The booking attachment transport could not be verified.', 'extrachill-api' ), array( 'status' => 400 ) );
+		}
+	}
+
+	return $files;
+}
+
+/** Fingerprint admitted bytes so an idempotency key cannot change its files. */
+function extrachill_api_booking_file_fingerprint( array $files ) {
+	$parts = array();
+	foreach ( $files as $file ) {
+		$parts[] = implode( ':', array( $file['purpose'], sanitize_file_name( $file['name'] ), (int) $file['size'], $file['sha256'] ) );
+	}
+	return hash( 'sha256', implode( "\n", $parts ) );
+}
+
+/** Stage and claim private files through Events-owned contracts. */
+function extrachill_api_attach_booking_files( array $receipt, array $files, $idempotency_key ) {
+	if ( ! $files ) {
+		return true;
+	}
+	$classes = array(
+		'ExtraChillEvents\\Core\\BookingPrivateFileProviders',
+		'ExtraChillEvents\\Core\\BookingRepository',
+		'ExtraChillEvents\\Core\\BookingAttachmentRepository',
+		'ExtraChillEvents\\Core\\BookingAttachmentService',
+	);
+	foreach ( $classes as $class ) {
+		if ( ! class_exists( $class ) ) {
+			return new WP_Error( 'booking_attachment_unavailable', __( 'Private booking attachments are unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
+		}
+	}
+
+	$provider = \ExtraChillEvents\Core\BookingPrivateFileProviders::resolve();
+	if ( is_wp_error( $provider ) ) {
+		return extrachill_api_booking_public_error( $provider );
+	}
+	$bookings = new \ExtraChillEvents\Core\BookingRepository();
+	$booking  = $bookings->get( (string) $receipt['public_id'] );
+	if ( ! is_array( $booking ) ) {
+		return new WP_Error( 'booking_attachment_booking_unavailable', __( 'The booking could not accept attachments.', 'extrachill-api' ), array( 'status' => 503 ) );
+	}
+	$attachments = new \ExtraChillEvents\Core\BookingAttachmentRepository();
+	$existing    = $attachments->list_for_booking( (int) $booking['id'] );
+	if ( is_wp_error( $existing ) ) {
+		return extrachill_api_booking_public_error( $existing );
+	}
+	$service = new \ExtraChillEvents\Core\BookingAttachmentService( $attachments, $bookings, null, null, $provider );
+
+	foreach ( $files as $index => $file ) {
+		$key = 'inquiry-attachment:' . hash( 'sha256', $idempotency_key . ':' . $index . ':' . $file['purpose'] );
+		foreach ( $existing as $prior ) {
+			if ( ( $prior['idempotency_key'] ?? '' ) === $key ) {
+				continue 2;
+			}
+		}
+		$reference = $provider->stage( $file['tmp_name'], sanitize_file_name( $file['name'] ), $file['purpose'] );
+		if ( is_wp_error( $reference ) ) {
+			return extrachill_api_booking_public_error( $reference );
+		}
+		$attached = $service->attach(
+			array(
+				'booking_id'         => (int) $booking['id'],
+				'storage_reference'  => $reference,
+				'idempotency_key'    => $key,
+				'purpose'            => $file['purpose'],
+				'uploader_type'      => 'anonymous',
+				'uploader_reference' => 'inquiry:' . $receipt['public_id'],
+			)
+		);
+		if ( is_wp_error( $attached ) ) {
+			$cleanup = $provider->retire( $reference );
+			if ( is_wp_error( $cleanup ) ) {
+				return new WP_Error( 'booking_attachment_cleanup_failed', __( 'A failed booking attachment could not be cleaned up safely.', 'extrachill-api' ), array( 'status' => 503 ) );
+			}
+			return extrachill_api_booking_public_error( $attached );
+		}
+		$existing[] = $attached;
+	}
+
+	return true;
+}
+
+/** Keep domain details private while preserving stable HTTP classes. */
+function extrachill_api_booking_public_error( WP_Error $error ) {
+	$code   = $error->get_error_code();
+	$data   = (array) $error->get_error_data();
+	$status = (int) ( $data['status'] ?? 0 );
+	if ( $status < 400 || $status > 599 ) {
+		$status = 0 === strpos( $code, 'invalid_' ) || false !== strpos( $code, '_required' ) ? 400 : 503;
+	}
+	$public_code = in_array( $status, array( 400, 403, 409, 413, 429 ), true ) ? $code : 'booking_inquiry_unavailable';
+	$message     = in_array( $status, array( 400, 403, 409, 413, 429 ), true ) ? $error->get_error_message() : __( 'Booking inquiry processing is temporarily unavailable.', 'extrachill-api' );
+	return new WP_Error( $public_code, $message, array( 'status' => $status ) );
+}
+
+/** Add file descriptors to the affinity signature without exposing bytes. */
+function extrachill_api_booking_affinity_signature_body( $body, WP_REST_Request $request ) {
+	if ( ! preg_match( '#^/extrachill/v1/venues/\d+/booking-inquiries$#', $request->get_route() ) ) {
+		return $body;
+	}
+	if ( empty( $body['_ec_affinity_client'] ) ) {
+		$client_ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+		if ( '' !== $client_ip && false !== filter_var( $client_ip, FILTER_VALIDATE_IP ) ) {
+			$body['_ec_affinity_client']      = hash_hmac( 'sha256', $client_ip, wp_salt( 'nonce' ) );
+			$body['_ec_affinity_remote_addr'] = $client_ip;
+		}
+	}
+	$encoded = $request->get_param( EXTRACHILL_API_BOOKING_FILES );
+	if ( is_string( $encoded ) ) {
+		$decoded = json_decode( $encoded, true );
+		if ( is_array( $decoded ) ) {
+			$body[ EXTRACHILL_API_BOOKING_FILES ] = $decoded;
+		}
+		return $body;
+	}
+	$files = extrachill_api_normalize_booking_files( $request );
+	if ( is_wp_error( $files ) || ! $files ) {
+		return $body;
+	}
+	foreach ( $body as $key => $value ) {
+		if ( is_array( $value ) ) {
+			$body[ $key ] = wp_json_encode( $value );
+		}
+	}
+	$body[ EXTRACHILL_API_BOOKING_FILES ] = extrachill_api_booking_file_descriptors( $files );
+	return $body;
+}
+
+/** Return signed descriptors used to verify the loopback multipart body. */
+function extrachill_api_booking_file_descriptors( array $files ) {
+	$descriptors = array();
+	foreach ( $files as $file ) {
+		$descriptors[] = array(
+			'name'    => sanitize_file_name( $file['name'] ),
+			'size'    => (int) $file['size'],
+			'purpose' => $file['purpose'],
+			'hash'    => $file['sha256'],
+		);
+	}
+	return $descriptors;
+}
+
+/** Preserve multipart booking files over the signed Events-site loopback. */
+function extrachill_api_booking_affinity_file_forward( $response, $target_site, $path, $args, WP_REST_Request $request ) {
+	if ( 'events' !== $target_site || ! preg_match( '#^/venues/\d+/booking-inquiries$#', $path ) || ! $request->get_file_params() ) {
+		return $response;
+	}
+	$files = extrachill_api_normalize_booking_files( $request );
+	if ( is_wp_error( $files ) ) {
+		return $files;
+	}
+	$site_url = ec_get_site_url( $target_site );
+	$host     = wp_parse_url( $site_url, PHP_URL_HOST );
+	if ( ! $host ) {
+		return new WP_Error( 'route_affinity_target_invalid', 'Could not resolve route-affinity target host.', array( 'status' => 500 ) );
+	}
+	$boundary = 'ec-' . wp_generate_password( 32, false, false );
+	$body     = extrachill_api_booking_multipart_body( (array) ( $args['body'] ?? array() ), $files, $boundary );
+	$headers  = array_merge(
+		(array) ( $args['headers'] ?? array() ),
+		array(
+			'Host'         => $host,
+			'Accept'       => 'application/json',
+			'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
+		)
+	);
+	return wp_remote_request(
+		'https://127.0.0.1/wp-json/extrachill/v1' . $path,
+		array(
+			'method'    => 'POST',
+			'headers'   => $headers,
+			'body'      => $body,
+			'timeout'   => 30,
+			'sslverify' => false,
+		)
+	);
+}
+
+/** Build the one endpoint-specific multipart loopback body. */
+function extrachill_api_booking_multipart_body( array $fields, array $files, $boundary ) {
+	$eol  = "\r\n";
+	$body = '';
+	foreach ( $fields as $name => $value ) {
+		if ( EXTRACHILL_API_BOOKING_FILES === $name ) {
+			$value = wp_json_encode( $value );
+		} elseif ( is_array( $value ) ) {
+			$value = wp_json_encode( $value );
+		}
+		$body .= '--' . $boundary . $eol;
+		$body .= 'Content-Disposition: form-data; name="' . sanitize_key( $name ) . '"' . $eol . $eol;
+		$body .= (string) $value . $eol;
+	}
+	foreach ( $files as $file ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Server-controlled temporary upload, not a URL.
+		$bytes = file_get_contents( $file['tmp_name'] );
+		$body .= '--' . $boundary . $eol;
+		$body .= 'Content-Disposition: form-data; name="attachments[]"; filename="' . sanitize_file_name( $file['name'] ) . '"' . $eol;
+		$body .= 'Content-Type: application/octet-stream' . $eol . $eol;
+		$body .= false === $bytes ? '' : $bytes;
+		$body .= $eol;
+	}
+	return $body . '--' . $boundary . '--' . $eol;
+}

--- a/tests/Unit/routes/events/BookingInquiriesTest.php
+++ b/tests/Unit/routes/events/BookingInquiriesTest.php
@@ -1,0 +1,298 @@
+<?php
+/**
+ * Tests for protected public booking inquiry admission.
+ *
+ * @package ExtraChill\API\Tests
+ */
+
+/** Exercises the facade without duplicating Events domain behavior. */
+class Booking_InquiriesTest extends WP_UnitTestCase {
+
+	/** @var array */
+	private $ability_inputs = array();
+
+	/** @var array */
+	private $temporary_files = array();
+
+	public function set_up() {
+		parent::set_up();
+		$this->ability_inputs  = array();
+		$this->temporary_files = array();
+		if ( isset( wp_get_abilities()[ EXTRACHILL_API_BOOKING_ABILITY ] ) ) {
+			wp_unregister_ability( EXTRACHILL_API_BOOKING_ABILITY );
+		}
+		$this->register_booking_ability();
+		$_SERVER['REMOTE_ADDR'] = '198.51.100.' . random_int( 1, 250 );
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'extrachill_bypass_turnstile_verification' );
+		remove_all_filters( 'extrachill_api_booking_inquiry_rate_limit' );
+		remove_all_filters( 'extrachill_api_allow_test_booking_file' );
+		foreach ( $this->temporary_files as $file ) {
+			if ( file_exists( $file ) ) {
+				unlink( $file );
+			}
+		}
+		if ( isset( wp_get_abilities()[ EXTRACHILL_API_BOOKING_ABILITY ] ) ) {
+			wp_unregister_ability( EXTRACHILL_API_BOOKING_ABILITY );
+		}
+		if ( isset( wp_get_ability_categories()['test'] ) ) {
+			wp_unregister_ability_category( 'test' );
+		}
+		parent::tear_down();
+	}
+
+	public function test_route_is_registered_for_anonymous_callers() {
+		do_action( 'rest_api_init' );
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/extrachill/v1/venues/(?P<venue>\d+)/booking-inquiries', $routes );
+		$this->assertSame( 'extrachill_api_booking_inquiry_permission', $routes['/extrachill/v1/venues/(?P<venue>\d+)/booking-inquiries'][0]['permission_callback'] );
+	}
+
+	public function test_route_affinity_uses_events_segment_boundary() {
+		$map = extrachill_api_add_booking_route_affinity( array() );
+
+		$this->assertSame( 'events', $map['/extrachill/v1/venues/'] );
+		$this->assertStringStartsWith( '/extrachill/v1/venues/', '/extrachill/v1/venues/42/booking-inquiries' );
+		$this->assertStringStartsNotWith( '/extrachill/v1/venues/', '/extrachill/v1/venuesfoo/42/booking-inquiries' );
+	}
+
+	public function test_anonymous_submission_invokes_hidden_ability() {
+		$request = $this->valid_request();
+		$result  = extrachill_api_handle_booking_inquiry( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( 201, $result->get_status() );
+		$this->assertSame( 42, $this->ability_inputs[0]['venue_term_id'] );
+		$this->assertArrayNotHasKey( 'user_id', $this->ability_inputs[0] );
+		$this->assertSame( 0, get_current_user_id() );
+	}
+
+	public function test_submitted_identity_is_never_forwarded() {
+		$request = $this->valid_request();
+		$request->set_param( 'user_id', 999 );
+		$request->set_param( 'submitter_user_id', 998 );
+		extrachill_api_handle_booking_inquiry( $request );
+
+		$this->assertArrayNotHasKey( 'user_id', $this->ability_inputs[0] );
+		$this->assertArrayNotHasKey( 'submitter_user_id', $this->ability_inputs[0] );
+	}
+
+	public function test_authenticated_identity_remains_request_identity() {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		extrachill_api_handle_booking_inquiry( $this->valid_request() );
+
+		$this->assertSame( $user_id, get_current_user_id() );
+		$this->assertArrayNotHasKey( 'user_id', $this->ability_inputs[0] );
+	}
+
+	public function test_missing_turnstile_primitive_fails_before_ability_execution() {
+		$request = $this->valid_request();
+		$request->set_param( 'turnstile_response', '' );
+		$result = extrachill_api_booking_inquiry_permission( $request );
+
+		$this->assertWPError( $result );
+		$this->assertContains( $result->get_error_code(), array( 'booking_security_unavailable', 'turnstile_missing_token' ) );
+		$this->assertEmpty( $this->ability_inputs );
+	}
+
+	public function test_rate_limit_returns_stable_429() {
+		$request = $this->valid_request();
+		$scope   = 'booking-test-' . wp_generate_uuid4();
+		$this->assertTrue( extrachill_api_check_public_write_rate_limit( $request, $scope, 1 ) );
+		$result = extrachill_api_check_public_write_rate_limit( $request, $scope, 1 );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'public_write_rate_limited', $result->get_error_code() );
+		$this->assertSame( 429, $result->get_error_data()['status'] );
+	}
+
+	public function test_unsigned_remote_address_is_not_trusted() {
+		$request = $this->valid_request();
+		$request->set_param( '_ec_affinity_remote_addr', '203.0.113.99' );
+
+		$this->assertNotSame( '203.0.113.99', $_SERVER['REMOTE_ADDR'] );
+		$this->assertNotSame( '1', $request->get_header( 'X-EC-Affinity-Verified' ) );
+	}
+
+	public function test_duplicate_retry_preserves_exact_ability_input() {
+		$request = $this->valid_request();
+		$first   = extrachill_api_handle_booking_inquiry( $request );
+		$second  = extrachill_api_handle_booking_inquiry( $request );
+
+		$this->assertSame( $first->get_data(), $second->get_data() );
+		$this->assertSame( $this->ability_inputs[0], $this->ability_inputs[1] );
+	}
+
+	public function test_multipart_normalization_adds_only_a_fingerprint_to_intake() {
+		$request = $this->valid_request();
+		$file    = $this->uploaded_file( 'press.txt', 'press notes' );
+		$request->set_file_params( array( 'attachments' => $file ) );
+		$request->set_param( 'attachment_purposes', array( 'press_release' ) );
+
+		$files = extrachill_api_normalize_booking_files( $request );
+		$input = extrachill_api_booking_ability_input( $request, $files );
+
+		$this->assertCount( 1, $files );
+		$this->assertSame( 'press_release', $files[0]['purpose'] );
+		$this->assertSame( 1, $input['intake']['_attachment_admission']['count'] );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', $input['intake']['_attachment_admission']['fingerprint'] );
+		$this->assertStringNotContainsString( $file['tmp_name'], wp_json_encode( $input ) );
+	}
+
+	public function test_multipart_upload_and_purpose_failures_are_stable() {
+		$request = $this->valid_request();
+		$file    = $this->uploaded_file( 'press.txt', 'press notes' );
+		$file['error'] = UPLOAD_ERR_PARTIAL;
+		$request->set_file_params( array( 'attachments' => $file ) );
+		$request->set_param( 'attachment_purposes', array( 'press_release' ) );
+		$result = extrachill_api_normalize_booking_files( $request );
+		$this->assertSame( 'booking_attachment_upload_failed', $result->get_error_code() );
+
+		$file['error'] = UPLOAD_ERR_OK;
+		$request->set_file_params( array( 'attachments' => $file ) );
+		$request->set_param( 'attachment_purposes', array() );
+		$result = extrachill_api_normalize_booking_files( $request );
+		$this->assertSame( 'booking_attachment_purpose_mismatch', $result->get_error_code() );
+	}
+
+	public function test_verified_multipart_rejects_changed_bytes() {
+		$request = $this->valid_request();
+		$file    = $this->uploaded_file( 'press.txt', 'changed bytes' );
+		$request->set_file_params( array( 'attachments' => $file ) );
+		$request->set_param( 'attachment_purposes', array( 'press_release' ) );
+		$request->set_param( EXTRACHILL_API_BOOKING_FILES, wp_json_encode( array( array( 'name' => 'press.txt', 'size' => 1, 'purpose' => 'press_release', 'hash' => str_repeat( 'a', 64 ) ) ) ) );
+		$request->set_header( 'X-EC-Affinity-Verified', '1' );
+
+		$result = extrachill_api_normalize_booking_files( $request );
+		$this->assertSame( 'booking_attachment_transport_invalid', $result->get_error_code() );
+	}
+
+	public function test_route_fields_cover_backing_ability_schema() {
+		$args    = extrachill_api_booking_inquiry_args();
+		$ability = wp_get_abilities()[ EXTRACHILL_API_BOOKING_ABILITY ];
+		$schema  = $ability->get_input_schema();
+		$mapped  = array_diff( array_keys( $args ), array( 'venue', 'turnstile_response', 'attachment_purposes' ) );
+		$mapped[] = 'venue_term_id';
+
+		$this->assertEmpty( array_diff( $schema['required'], $mapped ) );
+		$this->assertEmpty( array_diff( $mapped, array_keys( $schema['properties'] ) ) );
+	}
+
+	public function test_hidden_ability_cannot_run_through_generic_rest() {
+		$controller = new WP_REST_Abilities_V1_Run_Controller();
+		$request    = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/' . EXTRACHILL_API_BOOKING_ABILITY . '/run' );
+		$request->set_param( 'name', EXTRACHILL_API_BOOKING_ABILITY );
+		$result = $controller->check_ability_permissions( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_ability_not_found', $result->get_error_code() );
+	}
+
+	public function test_domain_errors_map_to_stable_public_statuses() {
+		$conflict = extrachill_api_booking_public_error( new WP_Error( 'booking_idempotency_conflict', 'Conflict.', array( 'status' => 409 ) ) );
+		$internal = extrachill_api_booking_public_error( new WP_Error( 'booking_read_failed', 'Database details.' ) );
+
+		$this->assertSame( 409, $conflict->get_error_data()['status'] );
+		$this->assertSame( 'booking_idempotency_conflict', $conflict->get_error_code() );
+		$this->assertSame( 503, $internal->get_error_data()['status'] );
+		$this->assertSame( 'booking_inquiry_unavailable', $internal->get_error_code() );
+		$this->assertStringNotContainsString( 'Database', $internal->get_error_message() );
+	}
+
+	public function test_attachment_failure_path_requires_private_cleanup() {
+		$source = file_get_contents( dirname( __DIR__, 4 ) . '/inc/routes/events/booking-inquiries.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source contract fixture.
+		$this->assertStringContainsString( '$provider->retire( $reference )', $source );
+		$this->assertStringContainsString( 'booking_attachment_cleanup_failed', $source );
+	}
+
+	private function register_booking_ability() {
+		$test = $this;
+		$register_category = static function () {
+			wp_register_ability_category(
+				'test',
+				array(
+					'label'       => 'Test',
+					'description' => 'Test-only ability contracts.',
+				)
+			);
+		};
+		add_action( 'wp_abilities_api_categories_init', $register_category );
+		do_action( 'wp_abilities_api_categories_init' );
+		remove_action( 'wp_abilities_api_categories_init', $register_category );
+
+		$register = static function () use ( $test ) {
+			wp_register_ability(
+				EXTRACHILL_API_BOOKING_ABILITY,
+				array(
+					'label'               => 'Test booking inquiry',
+					'description'         => 'Test hidden public booking inquiry contract.',
+					'category'            => 'test',
+					'input_schema'        => array(
+						'type'                 => 'object',
+						'properties'           => array(
+							'idempotency_key'     => array( 'type' => 'string' ),
+							'venue_term_id'       => array( 'type' => 'integer' ),
+							'artist_term_id'      => array( 'type' => array( 'integer', 'null' ) ),
+							'artist_profile_id'   => array( 'type' => array( 'integer', 'null' ) ),
+							'artist_name'         => array( 'type' => 'string' ),
+							'contact_name'        => array( 'type' => array( 'string', 'null' ) ),
+							'contact_email'       => array( 'type' => array( 'string', 'null' ) ),
+							'contact_phone'       => array( 'type' => array( 'string', 'null' ) ),
+							'requested_space_key' => array( 'type' => array( 'string', 'null' ) ),
+							'requested_start_at'  => array( 'type' => array( 'string', 'null' ) ),
+							'requested_end_at'    => array( 'type' => array( 'string', 'null' ) ),
+							'intake'              => array( 'type' => 'object' ),
+						),
+						'required'             => array( 'idempotency_key', 'venue_term_id', 'intake' ),
+						'additionalProperties' => false,
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'permission_callback' => '__return_true',
+					'execute_callback'    => static function ( $input ) use ( $test ) {
+						$test->ability_inputs[] = $input;
+						return array(
+							'public_id'     => '11111111-1111-4111-8111-111111111111',
+							'venue_term_id' => $input['venue_term_id'],
+							'submitted_at'  => '2026-07-24 20:00:00',
+						);
+					},
+					'meta'                => array(
+						'show_in_rest' => false,
+						'annotations'  => array( 'readonly' => false, 'idempotent' => true, 'destructive' => false ),
+					),
+				)
+			);
+		};
+		add_action( 'wp_abilities_api_init', $register );
+		do_action( 'wp_abilities_api_init' );
+		remove_action( 'wp_abilities_api_init', $register );
+	}
+
+	private function valid_request() {
+		$request = new WP_REST_Request( 'POST', '/extrachill/v1/venues/42/booking-inquiries' );
+		$request->set_param( 'venue', 42 );
+		$request->set_param( 'idempotency_key', 'request-123' );
+		$request->set_param( 'artist_name', 'Test Artist' );
+		$request->set_param( 'contact_email', 'artist@example.com' );
+		$request->set_param( 'intake', array( 'message' => 'Booking request.' ) );
+		$request->set_param( 'turnstile_response', 'test-token' );
+		return $request;
+	}
+
+	private function uploaded_file( $name, $contents ) {
+		$file = tempnam( sys_get_temp_dir(), 'ec-booking-test-' );
+		file_put_contents( $file, $contents ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture.
+		$this->temporary_files[] = $file;
+		add_filter( 'extrachill_api_allow_test_booking_file', '__return_true' );
+		return array(
+			'name'     => $name,
+			'type'     => 'text/plain',
+			'tmp_name' => $file,
+			'error'    => UPLOAD_ERR_OK,
+			'size'     => filesize( $file ),
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- add `POST /extrachill/v1/venues/{venue}/booking-inquiries` as an anonymous-capable, Turnstile-protected and rate-limited facade over hidden `extrachill/create-booking-inquiry`
- preserve Events-site route affinity for JSON and multipart requests, including signed file descriptors, original client admission identity, and stable downstream HTTP responses
- stage and claim multipart attachments only through Events-owned private provider/service contracts, with idempotent retries and fail-closed provisional cleanup

## Checked primitives
- WordPress route args, `WP_REST_Request` JSON/body/file normalization, and core Abilities REST `show_in_rest` enforcement
- Extra Chill Network `ec_turnstile_check_request()`, `ec_cross_site_rest_request()`, signed internal identity, and route-affinity resolver
- existing Extra Chill API telemetry fixed-window rate limiter, extracted into one shared public-write admission helper
- merged Events `extrachill/create-booking-inquiry` schema/receipt, `BookingPrivateFileProviders::resolve()`, `BookingAttachmentService::attach()`, booking repositories, and attachment policy
- WordPress public uploads and Data Machine flow files were explicitly rejected for private booking bytes; no parallel storage or upload substrate was added

## Facade/domain boundary
The API facade owns HTTP admission only: route affinity, Turnstile, per-client throttling, REST/multipart normalization, signed loopback file integrity, idempotency transport, and stable HTTP error classes. Events continues to own venue admission state, booking creation, identity binding from the actual request context, private byte validation/storage, attachment authorization/claims, activity, and cleanup policy. The facade performs no SQL, state transitions, email, venue policy, or booking persistence.

The route never accepts a submitted user ID as authority. Anonymous requests remain valid; an already authenticated caller remains the current WordPress request identity through the existing signed affinity transport, allowing the merged Events ability to bind that identity. Broader cookie/bearer identity policy and authenticated-caller test expansion remain tracked in #124.

The inquiry ability remains `show_in_rest: false`; core `WP_REST_Abilities_V1_Run_Controller` therefore returns `rest_ability_not_found` instead of exposing an unprotected generic public-write bypass.

## Verification
- focused booking and telemetry tests: `27 tests, 67 assertions`
- PHPCS: passed
- PHPStan level 7: passed
- PHP syntax and `git diff --check`: passed
- Homeboy PR audit: no introduced findings
- Homeboy production build: passed
- an initial unfiltered Homeboy run exposed the repository's existing validation-dependency/legacy-suite failures; filtered tests for this change pass cleanly

Closes #123