### PR TITLE
feat: integrate protected booking transport contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ The plugin ships route files under `inc/routes/` (loaded recursively) and regist
 ### Event Submissions (1)
 - `POST /event-submissions` - Submit event with optional flyer
 
+### Venue Booking Transport (2)
+- `POST /venues/{venue}/booking-inquiries` - Submit a Turnstile-protected anonymous or authenticated booking inquiry
+- `GET /events/bookings/{booking_id}/attachments/{attachment_id}/download` - Stream an authorized private booking attachment
+
 ### Media Management (1)
 - `POST /media` - Upload media
 

--- a/docs/routes/events/booking-transport.md
+++ b/docs/routes/events/booking-transport.md
@@ -6,7 +6,7 @@ The API plugin owns only protected HTTP admission and byte transport. Extra Chil
 
 `POST /wp-json/extrachill/v1/venues/{venue}/booking-inquiries`
 
-Anonymous, cookie-authenticated, and bearer-authenticated callers use the same Turnstile and rate-limit admission. Authentication is optional. When WordPress has validated a caller, Events reads that canonical current user from request context. Form fields such as `user_id`, `submitter_user_id`, and `uploader_user_id` are rejected and never become authority.
+Anonymous, cookie-authenticated, and bearer-authenticated callers use the same Turnstile and atomic fixed-window rate-limit admission. Authentication is optional. When WordPress has validated a caller, Events reads that canonical current user from request context. Multipart and JSON affinity hops use the same signed internal-user transport. Form fields such as `user_id`, `submitter_user_id`, and `uploader_user_id` are rejected and never become authority.
 
 JSON requests provide the inquiry fields directly. Multipart requests provide `intake` and `attachment_purposes` as JSON strings plus up to five `attachments[]` files. Transport limits are 20 MiB per file and 50 MiB in aggregate. Events applies the authoritative filename, MIME, purpose, scan, storage, and venue policy.
 
@@ -18,7 +18,7 @@ An exact retry with the same `idempotency_key`, fields, and ordered attachment b
 
 The caller must be authenticated and currently authorized by Events for the booking's exact venue. The API issues and consumes an Events-owned one-time handoff, supports one byte range, and streams at most 20 MiB. `HEAD` and REST `_envelope` requests cannot consume a handoff.
 
-Success is `200` or `206` with `Content-Disposition`, `Content-Length`, `Content-Type`, `Accept-Ranges`, `X-EC-Download-Correlation`, and private `no-store` headers. The correlation is issued by Events and is not accepted from clients. Every consumed handoff records `completed`, `failed`, `interrupted`, or `partial` against that correlation. Route-affinity spools are mode `0600`, bounded, and removed after serving, failure, interruption, or shutdown.
+Success is `200` or `206` with `Content-Disposition`, `Content-Length`, `Content-Type`, `Accept-Ranges`, and private `no-store` headers. The Events correlation is never exposed publicly or accepted from clients. For an affinity hop, nonce-bound internal response metadata transfers it to the outer worker and is stripped before the client response. Only that client-facing worker records `completed`, `failed`, `interrupted`, or `partial` after the actual stream outcome. Route-affinity spools are mode `0600`, bounded, and removed after serving, failure, interruption, or shutdown.
 
 ## Stable Errors
 
@@ -46,4 +46,4 @@ Success is `200` or `206` with `Content-Disposition`, `Content-Length`, `Content
 | Unknown inquiry failure | `booking_inquiry_unavailable` | 503 | Keep the draft and retry later. |
 | Unknown download failure | `booking_attachment_download_unavailable` | 502 or 503 | Retry later without exposing transport internals. |
 
-Errors and logs must never contain temporary paths, storage roots, hashes, storage or object references, handoff tokens, internal identities, or private bytes.
+Only the explicit code/message/status/field contracts above are forwarded. An unknown domain error is always `booking_inquiry_unavailable` (`503`) regardless of its original status. Errors and logs must never contain temporary paths, storage roots, hashes, storage or object references, handoff tokens, delivery correlations, internal identities, or private bytes.

--- a/docs/routes/events/booking-transport.md
+++ b/docs/routes/events/booking-transport.md
@@ -1,0 +1,49 @@
+# Booking Transport
+
+The API plugin owns only protected HTTP admission and byte transport. Extra Chill Events owns booking persistence, venue policy, authorization, idempotency, attachment storage and policy, one-time handoffs, delivery activity, and durable cleanup.
+
+## Submit An Inquiry
+
+`POST /wp-json/extrachill/v1/venues/{venue}/booking-inquiries`
+
+Anonymous, cookie-authenticated, and bearer-authenticated callers use the same Turnstile and rate-limit admission. Authentication is optional. When WordPress has validated a caller, Events reads that canonical current user from request context. Form fields such as `user_id`, `submitter_user_id`, and `uploader_user_id` are rejected and never become authority.
+
+JSON requests provide the inquiry fields directly. Multipart requests provide `intake` and `attachment_purposes` as JSON strings plus up to five `attachments[]` files. Transport limits are 20 MiB per file and 50 MiB in aggregate. Events applies the authoritative filename, MIME, purpose, scan, storage, and venue policy.
+
+An exact retry with the same `idempotency_key`, fields, and ordered attachment bytes returns the same immutable receipt. Reusing the key with changed input returns `booking_idempotency_conflict` (`409`). The receipt contains only `public_id`, `venue_term_id`, and `submitted_at`.
+
+## Download An Attachment
+
+`GET /wp-json/extrachill/v1/events/bookings/{booking_id}/attachments/{attachment_id}/download`
+
+The caller must be authenticated and currently authorized by Events for the booking's exact venue. The API issues and consumes an Events-owned one-time handoff, supports one byte range, and streams at most 20 MiB. `HEAD` and REST `_envelope` requests cannot consume a handoff.
+
+Success is `200` or `206` with `Content-Disposition`, `Content-Length`, `Content-Type`, `Accept-Ranges`, `X-EC-Download-Correlation`, and private `no-store` headers. The correlation is issued by Events and is not accepted from clients. Every consumed handoff records `completed`, `failed`, `interrupted`, or `partial` against that correlation. Route-affinity spools are mode `0600`, bounded, and removed after serving, failure, interruption, or shutdown.
+
+## Stable Errors
+
+| Situation | Code | Status | Client action |
+|---|---|---:|---|
+| REST field validation | `rest_missing_callback_param` or `rest_invalid_param` | 400 | Use `data.params` and `data.details` as field paths. |
+| Submitted user authority | `booking_identity_not_allowed` | 400 | Remove all submitted user ID fields. |
+| Invalid canonical identity | `booking_authentication_invalid` | 401 | Refresh or clear authentication, then retry. |
+| Exact duplicate inquiry | Successful immutable receipt | 201 | Treat the returned `public_id` as the existing receipt. |
+| Changed idempotent retry | `booking_idempotency_conflict` | 409 | Generate a new key only for an intentionally new inquiry. |
+| Missing Turnstile token | `turnstile_missing_token` | 403 | Render and submit a challenge. |
+| Expired or invalid Turnstile token | `turnstile_failed` | 403 | Refresh the challenge and retry. |
+| Inquiry rate limit | `public_write_rate_limited` | 429 | Wait for the `Retry-After` seconds. |
+| Stale booking configuration | `booking_inquiry_stale_config` | 409 | Refresh configuration before resubmitting. |
+| Intake disabled or unavailable | `booking_inquiry_unavailable` | 503 | Keep the draft and retry later. |
+| Attachment count/upload mismatch | `booking_attachment_count_invalid`, `booking_attachment_upload_failed`, or `booking_attachment_purpose_mismatch` | 400 | Correct the multipart request. |
+| Attachment too large | `booking_attachment_size_invalid` or `booking_attachment_aggregate_size_invalid` | 413 | Remove or reduce files. |
+| Attachment policy rejection | `booking_attachment_rejected` | 400 or 413 | Show the safe Events message next to the attachment. |
+| Attachment storage or scan unavailable | `booking_inquiry_unavailable` | 503 | Keep the draft and retry later; internals remain hidden. |
+| Uncertain inquiry attachment outcome | `booking_inquiry_reconciliation_required` | 503 | Do not change the idempotency key; retry only when reconciliation allows it. |
+| Download unauthenticated | `booking_attachment_download_unavailable` | 401 | Authenticate. |
+| Download unauthorized, revoked, missing, expired, replayed, or tampered | `booking_attachment_download_unavailable` | 404 | Do not reveal which condition occurred. |
+| Download rate limit | `booking_attachment_download_rate_limited` | 429 | Wait for the `Retry-After` seconds. |
+| Invalid or unsatisfiable range | `booking_attachment_range_unsatisfiable` | 416 | Retry with one valid range; inspect `Content-Range`. |
+| Unknown inquiry failure | `booking_inquiry_unavailable` | 503 | Keep the draft and retry later. |
+| Unknown download failure | `booking_attachment_download_unavailable` | 502 or 503 | Retry later without exposing transport internals. |
+
+Errors and logs must never contain temporary paths, storage roots, hashes, storage or object references, handoff tokens, internal identities, or private bytes.

--- a/extrachill-api.php
+++ b/extrachill-api.php
@@ -5,6 +5,7 @@
  * Description: Central REST API infrastructure for the Extra Chill multisite network.
  * Version: 0.26.1
  * Requires PHP: 8.4
+ * Requires Plugins: extrachill-network
  * Author: Extra Chill
  * Author URI: https://extrachill.com
  * Network: true

--- a/homeboy.json
+++ b/homeboy.json
@@ -4,13 +4,7 @@
   "extensions": {
     "wordpress": {
       "settings": {
-        "validation_dependencies": [
-          {
-            "path": "../extrachill-network",
-            "plugin_slug": "extrachill-network",
-            "activate": true
-          }
-        ],
+        "validation_dependencies": ["/var/lib/datamachine/workspace/extrachill-network"],
         "wordpress_runtime_php_version": "8.4"
       }
     }

--- a/homeboy.json
+++ b/homeboy.json
@@ -4,7 +4,13 @@
   "extensions": {
     "wordpress": {
       "settings": {
-        "validation_dependencies": ["data-machine", "extrachill-network"],
+        "validation_dependencies": [
+          {
+            "path": "../extrachill-network",
+            "plugin_slug": "extrachill-network",
+            "activate": true
+          }
+        ],
         "wordpress_runtime_php_version": "8.4"
       }
     }

--- a/inc/middleware/public-write-admission.php
+++ b/inc/middleware/public-write-admission.php
@@ -10,7 +10,60 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Apply the existing per-client transient limiter to one public-write scope.
+ * Atomically increment one bounded fixed-window counter.
+ *
+ * The production store uses the platform's persistent object cache, where
+ * add/increment are atomic across workers. Tests may replace the store with a
+ * process-safe implementation to exercise concurrent admission deterministically.
+ *
+ * @param string $key Stable opaque counter key.
+ * @param int    $ttl Remaining fixed-window lifetime.
+ * @return int|WP_Error
+ */
+function extrachill_api_atomic_rate_limit_increment( $key, $ttl ) {
+	/**
+	 * Filters the atomic API rate-limit store.
+	 *
+	 * @param callable $store Callable accepting key and TTL.
+	 */
+	$store = apply_filters( 'extrachill_api_rate_limit_store', 'extrachill_api_atomic_rate_limit_cache_increment' );
+	if ( ! is_callable( $store ) ) {
+		return new WP_Error( 'api_rate_limiter_unavailable', __( 'Request admission is temporarily unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
+	}
+	$count = call_user_func( $store, (string) $key, max( 1, (int) $ttl ) );
+	if ( is_wp_error( $count ) ) {
+		return $count;
+	}
+
+	return is_numeric( $count ) && (int) $count > 0
+		? (int) $count
+		: new WP_Error( 'api_rate_limiter_unavailable', __( 'Request admission is temporarily unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
+}
+
+/** Use atomic persistent-cache operations for the production counter. */
+function extrachill_api_atomic_rate_limit_cache_increment( $key, $ttl ) {
+	if ( ! wp_using_ext_object_cache() ) {
+		return new WP_Error( 'api_rate_limiter_unavailable', __( 'Request admission is temporarily unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
+	}
+	$group = 'extrachill_api_rate_limits';
+	if ( wp_cache_add( $key, 1, $group, $ttl ) ) {
+		return 1;
+	}
+	$count = wp_cache_incr( $key, 1, $group );
+
+	return false === $count || ! is_numeric( $count )
+		? new WP_Error( 'api_rate_limiter_unavailable', __( 'Request admission is temporarily unavailable.', 'extrachill-api' ), array( 'status' => 503 ) )
+		: (int) $count;
+}
+
+/** Atomically decide whether this request remains within its exact cap. */
+function extrachill_api_atomic_rate_limit_admit( $key, $limit, $ttl ) {
+	$count = extrachill_api_atomic_rate_limit_increment( $key, $ttl );
+	return is_wp_error( $count ) ? $count : $count <= (int) $limit;
+}
+
+/**
+ * Apply the atomic per-client limiter to one public-write scope.
  *
  * @param WP_REST_Request $request REST request.
  * @param string          $scope   Stable limiter scope.
@@ -23,10 +76,8 @@ function extrachill_api_check_public_write_rate_limit( WP_REST_Request $request,
 		return true;
 	}
 
-	$client = '';
-	if ( '1' === $request->get_header( 'X-EC-Affinity-Verified' ) ) {
-		$client = sanitize_text_field( (string) $request->get_param( '_ec_affinity_client' ) );
-	}
+	$context = function_exists( 'extrachill_api_route_affinity_context' ) ? extrachill_api_route_affinity_context( $request ) : array();
+	$client  = sanitize_text_field( (string) ( $context['client'] ?? '' ) );
 	if ( '' === $client ) {
 		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
 		if ( '' === $ip || false === filter_var( $ip, FILTER_VALIDATE_IP ) ) {
@@ -35,21 +86,25 @@ function extrachill_api_check_public_write_rate_limit( WP_REST_Request $request,
 		$client = hash_hmac( 'sha256', $ip, wp_salt( 'nonce' ) );
 	}
 
-	$key   = 'ec_api_write_' . substr( hash( 'sha256', sanitize_key( $scope ) . ':' . $client ), 0, 32 );
-	$count = (int) get_transient( $key );
-	if ( $count >= $limit ) {
+	$now         = time();
+	$window      = intdiv( $now, MINUTE_IN_SECONDS );
+	$retry_after = ( ( $window + 1 ) * MINUTE_IN_SECONDS ) - $now;
+	$key         = 'write_' . substr( hash( 'sha256', sanitize_key( $scope ) . ':' . $client . ':' . $window ), 0, 40 );
+	$admitted    = extrachill_api_atomic_rate_limit_admit( $key, $limit, $retry_after );
+	if ( is_wp_error( $admitted ) ) {
+		return $admitted;
+	}
+	if ( ! $admitted ) {
 		return new WP_Error(
 			'public_write_rate_limited',
 			__( 'Too many requests. Please try again later.', 'extrachill-api' ),
 			array(
 				'status'      => 429,
-				'retry_after' => MINUTE_IN_SECONDS,
-				'headers'     => array( 'Retry-After' => (string) MINUTE_IN_SECONDS ),
+				'retry_after' => $retry_after,
+				'headers'     => array( 'Retry-After' => (string) $retry_after ),
 			)
 		);
 	}
-
-	set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
 
 	return true;
 }

--- a/inc/middleware/public-write-admission.php
+++ b/inc/middleware/public-write-admission.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Shared fixed-window admission for public REST writes.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Apply the existing per-client transient limiter to one public-write scope.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @param string          $scope   Stable limiter scope.
+ * @param int             $limit   Maximum writes per minute.
+ * @return true|WP_Error
+ */
+function extrachill_api_check_public_write_rate_limit( WP_REST_Request $request, $scope, $limit ) {
+	$limit = (int) $limit;
+	if ( $limit < 1 ) {
+		return true;
+	}
+
+	$client = '';
+	if ( '1' === $request->get_header( 'X-EC-Affinity-Verified' ) ) {
+		$client = sanitize_text_field( (string) $request->get_param( '_ec_affinity_client' ) );
+	}
+	if ( '' === $client ) {
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+		if ( '' === $ip || false === filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+			return true;
+		}
+		$client = hash_hmac( 'sha256', $ip, wp_salt( 'nonce' ) );
+	}
+
+	$key   = 'ec_api_write_' . substr( hash( 'sha256', sanitize_key( $scope ) . ':' . $client ), 0, 32 );
+	$count = (int) get_transient( $key );
+	if ( $count >= $limit ) {
+		return new WP_Error(
+			'public_write_rate_limited',
+			__( 'Too many requests. Please try again later.', 'extrachill-api' ),
+			array(
+				'status'      => 429,
+				'retry_after' => MINUTE_IN_SECONDS,
+				'headers'     => array( 'Retry-After' => (string) MINUTE_IN_SECONDS ),
+			)
+		);
+	}
+
+	set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
+
+	return true;
+}

--- a/inc/middleware/public-write-admission.php
+++ b/inc/middleware/public-write-admission.php
@@ -77,11 +77,16 @@ function extrachill_api_check_public_write_rate_limit( WP_REST_Request $request,
 	}
 
 	$context = function_exists( 'extrachill_api_route_affinity_context' ) ? extrachill_api_route_affinity_context( $request ) : array();
-	$client  = sanitize_text_field( (string) ( $context['client'] ?? '' ) );
-	if ( '' === $client ) {
+	if ( $context ) {
+		$client = strtolower( sanitize_text_field( (string) ( $context['client'] ?? '' ) ) );
+		$ip     = sanitize_text_field( (string) ( $context['remote_addr'] ?? '' ) );
+		if ( 1 !== preg_match( '/^[a-f0-9]{64}$/', $client ) || false === filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+			return new WP_Error( 'public_write_admission_unavailable', __( 'Request admission is temporarily unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
+		}
+	} else {
 		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
 		if ( '' === $ip || false === filter_var( $ip, FILTER_VALIDATE_IP ) ) {
-			return true;
+			return new WP_Error( 'public_write_admission_unavailable', __( 'Request admission is temporarily unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
 		}
 		$client = hash_hmac( 'sha256', $ip, wp_salt( 'nonce' ) );
 	}

--- a/inc/middleware/route-affinity.php
+++ b/inc/middleware/route-affinity.php
@@ -138,6 +138,10 @@ function extrachill_api_route_affinity_forwarded_headers( WP_REST_Request $reque
 			$headers['x-ec-affinity-client']      = $client;
 			$headers['x-ec-affinity-remote-addr'] = $remote;
 		}
+		$handoff = trim( (string) $request->get_header( 'X-EC-Affinity-Download-Handoff' ) );
+		if ( function_exists( 'extrachill_api_decode_booking_attachment_handoff' ) && extrachill_api_decode_booking_attachment_handoff( $handoff ) ) {
+			$headers['x-ec-affinity-download-handoff'] = $handoff;
+		}
 	}
 
 	return $headers;
@@ -254,12 +258,16 @@ function extrachill_api_is_route_affinity_reentry( WP_REST_Request $request ) {
 	// residual replay boundary.
 	$verified = wp_cache_add( 'route_affinity_' . hash( 'sha256', $nonce ), 1, 'extrachill_api', 300 );
 	if ( $verified ) {
+		$download_handoff = function_exists( 'extrachill_api_decode_booking_attachment_handoff' )
+			? extrachill_api_decode_booking_attachment_handoff( $forwarded_headers['x-ec-affinity-download-handoff'] ?? '' )
+			: null;
 		extrachill_api_set_route_affinity_context(
 			$request,
 			array(
 				'client'      => (string) ( $forwarded_headers['x-ec-affinity-client'] ?? '' ),
 				'remote_addr' => (string) ( $forwarded_headers['x-ec-affinity-remote-addr'] ?? '' ),
 				'nonce'       => $nonce,
+				'download_handoff' => $download_handoff,
 			)
 		);
 	}
@@ -347,7 +355,21 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		return new WP_Error( 'route_affinity_target_invalid', 'Could not resolve route-affinity target host.', array( 'status' => 500 ) );
 	}
 
+	$private_stream    = function_exists( 'extrachill_api_is_booking_attachment_download_route' ) && extrachill_api_is_booking_attachment_download_route( $route );
+	$outer_delivery    = null;
 	$forwarded_headers = extrachill_api_route_affinity_forwarded_headers( $request, true );
+	if ( $private_stream ) {
+		$handoff = extrachill_api_prepare_booking_attachment_affinity_handoff( $request );
+		if ( is_wp_error( $handoff ) ) {
+			return extrachill_api_booking_attachment_download_error( 502 );
+		}
+		$forwarded_headers['x-ec-affinity-download-handoff'] = extrachill_api_encode_booking_attachment_handoff( $handoff );
+		$outer_delivery = array(
+			'booking_id'     => (int) $request->get_param( 'booking_id' ),
+			'attachment_id'  => (int) $request->get_param( 'attachment_id' ),
+			'correlation_id' => (string) $handoff['correlation_id'],
+		);
+	}
 	$timestamp         = time();
 	$nonce             = wp_generate_uuid4();
 	$payload           = extrachill_api_route_affinity_payload( $method, $route, $target_host, $query_params, $body, $timestamp, $nonce, $forwarded_headers );
@@ -382,7 +404,6 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		return true;
 	};
 	$forwarded_http_response = null;
-	$private_stream          = function_exists( 'extrachill_api_is_booking_attachment_download_route' ) && extrachill_api_is_booking_attachment_download_route( $route );
 	$private_spool           = null;
 	if ( $private_stream ) {
 		$private_spool = wp_tempnam( 'extrachill-private-download' );
@@ -435,8 +456,7 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		}
 	} catch ( Throwable $throwable ) {
 		if ( $private_stream ) {
-			extrachill_api_discard_private_affinity_spool( $private_spool );
-			$response = extrachill_api_booking_attachment_download_error( 502 );
+			$response = extrachill_api_fail_private_affinity_stream( $private_spool, $outer_delivery );
 		} else {
 			throw $throwable;
 		}
@@ -469,8 +489,7 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 
 	if ( is_wp_error( $response ) ) {
 		if ( $private_stream ) {
-			extrachill_api_discard_private_affinity_spool( $private_spool );
-			return extrachill_api_booking_attachment_download_error( 502 );
+			return extrachill_api_fail_private_affinity_stream( $private_spool, $outer_delivery );
 		}
 		if ( preg_match( '#^/extrachill/v1/venues/\d+/booking-inquiries$#', $route ) && function_exists( 'extrachill_api_booking_public_error' ) ) {
 			$response = extrachill_api_booking_public_error( $response );
@@ -487,8 +506,7 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 	}
 
 	if ( $private_stream ) {
-		extrachill_api_discard_private_affinity_spool( $private_spool );
-		return extrachill_api_booking_attachment_download_error( 502 );
+		return extrachill_api_fail_private_affinity_stream( $private_spool, $outer_delivery );
 	}
 
 	// Return the forwarded response.

--- a/inc/middleware/route-affinity.php
+++ b/inc/middleware/route-affinity.php
@@ -357,6 +357,17 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 
 	$private_stream    = function_exists( 'extrachill_api_is_booking_attachment_download_route' ) && extrachill_api_is_booking_attachment_download_route( $route );
 	$outer_delivery    = null;
+	$private_spool     = null;
+	if ( $private_stream ) {
+		$private_spool = apply_filters( 'extrachill_api_private_affinity_spool_path', wp_tempnam( 'extrachill-private-download' ) );
+		if ( ! is_string( $private_spool ) || '' === $private_spool ) {
+			return extrachill_api_fail_private_affinity_stream( $private_spool, null, 503 );
+		}
+		$spool_protected = apply_filters( 'extrachill_api_private_affinity_spool_protected', chmod( $private_spool, 0600 ), $private_spool ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- Private affinity spool must be process-only.
+		if ( ! $spool_protected ) {
+			return extrachill_api_fail_private_affinity_stream( $private_spool, null, 503 );
+		}
+	}
 	$forwarded_headers = extrachill_api_route_affinity_forwarded_headers( $request, true );
 	if ( $private_stream ) {
 		$handoff = extrachill_api_prepare_booking_attachment_affinity_handoff( $request );
@@ -404,16 +415,6 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		return true;
 	};
 	$forwarded_http_response = null;
-	$private_spool           = null;
-	if ( $private_stream ) {
-		$private_spool = wp_tempnam( 'extrachill-private-download' );
-		if ( ! is_string( $private_spool ) || '' === $private_spool || ! chmod( $private_spool, 0600 ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- Private affinity spool must be process-only.
-			if ( is_string( $private_spool ) && file_exists( $private_spool ) ) {
-				unlink( $private_spool ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Avoid path-observing deletion hooks for private spools.
-			}
-			return extrachill_api_booking_attachment_download_error( 503 );
-		}
-	}
 	$stream_http_response  = static function ( $http_args ) use ( $signature, $private_spool ) {
 		$headers = $http_args['headers'] ?? array();
 		if ( null !== $private_spool && ( $headers['X-EC-Affinity-Signature'] ?? '' ) === $signature ) {
@@ -456,7 +457,7 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		}
 	} catch ( Throwable $throwable ) {
 		if ( $private_stream ) {
-			$response = extrachill_api_fail_private_affinity_stream( $private_spool, $outer_delivery );
+			$response = extrachill_api_booking_attachment_download_error( 502 );
 		} else {
 			throw $throwable;
 		}

--- a/inc/middleware/route-affinity.php
+++ b/inc/middleware/route-affinity.php
@@ -372,7 +372,7 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 	if ( $private_stream ) {
 		$handoff = extrachill_api_prepare_booking_attachment_affinity_handoff( $request );
 		if ( is_wp_error( $handoff ) ) {
-			return extrachill_api_booking_attachment_download_error( 502 );
+			return extrachill_api_fail_private_affinity_stream( $private_spool, null );
 		}
 		$forwarded_headers['x-ec-affinity-download-handoff'] = extrachill_api_encode_booking_attachment_handoff( $handoff );
 		$outer_delivery = array(

--- a/inc/middleware/route-affinity.php
+++ b/inc/middleware/route-affinity.php
@@ -114,13 +114,18 @@ function extrachill_api_route_affinity_request_body( WP_REST_Request $request ) 
 	}
 
 	$body = $request->get_json_params();
-	if ( ! empty( $body ) ) {
-		return $body;
+	if ( empty( $body ) ) {
+		$body = $request->get_body_params();
 	}
+	$body = ! empty( $body ) ? $body : array();
 
-	$body = $request->get_body_params();
-
-	return ! empty( $body ) ? $body : array();
+	/**
+	 * Filters the signed body representation for transport-only request data.
+	 *
+	 * @param array           $body    Parsed request body.
+	 * @param WP_REST_Request $request Request being forwarded or verified.
+	 */
+	return apply_filters( 'extrachill_api_route_affinity_signature_body', $body, $request );
 }
 
 /**
@@ -187,7 +192,12 @@ function extrachill_api_is_route_affinity_reentry( WP_REST_Request $request ) {
 	// Persistent object caches make this single-use across loopback workers.
 	// Without one, localhost and the five-minute signature window remain the
 	// residual replay boundary.
-	return wp_cache_add( 'route_affinity_' . hash( 'sha256', $nonce ), 1, 'extrachill_api', 300 );
+	$verified = wp_cache_add( 'route_affinity_' . hash( 'sha256', $nonce ), 1, 'extrachill_api', 300 );
+	if ( $verified ) {
+		$request->set_header( 'X-EC-Affinity-Verified', '1' );
+	}
+
+	return $verified;
 }
 
 /**
@@ -314,7 +324,20 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 	add_filter( 'http_response', $capture_http_response, PHP_INT_MAX, 2 );
 
 	try {
-		$response = ec_cross_site_rest_request( $target_site, $method, $path, $args );
+		/**
+		 * Allows a route owner to preserve admitted files over the HTTP hop.
+		 * A null result falls through to the standard JSON transport.
+		 *
+		 * @param mixed           $response    Forwarded result or null.
+		 * @param string          $target_site Target site key.
+		 * @param string          $path        Namespace-relative path.
+		 * @param array           $args        Signed forwarding arguments.
+		 * @param WP_REST_Request $request     Original request.
+		 */
+		$response = apply_filters( 'extrachill_api_route_affinity_file_forward', null, $target_site, $path, $args, $request );
+		if ( null === $response ) {
+			$response = ec_cross_site_rest_request( $target_site, $method, $path, $args );
+		}
 	} finally {
 		remove_filter( 'ec_cross_site_use_http_loopback', $force_http_loopback, 10 );
 		remove_filter( 'pre_http_request', $capture_http_response, PHP_INT_MAX );

--- a/inc/middleware/route-affinity.php
+++ b/inc/middleware/route-affinity.php
@@ -472,6 +472,9 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 			extrachill_api_discard_private_affinity_spool( $private_spool );
 			return extrachill_api_booking_attachment_download_error( 502 );
 		}
+		if ( preg_match( '#^/extrachill/v1/venues/\d+/booking-inquiries$#', $route ) && function_exists( 'extrachill_api_booking_public_error' ) ) {
+			$response = extrachill_api_booking_public_error( $response );
+		}
 		$status = $response->get_error_data()['status'] ?? 500;
 		return new WP_REST_Response(
 			array(

--- a/inc/middleware/route-affinity.php
+++ b/inc/middleware/route-affinity.php
@@ -82,11 +82,13 @@ function extrachill_api_canonicalize_affinity_query( $query ) {
  * @param mixed  $body        Request body.
  * @param int    $timestamp   Unix timestamp.
  * @param string $nonce       Single-use nonce.
+ * @param array  $headers     Allowlisted forwarded headers.
  * @return string
  */
-function extrachill_api_route_affinity_payload( $method, $route, $target_host, $query, $body, $timestamp, $nonce ) {
-	$query_digest = hash( 'sha256', wp_json_encode( extrachill_api_canonicalize_affinity_query( $query ) ) );
-	$body_digest  = hash( 'sha256', wp_json_encode( extrachill_api_normalize_affinity_data( $body ) ) );
+function extrachill_api_route_affinity_payload( $method, $route, $target_host, $query, $body, $timestamp, $nonce, $headers = array() ) {
+	$query_digest  = hash( 'sha256', wp_json_encode( extrachill_api_canonicalize_affinity_query( $query ) ) );
+	$body_digest   = hash( 'sha256', wp_json_encode( extrachill_api_normalize_affinity_data( $body ) ) );
+	$header_digest = hash( 'sha256', wp_json_encode( extrachill_api_normalize_affinity_data( $headers ) ) );
 
 	return implode(
 		"\n",
@@ -96,10 +98,26 @@ function extrachill_api_route_affinity_payload( $method, $route, $target_host, $
 			strtolower( $target_host ),
 			$query_digest,
 			$body_digest,
+			$header_digest,
 			(string) $timestamp,
 			$nonce,
 		)
 	);
+}
+
+/** Return the only caller header permitted across route-affinity transport. */
+function extrachill_api_route_affinity_forwarded_headers( WP_REST_Request $request ) {
+	$headers = array();
+	if ( ! function_exists( 'extrachill_api_is_booking_attachment_download_route' ) || ! extrachill_api_is_booking_attachment_download_route( $request->get_route() ) ) {
+		return $headers;
+	}
+
+	$range = trim( (string) $request->get_header( 'Range' ) );
+	if ( '' !== $range ) {
+		$headers['range'] = $range;
+	}
+
+	return $headers;
 }
 
 /**
@@ -182,7 +200,8 @@ function extrachill_api_is_route_affinity_reentry( WP_REST_Request $request ) {
 		$request->get_query_params(),
 		extrachill_api_route_affinity_request_body( $request ),
 		$timestamp,
-		$nonce
+		$nonce,
+		extrachill_api_route_affinity_forwarded_headers( $request )
 	);
 	$expected = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
 	if ( ! hash_equals( $expected, $signature ) ) {
@@ -280,16 +299,20 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		return new WP_Error( 'route_affinity_target_invalid', 'Could not resolve route-affinity target host.', array( 'status' => 500 ) );
 	}
 
-	$timestamp       = time();
-	$nonce           = wp_generate_uuid4();
-	$payload         = extrachill_api_route_affinity_payload( $method, $route, $target_host, $query_params, $body, $timestamp, $nonce );
-	$signature       = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
-	$args['headers'] = array(
+	$forwarded_headers = extrachill_api_route_affinity_forwarded_headers( $request );
+	$timestamp         = time();
+	$nonce             = wp_generate_uuid4();
+	$payload           = extrachill_api_route_affinity_payload( $method, $route, $target_host, $query_params, $body, $timestamp, $nonce, $forwarded_headers );
+	$signature         = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
+	$args['headers']   = array(
 		'X-EC-Affinity-Timestamp' => (string) $timestamp,
 		'X-EC-Affinity-Signature' => $signature,
 		'X-EC-Affinity-Target'    => strtolower( $target_host ),
 		'X-EC-Affinity-Nonce'     => $nonce,
 	);
+	foreach ( $forwarded_headers as $name => $value ) {
+		$args['headers'][ $name ] = $value;
+	}
 
 	// Force HTTP loopback for affinity forwarding.
 	//
@@ -311,7 +334,30 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		return true;
 	};
 	$forwarded_http_response = null;
-	$capture_http_response   = static function ( $http_response, $http_args ) use ( &$forwarded_http_response, $signature ) {
+	$private_stream          = function_exists( 'extrachill_api_is_booking_attachment_download_route' ) && extrachill_api_is_booking_attachment_download_route( $route );
+	$private_spool           = null;
+	if ( $private_stream ) {
+		$private_spool = wp_tempnam( 'extrachill-private-download' );
+		if ( ! is_string( $private_spool ) || '' === $private_spool || ! chmod( $private_spool, 0600 ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- Private affinity spool must be process-only.
+			if ( is_string( $private_spool ) && file_exists( $private_spool ) ) {
+				unlink( $private_spool ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Avoid path-observing deletion hooks for private spools.
+			}
+			return extrachill_api_booking_attachment_download_error( 503 );
+		}
+	}
+	$stream_http_response  = static function ( $http_args ) use ( $signature, $private_spool ) {
+		$headers = $http_args['headers'] ?? array();
+		if ( null !== $private_spool && ( $headers['X-EC-Affinity-Signature'] ?? '' ) === $signature ) {
+			$http_args['stream']              = true;
+			$http_args['filename']            = $private_spool;
+			$http_args['limit_response_size'] = extrachill_api_booking_attachment_max_bytes() + 1;
+			$http_args['timeout']             = 30;
+			$http_args['headers']['Accept']   = 'application/octet-stream';
+		}
+
+		return $http_args;
+	};
+	$capture_http_response = static function ( $http_response, $http_args ) use ( &$forwarded_http_response, $signature ) {
 		$headers = $http_args['headers'] ?? array();
 		if ( ( $headers['X-EC-Affinity-Signature'] ?? '' ) === $signature && false !== $http_response ) {
 			$forwarded_http_response = $http_response;
@@ -320,6 +366,7 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		return $http_response;
 	};
 	add_filter( 'ec_cross_site_use_http_loopback', $force_http_loopback, 10, 0 );
+	add_filter( 'http_request_args', $stream_http_response, PHP_INT_MAX, 1 );
 	add_filter( 'pre_http_request', $capture_http_response, PHP_INT_MAX, 2 );
 	add_filter( 'http_response', $capture_http_response, PHP_INT_MAX, 2 );
 
@@ -338,13 +385,24 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		if ( null === $response ) {
 			$response = ec_cross_site_rest_request( $target_site, $method, $path, $args );
 		}
+	} catch ( Throwable $throwable ) {
+		if ( $private_stream ) {
+			extrachill_api_discard_private_affinity_spool( $private_spool );
+			$response = extrachill_api_booking_attachment_download_error( 502 );
+		} else {
+			throw $throwable;
+		}
 	} finally {
 		remove_filter( 'ec_cross_site_use_http_loopback', $force_http_loopback, 10 );
+		remove_filter( 'http_request_args', $stream_http_response, PHP_INT_MAX );
 		remove_filter( 'pre_http_request', $capture_http_response, PHP_INT_MAX );
 		remove_filter( 'http_response', $capture_http_response, PHP_INT_MAX );
 	}
 
 	if ( is_array( $forwarded_http_response ) ) {
+		if ( $private_stream ) {
+			return extrachill_api_private_stream_from_affinity_response( $forwarded_http_response, $private_spool );
+		}
 		$status  = wp_remote_retrieve_response_code( $forwarded_http_response );
 		$headers = wp_remote_retrieve_headers( $forwarded_http_response );
 		$body    = wp_remote_retrieve_body( $forwarded_http_response );
@@ -362,6 +420,10 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 	}
 
 	if ( is_wp_error( $response ) ) {
+		if ( $private_stream ) {
+			extrachill_api_discard_private_affinity_spool( $private_spool );
+			return extrachill_api_booking_attachment_download_error( 502 );
+		}
 		$status = $response->get_error_data()['status'] ?? 500;
 		return new WP_REST_Response(
 			array(
@@ -371,6 +433,11 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 			),
 			$status
 		);
+	}
+
+	if ( $private_stream ) {
+		extrachill_api_discard_private_affinity_spool( $private_spool );
+		return extrachill_api_booking_attachment_download_error( 502 );
 	}
 
 	// Return the forwarded response.

--- a/inc/middleware/route-affinity.php
+++ b/inc/middleware/route-affinity.php
@@ -105,19 +105,56 @@ function extrachill_api_route_affinity_payload( $method, $route, $target_host, $
 	);
 }
 
-/** Return the only caller header permitted across route-affinity transport. */
-function extrachill_api_route_affinity_forwarded_headers( WP_REST_Request $request ) {
+/**
+ * Return the headers bound to route-affinity transport.
+ *
+ * Client identity is derived only while creating the hop. Verification reads
+ * the transmitted values so a direct caller can never ask API to sign a
+ * caller-supplied affinity identity.
+ *
+ * @param WP_REST_Request $request    Request being forwarded or verified.
+ * @param bool            $forwarding Whether this is the source-side hop.
+ * @return array
+ */
+function extrachill_api_route_affinity_forwarded_headers( WP_REST_Request $request, $forwarding = false ) {
 	$headers = array();
-	if ( ! function_exists( 'extrachill_api_is_booking_attachment_download_route' ) || ! extrachill_api_is_booking_attachment_download_route( $request->get_route() ) ) {
-		return $headers;
+	if ( function_exists( 'extrachill_api_is_booking_attachment_download_route' ) && extrachill_api_is_booking_attachment_download_route( $request->get_route() ) ) {
+		$range = trim( (string) $request->get_header( 'Range' ) );
+		if ( '' !== $range ) {
+			$headers['range'] = $range;
+		}
 	}
 
-	$range = trim( (string) $request->get_header( 'Range' ) );
-	if ( '' !== $range ) {
-		$headers['range'] = $range;
+	if ( $forwarding ) {
+		$client_ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+		if ( '' !== $client_ip && false !== filter_var( $client_ip, FILTER_VALIDATE_IP ) ) {
+			$headers['x-ec-affinity-client']      = hash_hmac( 'sha256', $client_ip, wp_salt( 'nonce' ) );
+			$headers['x-ec-affinity-remote-addr'] = $client_ip;
+		}
+	} else {
+		$client = strtolower( trim( (string) $request->get_header( 'X-EC-Affinity-Client' ) ) );
+		$remote = trim( (string) $request->get_header( 'X-EC-Affinity-Remote-Addr' ) );
+		if ( 1 === preg_match( '/^[a-f0-9]{64}$/', $client ) && false !== filter_var( $remote, FILTER_VALIDATE_IP ) ) {
+			$headers['x-ec-affinity-client']      = $client;
+			$headers['x-ec-affinity-remote-addr'] = $remote;
+		}
 	}
 
 	return $headers;
+}
+
+/** Store cryptographically verified context without mutating public input. */
+function extrachill_api_set_route_affinity_context( WP_REST_Request $request, array $context ) {
+	if ( ! isset( $GLOBALS['extrachill_api_route_affinity_contexts'] ) || ! $GLOBALS['extrachill_api_route_affinity_contexts'] instanceof WeakMap ) {
+		$GLOBALS['extrachill_api_route_affinity_contexts'] = new WeakMap();
+	}
+	$GLOBALS['extrachill_api_route_affinity_contexts'][ $request ] = $context;
+}
+
+/** Return context created only by successful affinity HMAC verification. */
+function extrachill_api_route_affinity_context( WP_REST_Request $request ) {
+	$contexts = $GLOBALS['extrachill_api_route_affinity_contexts'] ?? null;
+	return $contexts instanceof WeakMap && isset( $contexts[ $request ] ) ? $contexts[ $request ] : array();
 }
 
 /**
@@ -136,6 +173,9 @@ function extrachill_api_route_affinity_request_body( WP_REST_Request $request ) 
 		$body = $request->get_body_params();
 	}
 	$body = ! empty( $body ) ? $body : array();
+	if ( is_array( $body ) ) {
+		unset( $body['_ec_affinity_client'], $body['_ec_affinity_remote_addr'] );
+	}
 
 	/**
 	 * Filters the signed body representation for transport-only request data.
@@ -193,7 +233,8 @@ function extrachill_api_is_route_affinity_reentry( WP_REST_Request $request ) {
 		return false;
 	}
 
-	$payload  = extrachill_api_route_affinity_payload(
+	$forwarded_headers = extrachill_api_route_affinity_forwarded_headers( $request );
+	$payload           = extrachill_api_route_affinity_payload(
 		$request->get_method(),
 		$request->get_route(),
 		$target,
@@ -201,9 +242,9 @@ function extrachill_api_is_route_affinity_reentry( WP_REST_Request $request ) {
 		extrachill_api_route_affinity_request_body( $request ),
 		$timestamp,
 		$nonce,
-		extrachill_api_route_affinity_forwarded_headers( $request )
+		$forwarded_headers
 	);
-	$expected = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
+	$expected          = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
 	if ( ! hash_equals( $expected, $signature ) ) {
 		return false;
 	}
@@ -213,7 +254,14 @@ function extrachill_api_is_route_affinity_reentry( WP_REST_Request $request ) {
 	// residual replay boundary.
 	$verified = wp_cache_add( 'route_affinity_' . hash( 'sha256', $nonce ), 1, 'extrachill_api', 300 );
 	if ( $verified ) {
-		$request->set_header( 'X-EC-Affinity-Verified', '1' );
+		extrachill_api_set_route_affinity_context(
+			$request,
+			array(
+				'client'      => (string) ( $forwarded_headers['x-ec-affinity-client'] ?? '' ),
+				'remote_addr' => (string) ( $forwarded_headers['x-ec-affinity-remote-addr'] ?? '' ),
+				'nonce'       => $nonce,
+			)
+		);
 	}
 
 	return $verified;
@@ -299,7 +347,7 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		return new WP_Error( 'route_affinity_target_invalid', 'Could not resolve route-affinity target host.', array( 'status' => 500 ) );
 	}
 
-	$forwarded_headers = extrachill_api_route_affinity_forwarded_headers( $request );
+	$forwarded_headers = extrachill_api_route_affinity_forwarded_headers( $request, true );
 	$timestamp         = time();
 	$nonce             = wp_generate_uuid4();
 	$payload           = extrachill_api_route_affinity_payload( $method, $route, $target_host, $query_params, $body, $timestamp, $nonce, $forwarded_headers );
@@ -401,7 +449,7 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 
 	if ( is_array( $forwarded_http_response ) ) {
 		if ( $private_stream ) {
-			return extrachill_api_private_stream_from_affinity_response( $forwarded_http_response, $private_spool );
+			return extrachill_api_private_stream_from_affinity_response( $forwarded_http_response, $private_spool, $nonce );
 		}
 		$status  = wp_remote_retrieve_response_code( $forwarded_http_response );
 		$headers = wp_remote_retrieve_headers( $forwarded_http_response );

--- a/inc/routes/analytics/telemetry-validation.php
+++ b/inc/routes/analytics/telemetry-validation.php
@@ -10,6 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! function_exists( 'extrachill_api_check_public_write_rate_limit' ) ) {
+	require_once dirname( __DIR__, 2 ) . '/middleware/public-write-admission.php';
+}
+
 /**
  * Validate and normalize common public telemetry input.
  *
@@ -285,27 +289,12 @@ function extrachill_api_is_safe_telemetry_text( $value ) {
  * @return true|WP_Error
  */
 function extrachill_api_check_telemetry_rate_limit() {
-	$limit = (int) apply_filters( 'extrachill_api_telemetry_rate_limit', 240 );
-	if ( $limit < 1 ) {
-		return true;
+	$limit   = (int) apply_filters( 'extrachill_api_telemetry_rate_limit', 240 );
+	$request = new WP_REST_Request();
+	$result  = extrachill_api_check_public_write_rate_limit( $request, 'telemetry', $limit );
+	if ( is_wp_error( $result ) ) {
+		return new WP_Error( 'telemetry_rate_limited', 'Too many telemetry requests.', array( 'status' => 429 ) );
 	}
 
-	$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
-	if ( '' === $ip || false === filter_var( $ip, FILTER_VALIDATE_IP ) ) {
-		return true;
-	}
-
-	$key   = 'ec_api_tel_' . substr( hash_hmac( 'sha256', $ip, wp_salt( 'nonce' ) ), 0, 32 );
-	$count = (int) get_transient( $key );
-	if ( $count >= $limit ) {
-		return new WP_Error(
-			'telemetry_rate_limited',
-			'Too many telemetry requests.',
-			array( 'status' => 429 )
-		);
-	}
-
-	set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
-
-	return true;
+	return $result;
 }

--- a/inc/routes/events/booking-attachment-download.php
+++ b/inc/routes/events/booking-attachment-download.php
@@ -795,15 +795,31 @@ function extrachill_api_private_stream_from_affinity_response( array $http_respo
 /** Finalize a consumed handoff without exposing callback or spool failures. */
 function extrachill_api_fail_private_affinity_stream( $path, $delivery, $status = 502 ) {
 	if ( is_array( $delivery ) ) {
-		try {
-			extrachill_api_record_booking_attachment_delivery( $delivery, 'failed', 0 );
-		} catch ( Throwable $throwable ) {
-			unset( $throwable );
+		$bytes = extrachill_api_private_affinity_spool_bytes( $path );
+		if ( ! is_wp_error( $bytes ) ) {
+			try {
+				extrachill_api_record_booking_attachment_delivery( $delivery, $bytes > 0 ? 'partial' : 'failed', $bytes );
+			} catch ( Throwable $throwable ) {
+				unset( $throwable );
+			}
 		}
 	}
 	extrachill_api_discard_private_affinity_spool( $path );
 
 	return extrachill_api_booking_attachment_download_error( $status );
+}
+
+/** Return exact bounded spool bytes, rejecting counts that cannot be trusted. */
+function extrachill_api_private_affinity_spool_bytes( $path ) {
+	if ( ! is_string( $path ) || '' === $path || ! is_file( $path ) ) {
+		return 0;
+	}
+	$size = filesize( $path );
+	if ( false === $size || $size < 0 || $size > extrachill_api_booking_attachment_max_bytes() ) {
+		return new WP_Error( 'booking_attachment_spool_size_invalid' );
+	}
+
+	return (int) $size;
 }
 
 /** Extract and sanitize only a presentation filename from Content-Disposition. */

--- a/inc/routes/events/booking-attachment-download.php
+++ b/inc/routes/events/booking-attachment-download.php
@@ -41,6 +41,42 @@ function extrachill_api_register_booking_attachment_download_route() {
 			),
 		)
 	);
+	register_rest_route(
+		'extrachill/v1',
+		'/events/internal/booking-attachment-delivery',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_record_booking_attachment_delivery_request',
+			'permission_callback' => 'extrachill_api_booking_attachment_delivery_internal_permission',
+		)
+	);
+}
+
+/** Admit terminal callbacks only through localhost signed-user transport. */
+function extrachill_api_booking_attachment_delivery_internal_permission( WP_REST_Request $request ) {
+	$has_internal_auth = ! empty( $_SERVER['HTTP_X_EC_INTERNAL_USER'] ) && ! empty( $_SERVER['HTTP_X_EC_INTERNAL_TIMESTAMP'] ) && ! empty( $_SERVER['HTTP_X_EC_INTERNAL_SIGNATURE'] );
+	$timestamp         = (int) $request->get_header( 'X-EC-Delivery-Timestamp' );
+	$signature         = (string) $request->get_header( 'X-EC-Delivery-Signature' );
+	$input             = (array) $request->get_json_params();
+	$expected          = extrachill_api_booking_attachment_delivery_callback_signature( $input, get_current_user_id(), $timestamp );
+	$verified          = $timestamp > 0 && abs( time() - $timestamp ) <= 60 && '' !== $signature && hash_equals( $expected, $signature );
+	return extrachill_api_is_local_request() && $has_internal_auth && is_user_logged_in() && $verified
+		? true
+		: extrachill_api_booking_attachment_download_error( 403 );
+}
+
+/** Sign one short-lived terminal callback independently of caller auth. */
+function extrachill_api_booking_attachment_delivery_callback_signature( array $input, $user_id, $timestamp ) {
+	$payload = wp_json_encode( extrachill_api_normalize_affinity_data( $input ) ) . "\n" . (int) $user_id . "\n" . (int) $timestamp;
+	return hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
+}
+
+/** Execute the Events-owned terminal callback on its owning site. */
+function extrachill_api_record_booking_attachment_delivery_request( WP_REST_Request $request ) {
+	$recorded = extrachill_api_record_booking_attachment_delivery_locally( (array) $request->get_json_params() );
+	return $recorded
+		? new WP_REST_Response( array( 'recorded' => true ), 200 )
+		: extrachill_api_booking_attachment_download_error( 502 );
 }
 
 /** Require an authenticated caller without disclosing attachment existence. */
@@ -115,15 +151,6 @@ function extrachill_api_download_booking_attachment( WP_REST_Request $request ) 
 		if ( is_resource( $stream ) ) {
 			fclose( $stream );
 		}
-		extrachill_api_record_booking_attachment_delivery(
-			array(
-				'booking_id'     => $input['booking_id'],
-				'attachment_id'  => $input['attachment_id'],
-				'correlation_id' => $correlation_id,
-			),
-			'failed',
-			0
-		);
 		return extrachill_api_booking_attachment_download_error( extrachill_api_booking_attachment_error_status( $stream ) );
 	}
 
@@ -140,7 +167,11 @@ function extrachill_api_download_booking_attachment( WP_REST_Request $request ) 
 		$delivery
 	);
 	if ( is_wp_error( $response ) ) {
-		extrachill_api_record_booking_attachment_delivery( $delivery, 'failed', 0 );
+		if ( function_exists( 'extrachill_api_route_affinity_context' ) && extrachill_api_route_affinity_context( $request ) ) {
+			$response = extrachill_api_booking_attachment_affinity_error( $response, $delivery, $request );
+		} else {
+			extrachill_api_record_booking_attachment_delivery( $delivery, 'failed', 0 );
+		}
 	}
 
 	return $response;
@@ -148,20 +179,47 @@ function extrachill_api_download_booking_attachment( WP_REST_Request $request ) 
 
 /** Record one Events-owned terminal delivery outcome without exposing it. */
 function extrachill_api_record_booking_attachment_delivery( array $delivery, $outcome, $bytes_sent ) {
-	if ( ! function_exists( 'wp_get_ability' ) ) {
-		return false;
-	}
-	$ability = wp_get_ability( 'extrachill/record-booking-attachment-delivery' );
-	if ( ! $ability ) {
-		return false;
-	}
-	$input   = array(
+	$input = array(
 		'booking_id'     => (int) ( $delivery['booking_id'] ?? 0 ),
 		'attachment_id'  => (int) ( $delivery['attachment_id'] ?? 0 ),
 		'correlation_id' => (string) ( $delivery['correlation_id'] ?? '' ),
 		'outcome'        => (string) $outcome,
 		'bytes_sent'     => max( 0, (int) $bytes_sent ),
 	);
+	if ( extrachill_api_record_booking_attachment_delivery_locally( $input ) ) {
+		return true;
+	}
+	if ( ! function_exists( 'ec_cross_site_rest_request_http' ) || get_current_user_id() < 1 ) {
+		return false;
+	}
+	$timestamp = time();
+	$result    = ec_cross_site_rest_request_http(
+		'events',
+		'POST',
+		'/events/internal/booking-attachment-delivery',
+		array(
+			'body'    => $input,
+			'headers' => array(
+				'X-EC-Delivery-Timestamp' => (string) $timestamp,
+				'X-EC-Delivery-Signature' => extrachill_api_booking_attachment_delivery_callback_signature( $input, get_current_user_id(), $timestamp ),
+			),
+			'user_id' => get_current_user_id(),
+			'timeout' => 10,
+		)
+	);
+
+	return is_array( $result ) && true === ( $result['recorded'] ?? false );
+}
+
+/** Record a terminal delivery when the Events ability is loaded locally. */
+function extrachill_api_record_booking_attachment_delivery_locally( array $input ) {
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		return false;
+	}
+	$ability = wp_get_abilities()['extrachill/record-booking-attachment-delivery'] ?? null;
+	if ( ! $ability ) {
+		return false;
+	}
 	$allowed = $ability->check_permissions( $input );
 	if ( true !== $allowed ) {
 		return false;
@@ -201,7 +259,7 @@ function extrachill_api_booking_attachment_download_error( $status ) {
 	return $response;
 }
 
-/** Apply a fixed-window per-user cap before Events issues a handoff. */
+/** Apply an atomic fixed-window per-user cap before Events issues a handoff. */
 function extrachill_api_check_booking_attachment_download_rate_limit() {
 	$limit = (int) apply_filters( 'extrachill_api_booking_attachment_download_rate_limit', 30 );
 	if ( $limit < 1 ) {
@@ -213,21 +271,25 @@ function extrachill_api_check_booking_attachment_download_rate_limit() {
 		return extrachill_api_booking_attachment_download_error( 401 );
 	}
 
-	$key   = 'ec_api_booking_dl_' . substr( hash_hmac( 'sha256', (string) $user_id, wp_salt( 'nonce' ) ), 0, 32 );
-	$count = (int) get_transient( $key );
-	if ( $count >= $limit ) {
+	$now         = time();
+	$window      = intdiv( $now, MINUTE_IN_SECONDS );
+	$retry_after = ( ( $window + 1 ) * MINUTE_IN_SECONDS ) - $now;
+	$key         = 'booking_dl_' . substr( hash_hmac( 'sha256', $user_id . ':' . $window, wp_salt( 'nonce' ) ), 0, 40 );
+	$admitted    = extrachill_api_atomic_rate_limit_admit( $key, $limit, $retry_after );
+	if ( is_wp_error( $admitted ) ) {
+		return extrachill_api_booking_attachment_download_error( 503 );
+	}
+	if ( ! $admitted ) {
 		return new WP_Error(
 			'booking_attachment_download_rate_limited',
 			'Too many attachment download requests.',
 			array(
 				'status'      => 429,
-				'retry_after' => MINUTE_IN_SECONDS,
-				'headers'     => array( 'Retry-After' => (string) MINUTE_IN_SECONDS ),
+				'retry_after' => $retry_after,
+				'headers'     => array( 'Retry-After' => (string) $retry_after ),
 			)
 		);
 	}
-	set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
-
 	return true;
 }
 
@@ -266,10 +328,18 @@ function extrachill_api_create_private_stream_response( $stream, $filename, $mim
 		return extrachill_api_booking_attachment_download_error( 502 );
 	}
 
-	$correlation_id = is_array( $delivery ) ? (string) ( $delivery['correlation_id'] ?? '' ) : null;
-	$headers        = extrachill_api_private_stream_headers( $filename, $mime, $range['length'], $correlation_id );
+	$headers = extrachill_api_private_stream_headers( $filename, $mime, $range['length'] );
 	if ( 206 === $range['status'] ) {
 		$headers['Content-Range'] = sprintf( 'bytes %d-%d/%d', $range['offset'], $range['offset'] + $range['length'] - 1, $size );
+	}
+	if ( is_array( $delivery ) ) {
+		$delivery['success_outcome'] = $range['length'] === $size ? 'completed' : 'partial';
+	}
+
+	$affinity_context = function_exists( 'extrachill_api_route_affinity_context' ) ? extrachill_api_route_affinity_context( $request ) : array();
+	if ( $affinity_context && is_array( $delivery ) ) {
+		$headers  = array_merge( $headers, extrachill_api_booking_attachment_affinity_delivery_headers( $delivery, $affinity_context ) );
+		$delivery = null;
 	}
 
 	return extrachill_api_register_private_stream( $stream, $range['length'], $range['status'], $headers, null, $delivery );
@@ -331,7 +401,7 @@ function extrachill_api_booking_attachment_range_error( $size ) {
 }
 
 /** Build headers that keep private bytes out of browsers and intermediary caches. */
-function extrachill_api_private_stream_headers( $filename, $mime, $length, $correlation_id = null ) {
+function extrachill_api_private_stream_headers( $filename, $mime, $length ) {
 	$safe_filename = sanitize_file_name( wp_basename( $filename ) );
 	if ( '' === $safe_filename ) {
 		$safe_filename = 'attachment.bin';
@@ -352,11 +422,66 @@ function extrachill_api_private_stream_headers( $filename, $mime, $length, $corr
 		'X-Content-Type-Options' => 'nosniff',
 		'X-Robots-Tag'           => 'noindex, nofollow, noarchive',
 	);
-	if ( is_string( $correlation_id ) && wp_is_uuid( $correlation_id, 4 ) ) {
-		$headers['X-EC-Download-Correlation'] = $correlation_id;
+	return $headers;
+}
+
+/** Build nonce-bound response metadata for the outer affinity worker only. */
+function extrachill_api_booking_attachment_affinity_delivery_headers( array $delivery, array $context ) {
+	$delivery = array(
+		'booking_id'      => (int) ( $delivery['booking_id'] ?? 0 ),
+		'attachment_id'   => (int) ( $delivery['attachment_id'] ?? 0 ),
+		'correlation_id'  => (string) ( $delivery['correlation_id'] ?? '' ),
+		'success_outcome' => (string) ( $delivery['success_outcome'] ?? 'completed' ),
+	);
+	$nonce    = (string) ( $context['nonce'] ?? '' );
+	if ( $delivery['booking_id'] < 1 || $delivery['attachment_id'] < 1 || ! wp_is_uuid( $delivery['correlation_id'], 4 ) || ! in_array( $delivery['success_outcome'], array( 'completed', 'partial' ), true ) || '' === $nonce ) {
+		return array();
+	}
+	$encoded   = rtrim( strtr( base64_encode( wp_json_encode( $delivery ) ), '+/', '-_' ), '=' );
+	$signature = hash_hmac( 'sha256', $encoded . "\n" . $nonce, wp_salt( 'auth' ) );
+
+	return array(
+		'X-EC-Affinity-Delivery'           => $encoded,
+		'X-EC-Affinity-Delivery-Signature' => $signature,
+	);
+}
+
+/** Attach internal delivery metadata to an affinity-only error response. */
+function extrachill_api_booking_attachment_affinity_error( WP_Error $error, array $delivery, WP_REST_Request $request ) {
+	$response = rest_convert_error_to_response( $error );
+	$context  = extrachill_api_route_affinity_context( $request );
+	foreach ( extrachill_api_booking_attachment_affinity_delivery_headers( $delivery, $context ) as $name => $value ) {
+		$response->header( $name, $value );
 	}
 
-	return $headers;
+	return $response;
+}
+
+/** Verify and decode internal response metadata without forwarding its headers. */
+function extrachill_api_booking_attachment_affinity_delivery_from_headers( array $headers, $nonce ) {
+	$lower     = array_change_key_case( $headers, CASE_LOWER );
+	$encoded   = (string) ( $lower['x-ec-affinity-delivery'] ?? '' );
+	$signature = (string) ( $lower['x-ec-affinity-delivery-signature'] ?? '' );
+	$expected  = hash_hmac( 'sha256', $encoded . "\n" . (string) $nonce, wp_salt( 'auth' ) );
+	if ( '' === $encoded || '' === $signature || ! hash_equals( $expected, $signature ) ) {
+		return null;
+	}
+	$padding = strlen( $encoded ) % 4;
+	if ( $padding ) {
+		$encoded .= str_repeat( '=', 4 - $padding );
+	}
+	$decoded  = base64_decode( strtr( $encoded, '-_', '+/' ), true );
+	$delivery = is_string( $decoded ) ? json_decode( $decoded, true ) : null;
+	if ( ! is_array( $delivery ) || array( 'booking_id', 'attachment_id', 'correlation_id', 'success_outcome' ) !== array_keys( $delivery ) || (int) $delivery['booking_id'] < 1 || (int) $delivery['attachment_id'] < 1 || ! wp_is_uuid( (string) $delivery['correlation_id'], 4 ) || ! in_array( $delivery['success_outcome'], array( 'completed', 'partial' ), true ) ) {
+		return null;
+	}
+
+	return array(
+		'booking_id'      => (int) $delivery['booking_id'],
+		'attachment_id'   => (int) $delivery['attachment_id'],
+		'correlation_id'  => (string) $delivery['correlation_id'],
+		'success_outcome' => (string) $delivery['success_outcome'],
+	);
 }
 
 /** Keep every success and failure for this private route out of caches. */
@@ -484,7 +609,7 @@ function extrachill_api_serve_private_stream( $served, $result, $request, $serve
 		}
 		if ( is_array( $entry['delivery'] ?? null ) ) {
 			if ( 0 === $remaining && ! $read_failed ) {
-				$outcome = 'completed';
+				$outcome = (string) ( $entry['delivery']['success_outcome'] ?? 'completed' );
 			} elseif ( $bytes_sent > 0 ) {
 				$outcome = 'partial';
 			} elseif ( connection_aborted() ) {
@@ -511,13 +636,21 @@ function extrachill_api_is_booking_attachment_download_route( $route ) {
  * @param string $path          Private temporary spool path.
  * @return WP_REST_Response|WP_Error
  */
-function extrachill_api_private_stream_from_affinity_response( array $http_response, $path ) {
-	$status  = (int) wp_remote_retrieve_response_code( $http_response );
-	$headers = wp_remote_retrieve_headers( $http_response );
-	$headers = $headers instanceof Traversable ? iterator_to_array( $headers ) : (array) $headers;
+function extrachill_api_private_stream_from_affinity_response( array $http_response, $path, $nonce ) {
+	$status   = (int) wp_remote_retrieve_response_code( $http_response );
+	$headers  = wp_remote_retrieve_headers( $http_response );
+	$headers  = $headers instanceof Traversable ? iterator_to_array( $headers ) : (array) $headers;
+	$delivery = extrachill_api_booking_attachment_affinity_delivery_from_headers( $headers, $nonce );
 	if ( ! in_array( $status, array( 200, 206 ), true ) ) {
 		extrachill_api_discard_private_affinity_spool( $path );
+		if ( is_array( $delivery ) ) {
+			extrachill_api_record_booking_attachment_delivery( $delivery, 'failed', 0 );
+		}
 		return extrachill_api_booking_attachment_download_error( extrachill_api_booking_attachment_proxy_status( $status ) );
+	}
+	if ( ! is_array( $delivery ) ) {
+		extrachill_api_discard_private_affinity_spool( $path );
+		return extrachill_api_booking_attachment_download_error( 502 );
 	}
 
 	$size = is_file( $path ) ? filesize( $path ) : false;
@@ -535,13 +668,7 @@ function extrachill_api_private_stream_from_affinity_response( array $http_respo
 	$disposition = (string) ( $headers['content-disposition'] ?? ( $headers['Content-Disposition'] ?? '' ) );
 	$filename    = extrachill_api_filename_from_content_disposition( $disposition );
 	$mime        = (string) ( $headers['content-type'] ?? ( $headers['Content-Type'] ?? '' ) );
-	$safe        = extrachill_api_private_stream_headers( $filename, $mime, $size, null );
-	$correlation = (string) ( $headers['x-ec-download-correlation'] ?? ( $headers['X-EC-Download-Correlation'] ?? '' ) );
-	if ( ! wp_is_uuid( $correlation, 4 ) ) {
-		extrachill_api_discard_private_affinity_spool( $path );
-		return extrachill_api_booking_attachment_download_error( 502 );
-	}
-	$safe['X-EC-Download-Correlation'] = $correlation;
+	$safe        = extrachill_api_private_stream_headers( $filename, $mime, $size );
 	if ( 206 === $status ) {
 		$content_range = (string) ( $headers['content-range'] ?? ( $headers['Content-Range'] ?? '' ) );
 		if ( 1 !== preg_match( '/^bytes (\d+)-(\d+)\/(\d+)$/', $content_range, $range ) || (int) $range[2] < (int) $range[1] || (int) $range[2] - (int) $range[1] + 1 !== (int) $size || (int) $range[3] > extrachill_api_booking_attachment_max_bytes() ) {
@@ -557,7 +684,7 @@ function extrachill_api_private_stream_from_affinity_response( array $http_respo
 		return extrachill_api_booking_attachment_download_error( 502 );
 	}
 
-	return extrachill_api_register_private_stream( $stream, $size, $status, $safe, $path );
+	return extrachill_api_register_private_stream( $stream, $size, $status, $safe, $path, $delivery );
 }
 
 /** Extract and sanitize only a presentation filename from Content-Disposition. */

--- a/inc/routes/events/booking-attachment-download.php
+++ b/inc/routes/events/booking-attachment-download.php
@@ -43,6 +43,15 @@ function extrachill_api_register_booking_attachment_download_route() {
 	);
 	register_rest_route(
 		'extrachill/v1',
+		'/events/internal/booking-attachment-handoff',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_issue_booking_attachment_handoff_request',
+			'permission_callback' => 'extrachill_api_booking_attachment_handoff_internal_permission',
+		)
+	);
+	register_rest_route(
+		'extrachill/v1',
 		'/events/internal/booking-attachment-delivery',
 		array(
 			'methods'             => WP_REST_Server::CREATABLE,
@@ -52,17 +61,53 @@ function extrachill_api_register_booking_attachment_download_route() {
 	);
 }
 
+/** Admit descriptor preflight only through body-bound localhost user transport. */
+function extrachill_api_booking_attachment_handoff_internal_permission( WP_REST_Request $request ) {
+	$timestamp         = (int) $request->get_header( 'X-EC-Handoff-Timestamp' );
+	$signature         = (string) $request->get_header( 'X-EC-Handoff-Signature' );
+	$input             = (array) $request->get_json_params();
+	$expected          = extrachill_api_booking_attachment_delivery_callback_signature( $input, get_current_user_id(), $timestamp );
+	$verified          = $timestamp > 0 && abs( time() - $timestamp ) <= 60 && '' !== $signature && hash_equals( $expected, $signature );
+
+	return extrachill_api_is_local_request() && extrachill_api_booking_attachment_has_verified_internal_user() && $verified
+		? true
+		: extrachill_api_booking_attachment_download_error( 403 );
+}
+
+/** Issue one Events-owned descriptor before the streamed affinity request. */
+function extrachill_api_issue_booking_attachment_handoff_request( WP_REST_Request $request ) {
+	$descriptor = extrachill_api_issue_booking_attachment_descriptor(
+		array(
+			'booking_id'    => (int) $request->get_param( 'booking_id' ),
+			'attachment_id' => (int) $request->get_param( 'attachment_id' ),
+		)
+	);
+
+	return is_wp_error( $descriptor ) ? extrachill_api_booking_attachment_download_error( 502 ) : new WP_REST_Response( $descriptor, 200 );
+}
+
 /** Admit terminal callbacks only through localhost signed-user transport. */
 function extrachill_api_booking_attachment_delivery_internal_permission( WP_REST_Request $request ) {
-	$has_internal_auth = ! empty( $_SERVER['HTTP_X_EC_INTERNAL_USER'] ) && ! empty( $_SERVER['HTTP_X_EC_INTERNAL_TIMESTAMP'] ) && ! empty( $_SERVER['HTTP_X_EC_INTERNAL_SIGNATURE'] );
 	$timestamp         = (int) $request->get_header( 'X-EC-Delivery-Timestamp' );
 	$signature         = (string) $request->get_header( 'X-EC-Delivery-Signature' );
 	$input             = (array) $request->get_json_params();
 	$expected          = extrachill_api_booking_attachment_delivery_callback_signature( $input, get_current_user_id(), $timestamp );
 	$verified          = $timestamp > 0 && abs( time() - $timestamp ) <= 60 && '' !== $signature && hash_equals( $expected, $signature );
-	return extrachill_api_is_local_request() && $has_internal_auth && is_user_logged_in() && $verified
+	return extrachill_api_is_local_request() && extrachill_api_booking_attachment_has_verified_internal_user() && $verified
 		? true
 		: extrachill_api_booking_attachment_download_error( 403 );
+}
+
+/** Verify the canonical signed internal user independently of auth hook order. */
+function extrachill_api_booking_attachment_has_verified_internal_user() {
+	$user_id   = isset( $_SERVER['HTTP_X_EC_INTERNAL_USER'] ) ? (int) $_SERVER['HTTP_X_EC_INTERNAL_USER'] : 0;
+	$timestamp = isset( $_SERVER['HTTP_X_EC_INTERNAL_TIMESTAMP'] ) ? (int) $_SERVER['HTTP_X_EC_INTERNAL_TIMESTAMP'] : 0;
+	$signature = isset( $_SERVER['HTTP_X_EC_INTERNAL_SIGNATURE'] ) ? (string) $_SERVER['HTTP_X_EC_INTERNAL_SIGNATURE'] : '';
+
+	return $user_id > 0
+		&& get_current_user_id() === $user_id
+		&& function_exists( 'ec_cross_site_verify_signature' )
+		&& ec_cross_site_verify_signature( $user_id, $timestamp, $signature );
 }
 
 /** Sign one short-lived terminal callback independently of caller auth. */
@@ -109,22 +154,13 @@ function extrachill_api_download_booking_attachment( WP_REST_Request $request ) 
 		return extrachill_api_booking_attachment_download_error( 503 );
 	}
 
-	$ability = wp_get_ability( 'extrachill/download-booking-attachment' );
-	if ( ! $ability ) {
-		return extrachill_api_booking_attachment_download_error( 503 );
-	}
-
 	$input   = array(
 		'booking_id'    => (int) $request->get_param( 'booking_id' ),
 		'attachment_id' => (int) $request->get_param( 'attachment_id' ),
 	);
-	$allowed = $ability->check_permissions( $input );
-	if ( true !== $allowed ) {
-		return extrachill_api_booking_attachment_download_error( 404 );
-	}
-
-	$descriptor = $ability->execute( $input );
-	if ( is_wp_error( $descriptor ) || ! is_array( $descriptor ) ) {
+	$context = function_exists( 'extrachill_api_route_affinity_context' ) ? extrachill_api_route_affinity_context( $request ) : array();
+	$descriptor = is_array( $context['download_handoff'] ?? null ) ? $context['download_handoff'] : extrachill_api_issue_booking_attachment_descriptor( $input );
+	if ( is_wp_error( $descriptor ) ) {
 		return extrachill_api_booking_attachment_download_error( extrachill_api_booking_attachment_error_status( $descriptor ) );
 	}
 
@@ -175,6 +211,76 @@ function extrachill_api_download_booking_attachment( WP_REST_Request $request ) 
 	}
 
 	return $response;
+}
+
+/** Authorize and issue one Events-owned download descriptor. */
+function extrachill_api_issue_booking_attachment_descriptor( array $input ) {
+	$ability = wp_get_ability( 'extrachill/download-booking-attachment' );
+	if ( ! $ability ) {
+		return new WP_Error( 'booking_attachment_descriptor_unavailable' );
+	}
+	$allowed = $ability->check_permissions( $input );
+	if ( true !== $allowed ) {
+		return is_wp_error( $allowed ) ? $allowed : new WP_Error( 'booking_attachment_descriptor_forbidden', '', array( 'status' => 404 ) );
+	}
+	$descriptor = $ability->execute( $input );
+
+	return is_array( $descriptor ) ? $descriptor : ( is_wp_error( $descriptor ) ? $descriptor : new WP_Error( 'booking_attachment_descriptor_invalid' ) );
+}
+
+/** Obtain the private descriptor before opening the streamed loopback. */
+function extrachill_api_prepare_booking_attachment_affinity_handoff( WP_REST_Request $request ) {
+	$input = array(
+		'booking_id'    => (int) $request->get_param( 'booking_id' ),
+		'attachment_id' => (int) $request->get_param( 'attachment_id' ),
+	);
+	$timestamp = time();
+	$result    = ec_cross_site_rest_request_http(
+		'events',
+		'POST',
+		'/events/internal/booking-attachment-handoff',
+		array(
+			'body'    => $input,
+			'headers' => array(
+				'X-EC-Handoff-Timestamp' => (string) $timestamp,
+				'X-EC-Handoff-Signature' => extrachill_api_booking_attachment_delivery_callback_signature( $input, get_current_user_id(), $timestamp ),
+			),
+			'user_id' => get_current_user_id(),
+			'timeout' => 10,
+		)
+	);
+
+	return extrachill_api_validate_booking_attachment_handoff( $result ) ? $result : extrachill_api_booking_attachment_download_error( 502 );
+}
+
+/** Validate the exact opaque handoff shape carried inside affinity HMAC. */
+function extrachill_api_validate_booking_attachment_handoff( $handoff ) {
+	return is_array( $handoff )
+		&& is_string( $handoff['stream_token'] ?? null )
+		&& 1 === preg_match( '/^[a-f0-9]{64}$/', $handoff['stream_token'] )
+		&& is_string( $handoff['correlation_id'] ?? null )
+		&& wp_is_uuid( $handoff['correlation_id'], 4 );
+}
+
+/** Encode a bounded internal handoff for one signed affinity hop. */
+function extrachill_api_encode_booking_attachment_handoff( array $handoff ) {
+	return rtrim( strtr( base64_encode( wp_json_encode( $handoff ) ), '+/', '-_' ), '=' );
+}
+
+/** Decode only a valid handoff after affinity HMAC verification. */
+function extrachill_api_decode_booking_attachment_handoff( $encoded ) {
+	$encoded = (string) $encoded;
+	if ( '' === $encoded || strlen( $encoded ) > 4096 || 1 !== preg_match( '/^[A-Za-z0-9_-]+$/', $encoded ) ) {
+		return null;
+	}
+	$padding = strlen( $encoded ) % 4;
+	if ( $padding ) {
+		$encoded .= str_repeat( '=', 4 - $padding );
+	}
+	$decoded = base64_decode( strtr( $encoded, '-_', '+/' ), true );
+	$handoff = is_string( $decoded ) ? json_decode( $decoded, true ) : null;
+
+	return extrachill_api_validate_booking_attachment_handoff( $handoff ) ? $handoff : null;
 }
 
 /** Record one Events-owned terminal delivery outcome without exposing it. */

--- a/inc/routes/events/booking-attachment-download.php
+++ b/inc/routes/events/booking-attachment-download.php
@@ -1,0 +1,588 @@
+<?php
+/**
+ * Protected booking attachment download transport.
+ *
+ * Events owns authorization, handoffs, private bytes, policy, and audit. This
+ * route only adapts those contracts to a bounded HTTP byte response.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Native resource streaming and unhooked spool deletion are required so private
+// bytes never enter WP_Filesystem buffers or path-observing deletion hooks.
+// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_fclose,WordPress.WP.AlternativeFunctions.file_system_operations_fopen,WordPress.WP.AlternativeFunctions.file_system_operations_fread,WordPress.WP.AlternativeFunctions.unlink_unlink
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_booking_attachment_download_route' );
+add_filter( 'rest_post_dispatch', 'extrachill_api_protect_booking_attachment_download_response', 10, 3 );
+add_filter( 'rest_pre_serve_request', 'extrachill_api_serve_private_stream', 10, 4 );
+
+/** Register the authenticated Events-owned attachment download route. */
+function extrachill_api_register_booking_attachment_download_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/events/bookings/(?P<booking_id>\d+)/attachments/(?P<attachment_id>\d+)/download',
+		array(
+			'methods'             => 'GET',
+			'callback'            => 'extrachill_api_download_booking_attachment',
+			'permission_callback' => 'extrachill_api_booking_attachment_download_permission',
+			'args'                => array(
+				'booking_id'    => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'attachment_id' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+			),
+		)
+	);
+}
+
+/** Require an authenticated caller without disclosing attachment existence. */
+function extrachill_api_booking_attachment_download_permission() {
+	return is_user_logged_in()
+		? true
+		: new WP_Error( 'booking_attachment_download_unavailable', 'The requested attachment is unavailable.', array( 'status' => 401 ) );
+}
+
+/**
+ * Issue and immediately consume an Events-owned one-time handoff.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function extrachill_api_download_booking_attachment( WP_REST_Request $request ) {
+	if ( 'GET' !== $request->get_method() ) {
+		return extrachill_api_booking_attachment_download_error( 405 );
+	}
+	if ( null !== $request->get_param( '_envelope' ) ) {
+		return extrachill_api_booking_attachment_download_error( 400 );
+	}
+
+	$rate_limit = extrachill_api_check_booking_attachment_download_rate_limit();
+	if ( is_wp_error( $rate_limit ) ) {
+		return $rate_limit;
+	}
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		return extrachill_api_booking_attachment_download_error( 503 );
+	}
+
+	$ability = wp_get_ability( 'extrachill/download-booking-attachment' );
+	if ( ! $ability ) {
+		return extrachill_api_booking_attachment_download_error( 503 );
+	}
+
+	$input   = array(
+		'booking_id'    => (int) $request->get_param( 'booking_id' ),
+		'attachment_id' => (int) $request->get_param( 'attachment_id' ),
+	);
+	$allowed = $ability->check_permissions( $input );
+	if ( true !== $allowed ) {
+		return extrachill_api_booking_attachment_download_error( 404 );
+	}
+
+	$descriptor = $ability->execute( $input );
+	if ( is_wp_error( $descriptor ) || ! is_array( $descriptor ) ) {
+		return extrachill_api_booking_attachment_download_error( extrachill_api_booking_attachment_error_status( $descriptor ) );
+	}
+
+	$token = $descriptor['stream_token'] ?? null;
+	$correlation_id = $descriptor['correlation_id'] ?? null;
+	if ( ! is_string( $token ) || 1 !== preg_match( '/^[a-f0-9]{64}$/', $token ) || ! is_string( $correlation_id ) || ! wp_is_uuid( $correlation_id, 4 ) ) {
+		return extrachill_api_booking_attachment_download_error( 502 );
+	}
+
+	$service_class = '\\ExtraChillEvents\\Core\\BookingAttachmentService';
+	if ( ! class_exists( $service_class ) ) {
+		return extrachill_api_booking_attachment_download_error( 503 );
+	}
+
+	$service = new $service_class();
+	$stream  = $service->open_download_stream(
+		$input['booking_id'],
+		$input['attachment_id'],
+		$token,
+		get_current_user_id(),
+		$correlation_id
+	);
+	if ( is_wp_error( $stream ) || ! is_resource( $stream ) ) {
+		if ( is_resource( $stream ) ) {
+			fclose( $stream );
+		}
+		extrachill_api_record_booking_attachment_delivery(
+			array(
+				'booking_id'     => $input['booking_id'],
+				'attachment_id'  => $input['attachment_id'],
+				'correlation_id' => $correlation_id,
+			),
+			'failed',
+			0
+		);
+		return extrachill_api_booking_attachment_download_error( extrachill_api_booking_attachment_error_status( $stream ) );
+	}
+
+	$delivery = array(
+		'booking_id'     => $input['booking_id'],
+		'attachment_id'  => $input['attachment_id'],
+		'correlation_id' => $correlation_id,
+	);
+	$response = extrachill_api_create_private_stream_response(
+		$stream,
+		(string) ( $descriptor['filename'] ?? '' ),
+		(string) ( $descriptor['mime_type'] ?? '' ),
+		$request,
+		$delivery
+	);
+	if ( is_wp_error( $response ) ) {
+		extrachill_api_record_booking_attachment_delivery( $delivery, 'failed', 0 );
+	}
+
+	return $response;
+}
+
+/** Record one Events-owned terminal delivery outcome without exposing it. */
+function extrachill_api_record_booking_attachment_delivery( array $delivery, $outcome, $bytes_sent ) {
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		return false;
+	}
+	$ability = wp_get_ability( 'extrachill/record-booking-attachment-delivery' );
+	if ( ! $ability ) {
+		return false;
+	}
+	$input = array(
+		'booking_id'     => (int) ( $delivery['booking_id'] ?? 0 ),
+		'attachment_id'  => (int) ( $delivery['attachment_id'] ?? 0 ),
+		'correlation_id' => (string) ( $delivery['correlation_id'] ?? '' ),
+		'outcome'        => (string) $outcome,
+		'bytes_sent'     => max( 0, (int) $bytes_sent ),
+	);
+	$allowed = $ability->check_permissions( $input );
+	if ( true !== $allowed ) {
+		return false;
+	}
+
+	return ! is_wp_error( $ability->execute( $input ) );
+}
+
+/**
+ * Return a stable public status without forwarding domain error details.
+ *
+ * @param mixed $error Domain result.
+ * @return int
+ */
+function extrachill_api_booking_attachment_error_status( $error ) {
+	if ( ! is_wp_error( $error ) ) {
+		return 502;
+	}
+
+	$data   = $error->get_error_data();
+	$status = is_array( $data ) ? (int) ( $data['status'] ?? 0 ) : 0;
+	if ( in_array( $status, array( 401, 403, 404, 409, 410 ), true ) ) {
+		return 404;
+	}
+
+	return in_array( $status, array( 429, 502, 503 ), true ) ? $status : 502;
+}
+
+/** Build a generic, non-cacheable download error. */
+function extrachill_api_booking_attachment_download_error( $status ) {
+	$response = new WP_Error(
+		'booking_attachment_download_unavailable',
+		'The requested attachment is unavailable.',
+		array( 'status' => (int) $status )
+	);
+
+	return $response;
+}
+
+/** Apply a fixed-window per-user cap before Events issues a handoff. */
+function extrachill_api_check_booking_attachment_download_rate_limit() {
+	$limit = (int) apply_filters( 'extrachill_api_booking_attachment_download_rate_limit', 30 );
+	if ( $limit < 1 ) {
+		return true;
+	}
+
+	$user_id = get_current_user_id();
+	if ( $user_id < 1 ) {
+		return extrachill_api_booking_attachment_download_error( 401 );
+	}
+
+	$key   = 'ec_api_booking_dl_' . substr( hash_hmac( 'sha256', (string) $user_id, wp_salt( 'nonce' ) ), 0, 32 );
+	$count = (int) get_transient( $key );
+	if ( $count >= $limit ) {
+		return new WP_Error(
+			'booking_attachment_download_rate_limited',
+			'Too many attachment download requests.',
+			array(
+				'status'      => 429,
+				'retry_after' => MINUTE_IN_SECONDS,
+				'headers'     => array( 'Retry-After' => (string) MINUTE_IN_SECONDS ),
+			)
+		);
+	}
+	set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
+
+	return true;
+}
+
+/** Return the transport byte ceiling, bounded by Events' hard policy ceiling. */
+function extrachill_api_booking_attachment_max_bytes() {
+	$maximum = (int) apply_filters( 'extrachill_api_booking_attachment_max_bytes', 20 * MB_IN_BYTES );
+
+	return max( 1, min( 20 * MB_IN_BYTES, $maximum ) );
+}
+
+/**
+ * Validate metadata and register a local Events stream for manual REST serving.
+ *
+ * @param resource        $stream   Opened Events-owned stream.
+ * @param string          $filename Events-provided filename.
+ * @param string          $mime     Events-provided MIME type.
+ * @param WP_REST_Request $request  REST request.
+ * @param array|null      $delivery Events delivery correlation context.
+ * @return WP_REST_Response|WP_Error
+ */
+function extrachill_api_create_private_stream_response( $stream, $filename, $mime, WP_REST_Request $request, $delivery = null ) {
+	$stat = fstat( $stream );
+	$size = is_array( $stat ) ? (int) ( $stat['size'] ?? -1 ) : -1;
+	if ( $size < 0 || $size > extrachill_api_booking_attachment_max_bytes() ) {
+		fclose( $stream );
+		return extrachill_api_booking_attachment_download_error( 413 );
+	}
+
+	$range = extrachill_api_booking_attachment_range( $request->get_header( 'Range' ), $size );
+	if ( is_wp_error( $range ) ) {
+		fclose( $stream );
+		return $range;
+	}
+	if ( 0 !== $range['offset'] && 0 !== fseek( $stream, $range['offset'] ) ) {
+		fclose( $stream );
+		return extrachill_api_booking_attachment_download_error( 502 );
+	}
+
+	$correlation_id = is_array( $delivery ) ? (string) ( $delivery['correlation_id'] ?? '' ) : null;
+	$headers        = extrachill_api_private_stream_headers( $filename, $mime, $range['length'], $correlation_id );
+	if ( 206 === $range['status'] ) {
+		$headers['Content-Range'] = sprintf( 'bytes %d-%d/%d', $range['offset'], $range['offset'] + $range['length'] - 1, $size );
+	}
+
+	return extrachill_api_register_private_stream( $stream, $range['length'], $range['status'], $headers, null, $delivery );
+}
+
+/**
+ * Parse one bounded HTTP byte range.
+ *
+ * @param string $header Range header.
+ * @param int    $size   Full stream size.
+ * @return array|WP_Error
+ */
+function extrachill_api_booking_attachment_range( $header, $size ) {
+	if ( '' === $header || null === $header ) {
+		return array(
+			'offset' => 0,
+			'length' => $size,
+			'status' => 200,
+		);
+	}
+
+	if ( $size < 1 || 1 !== preg_match( '/^bytes=(\d*)-(\d*)$/', trim( $header ), $match ) || ( '' === $match[1] && '' === $match[2] ) ) {
+		return extrachill_api_booking_attachment_range_error( $size );
+	}
+
+	if ( '' === $match[1] ) {
+		$suffix = (int) $match[2];
+		if ( $suffix < 1 ) {
+			return extrachill_api_booking_attachment_range_error( $size );
+		}
+		$length = min( $suffix, $size );
+		$offset = $size - $length;
+	} else {
+		$offset = (int) $match[1];
+		$end    = '' === $match[2] ? $size - 1 : min( (int) $match[2], $size - 1 );
+		if ( $offset >= $size || $end < $offset ) {
+			return extrachill_api_booking_attachment_range_error( $size );
+		}
+		$length = $end - $offset + 1;
+	}
+
+	return array(
+		'offset' => $offset,
+		'length' => $length,
+		'status' => 206,
+	);
+}
+
+/** Return a non-cacheable RFC 9110 unsatisfied range response. */
+function extrachill_api_booking_attachment_range_error( $size ) {
+	return new WP_Error(
+		'booking_attachment_range_unsatisfiable',
+		'The requested byte range is unavailable.',
+		array(
+			'status'  => 416,
+			'headers' => array( 'Content-Range' => 'bytes */' . max( 0, (int) $size ) ),
+		)
+	);
+}
+
+/** Build headers that keep private bytes out of browsers and intermediary caches. */
+function extrachill_api_private_stream_headers( $filename, $mime, $length, $correlation_id = null ) {
+	$safe_filename = sanitize_file_name( wp_basename( $filename ) );
+	if ( '' === $safe_filename ) {
+		$safe_filename = 'attachment.bin';
+	}
+	$fallback = preg_replace( '/[^A-Za-z0-9._-]/', '_', $safe_filename );
+	$fallback = '' === $fallback ? 'attachment.bin' : $fallback;
+	$mime     = 1 === preg_match( '#^[a-z0-9][a-z0-9.+-]*/[a-z0-9][a-z0-9.+-]*$#i', $mime ) ? strtolower( $mime ) : 'application/octet-stream';
+
+	$headers = array(
+		'Accept-Ranges'             => 'bytes',
+		'Cache-Control'             => 'private, no-store, no-cache, must-revalidate, max-age=0',
+		'Content-Disposition'       => 'attachment; filename="' . $fallback . '"; filename*=UTF-8\'\'' . rawurlencode( $safe_filename ),
+		'Content-Length'            => (string) $length,
+		'Content-Type'              => $mime,
+		'Expires'                   => '0',
+		'Pragma'                    => 'no-cache',
+		'Vary'                      => 'Authorization, Cookie',
+		'X-Content-Type-Options'    => 'nosniff',
+		'X-Robots-Tag'              => 'noindex, nofollow, noarchive',
+	);
+	if ( is_string( $correlation_id ) && wp_is_uuid( $correlation_id, 4 ) ) {
+		$headers['X-EC-Download-Correlation'] = $correlation_id;
+	}
+
+	return $headers;
+}
+
+/** Keep every success and failure for this private route out of caches. */
+function extrachill_api_protect_booking_attachment_download_response( $response, $server, $request ) {
+	unset( $server );
+	if ( ! extrachill_api_is_booking_attachment_download_route( $request->get_route() ) ) {
+		return $response;
+	}
+
+	$response->header( 'Cache-Control', 'private, no-store, no-cache, must-revalidate, max-age=0' );
+	$response->header( 'Expires', '0' );
+	$response->header( 'Pragma', 'no-cache' );
+	$response->header( 'Vary', 'Authorization, Cookie' );
+	$response->header( 'X-Content-Type-Options', 'nosniff' );
+	$response->header( 'X-Robots-Tag', 'noindex, nofollow, noarchive' );
+
+	return $response;
+}
+
+/**
+ * Register an exact stream response without placing its resource in REST data.
+ *
+ * @param resource    $stream       Open stream.
+ * @param int         $length       Bytes to emit.
+ * @param int         $status       HTTP status.
+ * @param array       $headers      Safe response headers.
+ * @param string|null $cleanup_path Optional affinity spool to unlink.
+ * @param array|null  $delivery     Events delivery correlation context.
+ * @return WP_REST_Response
+ */
+function extrachill_api_register_private_stream( $stream, $length, $status, array $headers, $cleanup_path = null, $delivery = null ) {
+	$response = new WP_REST_Response( null, $status, $headers );
+	$key      = spl_object_id( $response );
+	$GLOBALS['extrachill_api_private_streams'][ $key ] = array(
+		'stream'       => $stream,
+		'length'       => (int) $length,
+		'cleanup_path' => is_string( $cleanup_path ) ? $cleanup_path : null,
+		'delivery'     => is_array( $delivery ) ? $delivery : null,
+	);
+	extrachill_api_register_private_stream_shutdown_cleanup();
+
+	return $response;
+}
+
+/** Register one request-level safety net for aborted/private stream responses. */
+function extrachill_api_register_private_stream_shutdown_cleanup() {
+	if ( ! empty( $GLOBALS['extrachill_api_private_stream_cleanup_registered'] ) ) {
+		return;
+	}
+	$GLOBALS['extrachill_api_private_stream_cleanup_registered'] = true;
+	register_shutdown_function( 'extrachill_api_cleanup_private_streams' );
+}
+
+/** Close every pending resource and unlink every private affinity spool. */
+function extrachill_api_cleanup_private_streams() {
+	$streams = is_array( $GLOBALS['extrachill_api_private_streams'] ?? null ) ? $GLOBALS['extrachill_api_private_streams'] : array();
+	foreach ( $streams as $entry ) {
+		if ( is_resource( $entry['stream'] ?? null ) ) {
+			fclose( $entry['stream'] );
+		}
+		$path = $entry['cleanup_path'] ?? null;
+		if ( is_string( $path ) && '' !== $path && file_exists( $path ) ) {
+			unlink( $path );
+		}
+		if ( is_array( $entry['delivery'] ?? null ) ) {
+			extrachill_api_record_booking_attachment_delivery( $entry['delivery'], 'interrupted', 0 );
+		}
+	}
+	$GLOBALS['extrachill_api_private_streams'] = array();
+}
+
+/**
+ * Emit a registered private stream after WordPress has sent its safe headers.
+ *
+ * @param bool             $served  Whether already served.
+ * @param WP_HTTP_Response $result  REST response.
+ * @param WP_REST_Request  $request REST request.
+ * @param WP_REST_Server   $server  REST server.
+ * @return bool
+ */
+function extrachill_api_serve_private_stream( $served, $result, $request, $server ) {
+	unset( $request, $server );
+	if ( $served || ! is_object( $result ) ) {
+		return $served;
+	}
+
+	$key = spl_object_id( $result );
+	if ( ! isset( $GLOBALS['extrachill_api_private_streams'][ $key ] ) ) {
+		return $served;
+	}
+
+	$entry = $GLOBALS['extrachill_api_private_streams'][ $key ];
+	unset( $GLOBALS['extrachill_api_private_streams'][ $key ] );
+	$stream      = $entry['stream'];
+	$remaining   = max( 0, (int) $entry['length'] );
+	$bytes_sent  = 0;
+	$read_failed = false;
+	try {
+		while ( $remaining > 0 && is_resource( $stream ) && ! feof( $stream ) ) {
+			$chunk = fread( $stream, min( 64 * KB_IN_BYTES, $remaining ) );
+			if ( false === $chunk ) {
+				$read_failed = true;
+				break;
+			}
+			if ( '' === $chunk ) {
+				break;
+			}
+			echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Verified private binary transport.
+			$remaining -= strlen( $chunk );
+			$bytes_sent += strlen( $chunk );
+			if ( connection_aborted() ) {
+				break;
+			}
+		}
+	} finally {
+		if ( is_resource( $stream ) ) {
+			fclose( $stream );
+		}
+		$path = $entry['cleanup_path'] ?? null;
+		if ( is_string( $path ) && '' !== $path && file_exists( $path ) ) {
+			unlink( $path );
+		}
+		if ( is_array( $entry['delivery'] ?? null ) ) {
+			if ( 0 === $remaining && ! $read_failed ) {
+				$outcome = 'completed';
+			} elseif ( $bytes_sent > 0 ) {
+				$outcome = 'partial';
+			} elseif ( connection_aborted() ) {
+				$outcome = 'interrupted';
+			} else {
+				$outcome = 'failed';
+			}
+			extrachill_api_record_booking_attachment_delivery( $entry['delivery'], $outcome, $bytes_sent );
+		}
+	}
+
+	return true;
+}
+
+/** Return whether a route is the protected binary transport. */
+function extrachill_api_is_booking_attachment_download_route( $route ) {
+	return 1 === preg_match( '#^/extrachill/v1/events/bookings/\d+/attachments/\d+/download$#', (string) $route );
+}
+
+/**
+ * Convert a bounded affinity spool into the same manual stream response.
+ *
+ * @param array  $http_response Raw WordPress HTTP response.
+ * @param string $path          Private temporary spool path.
+ * @return WP_REST_Response|WP_Error
+ */
+function extrachill_api_private_stream_from_affinity_response( array $http_response, $path ) {
+	$status  = (int) wp_remote_retrieve_response_code( $http_response );
+	$headers = wp_remote_retrieve_headers( $http_response );
+	$headers = $headers instanceof Traversable ? iterator_to_array( $headers ) : (array) $headers;
+	if ( ! in_array( $status, array( 200, 206 ), true ) ) {
+		extrachill_api_discard_private_affinity_spool( $path );
+		return extrachill_api_booking_attachment_download_error( extrachill_api_booking_attachment_proxy_status( $status ) );
+	}
+
+	$size = is_file( $path ) ? filesize( $path ) : false;
+	if ( false === $size || $size > extrachill_api_booking_attachment_max_bytes() ) {
+		extrachill_api_discard_private_affinity_spool( $path );
+		return extrachill_api_booking_attachment_download_error( 502 );
+	}
+
+	$declared = isset( $headers['content-length'] ) ? (int) $headers['content-length'] : ( isset( $headers['Content-Length'] ) ? (int) $headers['Content-Length'] : -1 );
+	if ( $declared !== (int) $size ) {
+		extrachill_api_discard_private_affinity_spool( $path );
+		return extrachill_api_booking_attachment_download_error( 502 );
+	}
+
+	$disposition = (string) ( $headers['content-disposition'] ?? ( $headers['Content-Disposition'] ?? '' ) );
+	$filename    = extrachill_api_filename_from_content_disposition( $disposition );
+	$mime        = (string) ( $headers['content-type'] ?? ( $headers['Content-Type'] ?? '' ) );
+	$safe        = extrachill_api_private_stream_headers( $filename, $mime, $size, null );
+	$correlation = (string) ( $headers['x-ec-download-correlation'] ?? ( $headers['X-EC-Download-Correlation'] ?? '' ) );
+	if ( ! wp_is_uuid( $correlation, 4 ) ) {
+		extrachill_api_discard_private_affinity_spool( $path );
+		return extrachill_api_booking_attachment_download_error( 502 );
+	}
+	$safe['X-EC-Download-Correlation'] = $correlation;
+	if ( 206 === $status ) {
+		$content_range = (string) ( $headers['content-range'] ?? ( $headers['Content-Range'] ?? '' ) );
+		if ( 1 !== preg_match( '/^bytes (\d+)-(\d+)\/(\d+)$/', $content_range, $range ) || (int) $range[2] < (int) $range[1] || (int) $range[2] - (int) $range[1] + 1 !== (int) $size || (int) $range[3] > extrachill_api_booking_attachment_max_bytes() ) {
+			extrachill_api_discard_private_affinity_spool( $path );
+			return extrachill_api_booking_attachment_download_error( 502 );
+		}
+		$safe['Content-Range'] = $content_range;
+	}
+
+	$stream = fopen( $path, 'rb' );
+	if ( false === $stream ) {
+		extrachill_api_discard_private_affinity_spool( $path );
+		return extrachill_api_booking_attachment_download_error( 502 );
+	}
+
+	return extrachill_api_register_private_stream( $stream, $size, $status, $safe, $path );
+}
+
+/** Extract and sanitize only a presentation filename from Content-Disposition. */
+function extrachill_api_filename_from_content_disposition( $header ) {
+	$filename = '';
+	if ( 1 === preg_match( "/filename\*=UTF-8''([^;]+)/i", $header, $match ) ) {
+		$filename = rawurldecode( $match[1] );
+	} elseif ( 1 === preg_match( '/filename="?([^";]+)"?/i', $header, $match ) ) {
+		$filename = $match[1];
+	}
+
+	return sanitize_file_name( wp_basename( $filename ) );
+}
+
+/** Map a downstream private transport status without exposing its response. */
+function extrachill_api_booking_attachment_proxy_status( $status ) {
+	if ( in_array( (int) $status, array( 401, 403, 404, 409, 410 ), true ) ) {
+		return 404;
+	}
+
+	return in_array( (int) $status, array( 413, 416, 429, 502, 503 ), true ) ? (int) $status : 502;
+}
+
+/** Close and unlink an affinity spool on every failure path. */
+function extrachill_api_discard_private_affinity_spool( $path ) {
+	if ( is_string( $path ) && '' !== $path && file_exists( $path ) ) {
+		unlink( $path );
+	}
+}
+
+// phpcs:enable WordPress.WP.AlternativeFunctions.file_system_operations_fclose,WordPress.WP.AlternativeFunctions.file_system_operations_fopen,WordPress.WP.AlternativeFunctions.file_system_operations_fread,WordPress.WP.AlternativeFunctions.unlink_unlink

--- a/inc/routes/events/booking-attachment-download.php
+++ b/inc/routes/events/booking-attachment-download.php
@@ -642,11 +642,7 @@ function extrachill_api_private_stream_from_affinity_response( array $http_respo
 	$headers  = $headers instanceof Traversable ? iterator_to_array( $headers ) : (array) $headers;
 	$delivery = extrachill_api_booking_attachment_affinity_delivery_from_headers( $headers, $nonce );
 	if ( ! in_array( $status, array( 200, 206 ), true ) ) {
-		extrachill_api_discard_private_affinity_spool( $path );
-		if ( is_array( $delivery ) ) {
-			extrachill_api_record_booking_attachment_delivery( $delivery, 'failed', 0 );
-		}
-		return extrachill_api_booking_attachment_download_error( extrachill_api_booking_attachment_proxy_status( $status ) );
+		return extrachill_api_fail_private_affinity_stream( $path, $delivery, extrachill_api_booking_attachment_proxy_status( $status ) );
 	}
 	if ( ! is_array( $delivery ) ) {
 		extrachill_api_discard_private_affinity_spool( $path );
@@ -655,14 +651,12 @@ function extrachill_api_private_stream_from_affinity_response( array $http_respo
 
 	$size = is_file( $path ) ? filesize( $path ) : false;
 	if ( false === $size || $size > extrachill_api_booking_attachment_max_bytes() ) {
-		extrachill_api_discard_private_affinity_spool( $path );
-		return extrachill_api_booking_attachment_download_error( 502 );
+		return extrachill_api_fail_private_affinity_stream( $path, $delivery );
 	}
 
 	$declared = isset( $headers['content-length'] ) ? (int) $headers['content-length'] : ( isset( $headers['Content-Length'] ) ? (int) $headers['Content-Length'] : -1 );
 	if ( $declared !== (int) $size ) {
-		extrachill_api_discard_private_affinity_spool( $path );
-		return extrachill_api_booking_attachment_download_error( 502 );
+		return extrachill_api_fail_private_affinity_stream( $path, $delivery );
 	}
 
 	$disposition = (string) ( $headers['content-disposition'] ?? ( $headers['Content-Disposition'] ?? '' ) );
@@ -672,26 +666,38 @@ function extrachill_api_private_stream_from_affinity_response( array $http_respo
 	if ( 206 === $status ) {
 		$content_range = (string) ( $headers['content-range'] ?? ( $headers['Content-Range'] ?? '' ) );
 		if ( 1 !== preg_match( '/^bytes (\d+)-(\d+)\/(\d+)$/', $content_range, $range ) ) {
-			extrachill_api_discard_private_affinity_spool( $path );
-			return extrachill_api_booking_attachment_download_error( 502 );
+			return extrachill_api_fail_private_affinity_stream( $path, $delivery );
 		}
 		$start = (int) $range[1];
 		$end   = (int) $range[2];
 		$total = (int) $range[3];
 		if ( $total < 1 || $start < 0 || $start > $end || $end >= $total || $end - $start + 1 !== (int) $size || $total > extrachill_api_booking_attachment_max_bytes() ) {
-			extrachill_api_discard_private_affinity_spool( $path );
-			return extrachill_api_booking_attachment_download_error( 502 );
+			return extrachill_api_fail_private_affinity_stream( $path, $delivery );
 		}
 		$safe['Content-Range'] = $content_range;
 	}
 
 	$stream = fopen( $path, 'rb' );
+	$stream = apply_filters( 'extrachill_api_private_affinity_stream', $stream, $path );
 	if ( false === $stream ) {
-		extrachill_api_discard_private_affinity_spool( $path );
-		return extrachill_api_booking_attachment_download_error( 502 );
+		return extrachill_api_fail_private_affinity_stream( $path, $delivery );
 	}
 
 	return extrachill_api_register_private_stream( $stream, $size, $status, $safe, $path, $delivery );
+}
+
+/** Finalize a consumed handoff without exposing callback or spool failures. */
+function extrachill_api_fail_private_affinity_stream( $path, $delivery, $status = 502 ) {
+	if ( is_array( $delivery ) ) {
+		try {
+			extrachill_api_record_booking_attachment_delivery( $delivery, 'failed', 0 );
+		} catch ( Throwable $throwable ) {
+			unset( $throwable );
+		}
+	}
+	extrachill_api_discard_private_affinity_spool( $path );
+
+	return extrachill_api_booking_attachment_download_error( $status );
 }
 
 /** Extract and sanitize only a presentation filename from Content-Disposition. */

--- a/inc/routes/events/booking-attachment-download.php
+++ b/inc/routes/events/booking-attachment-download.php
@@ -92,7 +92,7 @@ function extrachill_api_download_booking_attachment( WP_REST_Request $request ) 
 		return extrachill_api_booking_attachment_download_error( extrachill_api_booking_attachment_error_status( $descriptor ) );
 	}
 
-	$token = $descriptor['stream_token'] ?? null;
+	$token          = $descriptor['stream_token'] ?? null;
 	$correlation_id = $descriptor['correlation_id'] ?? null;
 	if ( ! is_string( $token ) || 1 !== preg_match( '/^[a-f0-9]{64}$/', $token ) || ! is_string( $correlation_id ) || ! wp_is_uuid( $correlation_id, 4 ) ) {
 		return extrachill_api_booking_attachment_download_error( 502 );
@@ -155,7 +155,7 @@ function extrachill_api_record_booking_attachment_delivery( array $delivery, $ou
 	if ( ! $ability ) {
 		return false;
 	}
-	$input = array(
+	$input   = array(
 		'booking_id'     => (int) ( $delivery['booking_id'] ?? 0 ),
 		'attachment_id'  => (int) ( $delivery['attachment_id'] ?? 0 ),
 		'correlation_id' => (string) ( $delivery['correlation_id'] ?? '' ),
@@ -341,16 +341,16 @@ function extrachill_api_private_stream_headers( $filename, $mime, $length, $corr
 	$mime     = 1 === preg_match( '#^[a-z0-9][a-z0-9.+-]*/[a-z0-9][a-z0-9.+-]*$#i', $mime ) ? strtolower( $mime ) : 'application/octet-stream';
 
 	$headers = array(
-		'Accept-Ranges'             => 'bytes',
-		'Cache-Control'             => 'private, no-store, no-cache, must-revalidate, max-age=0',
-		'Content-Disposition'       => 'attachment; filename="' . $fallback . '"; filename*=UTF-8\'\'' . rawurlencode( $safe_filename ),
-		'Content-Length'            => (string) $length,
-		'Content-Type'              => $mime,
-		'Expires'                   => '0',
-		'Pragma'                    => 'no-cache',
-		'Vary'                      => 'Authorization, Cookie',
-		'X-Content-Type-Options'    => 'nosniff',
-		'X-Robots-Tag'              => 'noindex, nofollow, noarchive',
+		'Accept-Ranges'          => 'bytes',
+		'Cache-Control'          => 'private, no-store, no-cache, must-revalidate, max-age=0',
+		'Content-Disposition'    => 'attachment; filename="' . $fallback . '"; filename*=UTF-8\'\'' . rawurlencode( $safe_filename ),
+		'Content-Length'         => (string) $length,
+		'Content-Type'           => $mime,
+		'Expires'                => '0',
+		'Pragma'                 => 'no-cache',
+		'Vary'                   => 'Authorization, Cookie',
+		'X-Content-Type-Options' => 'nosniff',
+		'X-Robots-Tag'           => 'noindex, nofollow, noarchive',
 	);
 	if ( is_string( $correlation_id ) && wp_is_uuid( $correlation_id, 4 ) ) {
 		$headers['X-EC-Download-Correlation'] = $correlation_id;
@@ -361,6 +361,9 @@ function extrachill_api_private_stream_headers( $filename, $mime, $length, $corr
 
 /** Keep every success and failure for this private route out of caches. */
 function extrachill_api_protect_booking_attachment_download_response( $response, $server, $request ) {
+	if ( function_exists( 'extrachill_api_booking_transport_error_headers' ) ) {
+		$response = extrachill_api_booking_transport_error_headers( $response, $server, $request );
+	}
 	unset( $server );
 	if ( ! extrachill_api_is_booking_attachment_download_route( $request->get_route() ) ) {
 		return $response;
@@ -465,7 +468,7 @@ function extrachill_api_serve_private_stream( $served, $result, $request, $serve
 				break;
 			}
 			echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Verified private binary transport.
-			$remaining -= strlen( $chunk );
+			$remaining  -= strlen( $chunk );
 			$bytes_sent += strlen( $chunk );
 			if ( connection_aborted() ) {
 				break;

--- a/inc/routes/events/booking-attachment-download.php
+++ b/inc/routes/events/booking-attachment-download.php
@@ -671,7 +671,14 @@ function extrachill_api_private_stream_from_affinity_response( array $http_respo
 	$safe        = extrachill_api_private_stream_headers( $filename, $mime, $size );
 	if ( 206 === $status ) {
 		$content_range = (string) ( $headers['content-range'] ?? ( $headers['Content-Range'] ?? '' ) );
-		if ( 1 !== preg_match( '/^bytes (\d+)-(\d+)\/(\d+)$/', $content_range, $range ) || (int) $range[2] < (int) $range[1] || (int) $range[2] - (int) $range[1] + 1 !== (int) $size || (int) $range[3] > extrachill_api_booking_attachment_max_bytes() ) {
+		if ( 1 !== preg_match( '/^bytes (\d+)-(\d+)\/(\d+)$/', $content_range, $range ) ) {
+			extrachill_api_discard_private_affinity_spool( $path );
+			return extrachill_api_booking_attachment_download_error( 502 );
+		}
+		$start = (int) $range[1];
+		$end   = (int) $range[2];
+		$total = (int) $range[3];
+		if ( $total < 1 || $start < 0 || $start > $end || $end >= $total || $end - $start + 1 !== (int) $size || $total > extrachill_api_booking_attachment_max_bytes() ) {
 			extrachill_api_discard_private_affinity_spool( $path );
 			return extrachill_api_booking_attachment_download_error( 502 );
 		}

--- a/inc/routes/events/booking-inquiries.php
+++ b/inc/routes/events/booking-inquiries.php
@@ -139,6 +139,11 @@ function extrachill_api_validate_booking_attachment_purposes( $value ) {
 
 /** Enforce Turnstile before consuming the public-write rate budget. */
 function extrachill_api_booking_inquiry_permission( WP_REST_Request $request ) {
+	foreach ( array( 'user_id', 'submitter_user_id', 'uploader_user_id' ) as $identity_field ) {
+		if ( null !== $request->get_param( $identity_field ) ) {
+			return new WP_Error( 'booking_identity_not_allowed', __( 'Caller identity cannot be submitted as form data.', 'extrachill-api' ), array( 'status' => 400 ) );
+		}
+	}
 	if ( ! function_exists( 'ec_turnstile_check_request' ) ) {
 		return new WP_Error( 'booking_security_unavailable', __( 'Security verification is unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
 	}
@@ -165,6 +170,10 @@ function extrachill_api_booking_inquiry_permission( WP_REST_Request $request ) {
 
 /** Normalize and invoke the Events-owned inquiry and attachment contracts. */
 function extrachill_api_handle_booking_inquiry( WP_REST_Request $request ) {
+	$identity = extrachill_api_booking_validate_canonical_identity();
+	if ( is_wp_error( $identity ) ) {
+		return $identity;
+	}
 	$abilities = wp_get_abilities();
 	$ability   = $abilities[ EXTRACHILL_API_BOOKING_ABILITY ] ?? null;
 	if ( ! $ability || $ability->get_meta_item( 'show_in_rest' ) ) {
@@ -188,6 +197,20 @@ function extrachill_api_handle_booking_inquiry( WP_REST_Request $request ) {
 	}
 
 	return new WP_REST_Response( $result, 201 );
+}
+
+/** Accept anonymous callers or an existing user established by canonical auth. */
+function extrachill_api_booking_validate_canonical_identity() {
+	$user_id = get_current_user_id();
+	if ( $user_id < 1 ) {
+		return true;
+	}
+	$user = wp_get_current_user();
+	if ( ! $user instanceof WP_User || ! $user->exists() || (int) $user->ID !== $user_id ) {
+		return new WP_Error( 'booking_authentication_invalid', __( 'The authenticated booking identity is invalid.', 'extrachill-api' ), array( 'status' => 401 ) );
+	}
+
+	return true;
 }
 
 /** Build only fields accepted by the hidden ability schema. */

--- a/inc/routes/events/booking-inquiries.php
+++ b/inc/routes/events/booking-inquiries.php
@@ -171,7 +171,8 @@ function extrachill_api_booking_inquiry_permission( WP_REST_Request $request ) {
 		return new WP_Error( 'booking_security_unavailable', __( 'Security verification is unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
 	}
 	$original_remote_addr = $_SERVER['REMOTE_ADDR'] ?? null;
-	$affinity_remote_addr = '1' === $request->get_header( 'X-EC-Affinity-Verified' ) ? (string) $request->get_param( '_ec_affinity_remote_addr' ) : '';
+	$affinity_context     = function_exists( 'extrachill_api_route_affinity_context' ) ? extrachill_api_route_affinity_context( $request ) : array();
+	$affinity_remote_addr = (string) ( $affinity_context['remote_addr'] ?? '' );
 	if ( '' !== $affinity_remote_addr && false !== filter_var( $affinity_remote_addr, FILTER_VALIDATE_IP ) ) {
 		$_SERVER['REMOTE_ADDR'] = $affinity_remote_addr;
 	}
@@ -332,7 +333,8 @@ function extrachill_api_normalize_booking_files( WP_REST_Request $request ) {
 		$file['purpose'] = sanitize_key( $purposes[ $index ] );
 	}
 	unset( $file );
-	if ( '1' === $request->get_header( 'X-EC-Affinity-Verified' ) ) {
+	$affinity_context = function_exists( 'extrachill_api_route_affinity_context' ) ? extrachill_api_route_affinity_context( $request ) : array();
+	if ( $affinity_context ) {
 		$expected = json_decode( (string) $request->get_param( EXTRACHILL_API_BOOKING_FILES ), true );
 		if ( ! is_array( $expected ) || extrachill_api_booking_file_descriptors( $files ) !== $expected ) {
 			return new WP_Error( 'booking_attachment_transport_invalid', __( 'The booking attachment transport could not be verified.', 'extrachill-api' ), array( 'status' => 400 ) );
@@ -341,49 +343,46 @@ function extrachill_api_normalize_booking_files( WP_REST_Request $request ) {
 
 	return $files;
 }
-/** Keep domain details private while preserving stable HTTP classes. */
+/** Map only explicitly contracted domain errors to fixed public responses. */
 function extrachill_api_booking_public_error( WP_Error $error ) {
-	$code   = $error->get_error_code();
-	$data   = (array) $error->get_error_data();
-	$status = (int) ( $data['status'] ?? 0 );
-	if ( $status < 400 || $status > 599 ) {
-		$status = 0 === strpos( $code, 'invalid_' ) || false !== strpos( $code, '_required' ) ? 400 : 503;
+	$contracts = array(
+		'booking_idempotency_conflict'              => array( 'booking_idempotency_conflict', 409, __( 'This inquiry key was already used for different details.', 'extrachill-api' ), array() ),
+		'booking_config_revision_conflict'          => array( 'booking_inquiry_stale_config', 409, __( 'The venue booking configuration changed. Refresh it before resubmitting.', 'extrachill-api' ), array() ),
+		'venue_booking_config_version_conflict'     => array( 'booking_inquiry_stale_config', 409, __( 'The venue booking configuration changed. Refresh it before resubmitting.', 'extrachill-api' ), array() ),
+		'booking_inquiry_admission_disabled'        => array( 'booking_inquiry_unavailable', 503, __( 'This venue is not accepting booking inquiries.', 'extrachill-api' ), array() ),
+		'booking_inquiry_unavailable'               => array( 'booking_inquiry_unavailable', 503, __( 'Booking inquiry processing is temporarily unavailable.', 'extrachill-api' ), array() ),
+		'booking_inquiry_reconciliation_required'   => array( 'booking_inquiry_reconciliation_required', 503, __( 'The inquiry outcome requires reconciliation before retrying.', 'extrachill-api' ), array( 'retryable', 'reconciliation_required' ) ),
+		'invalid_booking_attachment_count'          => array( 'booking_attachment_rejected', 400, __( 'Too many booking attachments were submitted.', 'extrachill-api' ), array() ),
+		'booking_attachment_upload_failed'          => array( 'booking_attachment_rejected', 400, __( 'A booking attachment could not be received.', 'extrachill-api' ), array() ),
+		'invalid_booking_attachment_filename'       => array( 'booking_attachment_rejected', 400, __( 'A booking attachment filename is not allowed.', 'extrachill-api' ), array() ),
+		'invalid_booking_attachment_purpose'        => array( 'booking_attachment_rejected', 400, __( 'A booking attachment purpose is not supported.', 'extrachill-api' ), array() ),
+		'invalid_booking_attachment_type'           => array( 'booking_attachment_rejected', 400, __( 'A booking attachment type is not supported.', 'extrachill-api' ), array() ),
+		'invalid_booking_attachment_size'           => array( 'booking_attachment_rejected', 413, __( 'A booking attachment is outside the allowed size.', 'extrachill-api' ), array() ),
+		'invalid_booking_attachment_aggregate_size' => array( 'booking_attachment_rejected', 413, __( 'The combined booking attachments are too large.', 'extrachill-api' ), array() ),
+		'booking_tax_document_denied'               => array( 'booking_attachment_rejected', 400, __( 'Tax identity documents are not accepted here.', 'extrachill-api' ), array() ),
+		'turnstile_missing_token'                   => array( 'turnstile_missing_token', 403, __( 'Security verification is required.', 'extrachill-api' ), array() ),
+		'turnstile_failed'                          => array( 'turnstile_failed', 403, __( 'Security verification failed. Refresh the challenge and retry.', 'extrachill-api' ), array() ),
+	);
+	$contract  = $contracts[ $error->get_error_code() ] ?? null;
+	if ( ! is_array( $contract ) ) {
+		return new WP_Error( 'booking_inquiry_unavailable', __( 'Booking inquiry processing is temporarily unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
 	}
-	$safe = in_array( $status, array( 400, 403, 409, 413, 429 ), true ) || 'booking_inquiry_reconciliation_required' === $code;
-	if ( ! $safe ) {
-		$status = 503;
-	}
-	$public_code = $code;
-	if ( 409 === $status && false !== strpos( $code, 'config' ) ) {
-		$public_code = 'booking_inquiry_stale_config';
-	} elseif ( in_array( $status, array( 400, 413 ), true ) && false !== strpos( $code, 'attachment' ) ) {
-		$public_code = 'booking_attachment_rejected';
-	}
-	$public_data = array( 'status' => $status );
-	foreach ( array( 'retryable', 'reconciliation_required', 'retry_after', 'headers' ) as $key ) {
-		if ( array_key_exists( $key, $data ) ) {
-			$public_data[ $key ] = $data[ $key ];
+
+	$data        = (array) $error->get_error_data();
+	$public_data = array( 'status' => $contract[1] );
+	foreach ( $contract[3] as $field ) {
+		if ( isset( $data[ $field ] ) && is_bool( $data[ $field ] ) ) {
+			$public_data[ $field ] = $data[ $field ];
 		}
 	}
 
-	return new WP_Error(
-		$safe ? $public_code : 'booking_inquiry_unavailable',
-		$safe ? $error->get_error_message() : __( 'Booking inquiry processing is temporarily unavailable.', 'extrachill-api' ),
-		$public_data
-	);
+	return new WP_Error( $contract[0], $contract[2], $public_data );
 }
 
 /** Add file descriptors to the affinity signature without exposing bytes. */
 function extrachill_api_booking_affinity_signature_body( $body, WP_REST_Request $request ) {
 	if ( ! preg_match( '#^/extrachill/v1/venues/\d+/booking-inquiries$#', $request->get_route() ) ) {
 		return $body;
-	}
-	if ( empty( $body['_ec_affinity_client'] ) ) {
-		$client_ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
-		if ( '' !== $client_ip && false !== filter_var( $client_ip, FILTER_VALIDATE_IP ) ) {
-			$body['_ec_affinity_client']      = hash_hmac( 'sha256', $client_ip, wp_salt( 'nonce' ) );
-			$body['_ec_affinity_remote_addr'] = $client_ip;
-		}
 	}
 	$encoded = $request->get_param( EXTRACHILL_API_BOOKING_FILES );
 	if ( is_string( $encoded ) ) {
@@ -439,8 +438,10 @@ function extrachill_api_booking_affinity_file_forward( $response, $target_site, 
 	if ( is_wp_error( $body ) ) {
 		return $body;
 	}
-	$headers = array_merge(
+	$auth_headers = function_exists( 'ec_cross_site_build_auth_headers' ) ? ec_cross_site_build_auth_headers( get_current_user_id() ) : array();
+	$headers      = array_merge(
 		(array) ( $args['headers'] ?? array() ),
+		$auth_headers,
 		array(
 			'Host'         => $host,
 			'Accept'       => 'application/json',

--- a/inc/routes/events/booking-inquiries.php
+++ b/inc/routes/events/booking-inquiries.php
@@ -1,0 +1,424 @@
+<?php
+/**
+ * Protected public venue booking inquiry admission.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const EXTRACHILL_API_BOOKING_ABILITY             = 'extrachill/create-booking-inquiry';
+const EXTRACHILL_API_BOOKING_FILES               = '_ec_affinity_files';
+const EXTRACHILL_API_BOOKING_MAX_FILES           = 5;
+const EXTRACHILL_API_BOOKING_MAX_FILE_BYTES      = 20 * MB_IN_BYTES;
+const EXTRACHILL_API_BOOKING_MAX_AGGREGATE_BYTES = 50 * MB_IN_BYTES;
+
+add_filter( 'ec_route_site_affinity_map', 'extrachill_api_add_booking_route_affinity' );
+add_filter( 'extrachill_api_route_affinity_signature_body', 'extrachill_api_booking_affinity_signature_body', 10, 2 );
+add_filter( 'extrachill_api_route_affinity_file_forward', 'extrachill_api_booking_affinity_file_forward', 10, 5 );
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_booking_inquiry_route' );
+
+/** Route booking inquiries to the Events site on a segment boundary. */
+function extrachill_api_add_booking_route_affinity( $affinity_map ) {
+	$affinity_map['/extrachill/v1/venues/'] = 'events';
+	return $affinity_map;
+}
+
+/** Register the protected public facade. */
+function extrachill_api_register_booking_inquiry_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/venues/(?P<venue>\d+)/booking-inquiries',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_handle_booking_inquiry',
+			'permission_callback' => 'extrachill_api_booking_inquiry_permission',
+			'args'                => extrachill_api_booking_inquiry_args(),
+		)
+	);
+}
+
+/** Return the facade schema, including transport-only fields. */
+function extrachill_api_booking_inquiry_args() {
+	$nullable_text = array(
+		'required'          => false,
+		'type'              => array( 'string', 'null' ),
+		'sanitize_callback' => 'sanitize_text_field',
+	);
+
+	return array(
+		'venue'               => array(
+			'required' => true,
+			'type'     => 'integer',
+			'minimum'  => 1,
+		),
+		'idempotency_key'     => array(
+			'required'          => true,
+			'type'              => 'string',
+			'minLength'         => 1,
+			'maxLength'         => 191,
+			'sanitize_callback' => 'sanitize_text_field',
+		),
+		'artist_term_id'      => array(
+			'required' => false,
+			'type'     => array( 'integer', 'null' ),
+			'minimum'  => 1,
+		),
+		'artist_profile_id'   => array(
+			'required' => false,
+			'type'     => array( 'integer', 'null' ),
+			'minimum'  => 1,
+		),
+		'artist_name'         => array(
+			'required'          => false,
+			'type'              => 'string',
+			'minLength'         => 1,
+			'maxLength'         => 255,
+			'sanitize_callback' => 'sanitize_text_field',
+		),
+		'contact_name'        => array_merge( $nullable_text, array( 'maxLength' => 255 ) ),
+		'contact_email'       => array_merge(
+			$nullable_text,
+			array(
+				'format'            => 'email',
+				'maxLength'         => 255,
+				'sanitize_callback' => 'sanitize_email',
+			)
+		),
+		'contact_phone'       => array_merge( $nullable_text, array( 'maxLength' => 64 ) ),
+		'requested_space_key' => array_merge( $nullable_text, array( 'maxLength' => 64 ) ),
+		'requested_start_at'  => array_merge( $nullable_text, array( 'pattern' => '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$' ) ),
+		'requested_end_at'    => array_merge( $nullable_text, array( 'pattern' => '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$' ) ),
+		'intake'              => array(
+			'required'          => true,
+			'type'              => array( 'object', 'string' ),
+			'validate_callback' => 'extrachill_api_validate_booking_intake',
+		),
+		'attachment_purposes' => array(
+			'required'          => false,
+			'type'              => array( 'array', 'string' ),
+			'validate_callback' => 'extrachill_api_validate_booking_attachment_purposes',
+		),
+		'turnstile_response'  => array(
+			'required'          => true,
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+		),
+	);
+}
+
+/** Validate JSON-or-object intake used by JSON and multipart clients. */
+function extrachill_api_validate_booking_intake( $value ) {
+	if ( is_array( $value ) ) {
+		return true;
+	}
+	if ( ! is_string( $value ) || '' === $value ) {
+		return false;
+	}
+	$decoded = json_decode( $value, true );
+	return is_array( $decoded ) && JSON_ERROR_NONE === json_last_error();
+}
+
+/** Validate the declared purpose list without duplicating Events policy. */
+function extrachill_api_validate_booking_attachment_purposes( $value ) {
+	if ( is_string( $value ) ) {
+		$value = json_decode( $value, true );
+	}
+	if ( ! is_array( $value ) ) {
+		return false;
+	}
+	foreach ( $value as $purpose ) {
+		if ( ! is_string( $purpose ) || '' === sanitize_key( $purpose ) ) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/** Enforce Turnstile before consuming the public-write rate budget. */
+function extrachill_api_booking_inquiry_permission( WP_REST_Request $request ) {
+	if ( ! function_exists( 'ec_turnstile_check_request' ) ) {
+		return new WP_Error( 'booking_security_unavailable', __( 'Security verification is unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
+	}
+	$original_remote_addr = $_SERVER['REMOTE_ADDR'] ?? null;
+	$affinity_remote_addr = '1' === $request->get_header( 'X-EC-Affinity-Verified' ) ? (string) $request->get_param( '_ec_affinity_remote_addr' ) : '';
+	if ( '' !== $affinity_remote_addr && false !== filter_var( $affinity_remote_addr, FILTER_VALIDATE_IP ) ) {
+		$_SERVER['REMOTE_ADDR'] = $affinity_remote_addr;
+	}
+	try {
+		$turnstile = ec_turnstile_check_request( $request );
+	} finally {
+		if ( null === $original_remote_addr ) {
+			unset( $_SERVER['REMOTE_ADDR'] );
+		} else {
+			$_SERVER['REMOTE_ADDR'] = $original_remote_addr;
+		}
+	}
+	if ( is_wp_error( $turnstile ) ) {
+		return extrachill_api_booking_public_error( $turnstile );
+	}
+	$limit = (int) apply_filters( 'extrachill_api_booking_inquiry_rate_limit', 10 );
+	return extrachill_api_check_public_write_rate_limit( $request, 'booking-inquiry', $limit );
+}
+
+/** Normalize and invoke the Events-owned inquiry and attachment contracts. */
+function extrachill_api_handle_booking_inquiry( WP_REST_Request $request ) {
+	$abilities = wp_get_abilities();
+	$ability   = $abilities[ EXTRACHILL_API_BOOKING_ABILITY ] ?? null;
+	if ( ! $ability || $ability->get_meta_item( 'show_in_rest' ) ) {
+		return new WP_Error( 'booking_inquiry_unavailable', __( 'Booking inquiry processing is unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
+	}
+
+	$files = extrachill_api_normalize_booking_files( $request );
+	if ( is_wp_error( $files ) ) {
+		return $files;
+	}
+	$input = extrachill_api_booking_ability_input( $request, $files );
+	if ( is_wp_error( $input ) ) {
+		return $input;
+	}
+	$result = $ability->execute( $input );
+	if ( is_wp_error( $result ) ) {
+		return extrachill_api_booking_public_error( $result );
+	}
+	if ( ! is_array( $result ) || empty( $result['public_id'] ) ) {
+		return new WP_Error( 'booking_inquiry_invalid_response', __( 'Booking inquiry processing returned an invalid response.', 'extrachill-api' ), array( 'status' => 502 ) );
+	}
+
+	return new WP_REST_Response( $result, 201 );
+}
+
+/** Build only fields accepted by the hidden ability schema. */
+function extrachill_api_booking_ability_input( WP_REST_Request $request, array $files ) {
+	$intake = $request->get_param( 'intake' );
+	if ( is_string( $intake ) ) {
+		$intake = json_decode( $intake, true );
+	}
+	if ( ! is_array( $intake ) ) {
+		return new WP_Error( 'booking_inquiry_invalid_intake', __( 'A valid intake object is required.', 'extrachill-api' ), array( 'status' => 400 ) );
+	}
+	$input = array(
+		'idempotency_key' => sanitize_text_field( (string) $request->get_param( 'idempotency_key' ) ),
+		'venue_term_id'   => absint( $request->get_param( 'venue' ) ),
+		'intake'          => $intake,
+	);
+	foreach ( array( 'artist_term_id', 'artist_profile_id' ) as $key ) {
+		$value = $request->get_param( $key );
+		if ( null !== $value && '' !== $value ) {
+			$input[ $key ] = absint( $value );
+		}
+	}
+	foreach ( array( 'artist_name', 'contact_name', 'contact_email', 'contact_phone', 'requested_space_key', 'requested_start_at', 'requested_end_at' ) as $key ) {
+		$value = $request->get_param( $key );
+		if ( null !== $value ) {
+			$input[ $key ] = '' === $value ? null : $value;
+		}
+	}
+	if ( $files ) {
+		$input['attachments'] = array_map(
+			static function ( array $file ) {
+				return array(
+					'name'     => $file['name'],
+					'tmp_name' => $file['tmp_name'],
+					'error'    => (int) $file['error'],
+					'size'     => (int) $file['size'],
+					'purpose'  => $file['purpose'],
+				);
+			},
+			$files
+		);
+	}
+
+	return $input;
+}
+
+/** Normalize PHP's single/multiple file shapes and bind declared purposes. */
+function extrachill_api_normalize_booking_files( WP_REST_Request $request ) {
+	$raw = $request->get_file_params();
+	if ( empty( $raw['attachments'] ) ) {
+		return array();
+	}
+	$upload = $raw['attachments'];
+	$names  = is_array( $upload['name'] ?? null ) ? $upload['name'] : array( $upload['name'] ?? '' );
+	if ( count( $names ) > EXTRACHILL_API_BOOKING_MAX_FILES ) {
+		return new WP_Error( 'booking_attachment_count_invalid', __( 'Too many booking attachments were submitted.', 'extrachill-api' ), array( 'status' => 400 ) );
+	}
+	$files          = array();
+	$aggregate_size = 0;
+	foreach ( array_keys( $names ) as $index ) {
+		$file = array();
+		foreach ( array( 'name', 'type', 'tmp_name', 'error', 'size' ) as $key ) {
+			$file[ $key ] = is_array( $upload[ $key ] ?? null ) ? ( $upload[ $key ][ $index ] ?? null ) : ( $upload[ $key ] ?? null );
+		}
+		if ( UPLOAD_ERR_NO_FILE === (int) $file['error'] ) {
+			continue;
+		}
+		if ( UPLOAD_ERR_OK !== (int) $file['error'] || '' === (string) $file['tmp_name'] || ! is_readable( $file['tmp_name'] ) || ( ! is_uploaded_file( $file['tmp_name'] ) && ! apply_filters( 'extrachill_api_allow_test_booking_file', false, $file ) ) ) {
+			return new WP_Error( 'booking_attachment_upload_failed', __( 'A booking attachment could not be received.', 'extrachill-api' ), array( 'status' => 400 ) );
+		}
+		$actual_size = filesize( $file['tmp_name'] );
+		if ( false === $actual_size || (int) $file['size'] !== $actual_size || $actual_size < 1 || $actual_size > EXTRACHILL_API_BOOKING_MAX_FILE_BYTES ) {
+			return new WP_Error( 'booking_attachment_size_invalid', __( 'A booking attachment is outside the allowed size.', 'extrachill-api' ), array( 'status' => 413 ) );
+		}
+		$aggregate_size += $actual_size;
+		if ( $aggregate_size > EXTRACHILL_API_BOOKING_MAX_AGGREGATE_BYTES ) {
+			return new WP_Error( 'booking_attachment_aggregate_size_invalid', __( 'The combined booking attachments are too large.', 'extrachill-api' ), array( 'status' => 413 ) );
+		}
+		$file['name'] = sanitize_file_name( (string) $file['name'] );
+		$file['size'] = $actual_size;
+		$file['sha256'] = hash_file( 'sha256', $file['tmp_name'] );
+		if ( false === $file['sha256'] ) {
+			return new WP_Error( 'booking_attachment_upload_failed', __( 'A booking attachment could not be received.', 'extrachill-api' ), array( 'status' => 400 ) );
+		}
+		$files[] = $file;
+	}
+
+	$purposes = $request->get_param( 'attachment_purposes' );
+	if ( is_string( $purposes ) ) {
+		$purposes = json_decode( $purposes, true );
+	}
+	if ( count( $files ) !== count( (array) $purposes ) ) {
+		return new WP_Error( 'booking_attachment_purpose_mismatch', __( 'Each booking attachment requires one purpose.', 'extrachill-api' ), array( 'status' => 400 ) );
+	}
+	foreach ( $files as $index => &$file ) {
+		$file['purpose'] = sanitize_key( $purposes[ $index ] );
+	}
+	unset( $file );
+	if ( '1' === $request->get_header( 'X-EC-Affinity-Verified' ) ) {
+		$expected = json_decode( (string) $request->get_param( EXTRACHILL_API_BOOKING_FILES ), true );
+		if ( ! is_array( $expected ) || extrachill_api_booking_file_descriptors( $files ) !== $expected ) {
+			return new WP_Error( 'booking_attachment_transport_invalid', __( 'The booking attachment transport could not be verified.', 'extrachill-api' ), array( 'status' => 400 ) );
+		}
+	}
+
+	return $files;
+}
+/** Keep domain details private while preserving stable HTTP classes. */
+function extrachill_api_booking_public_error( WP_Error $error ) {
+	$code   = $error->get_error_code();
+	$data   = (array) $error->get_error_data();
+	$status = (int) ( $data['status'] ?? 0 );
+	if ( $status < 400 || $status > 599 ) {
+		$status = 0 === strpos( $code, 'invalid_' ) || false !== strpos( $code, '_required' ) ? 400 : 503;
+	}
+	$public_code = in_array( $status, array( 400, 403, 409, 413, 429 ), true ) ? $code : 'booking_inquiry_unavailable';
+	$message     = in_array( $status, array( 400, 403, 409, 413, 429 ), true ) ? $error->get_error_message() : __( 'Booking inquiry processing is temporarily unavailable.', 'extrachill-api' );
+	return new WP_Error( $public_code, $message, array( 'status' => $status ) );
+}
+
+/** Add file descriptors to the affinity signature without exposing bytes. */
+function extrachill_api_booking_affinity_signature_body( $body, WP_REST_Request $request ) {
+	if ( ! preg_match( '#^/extrachill/v1/venues/\d+/booking-inquiries$#', $request->get_route() ) ) {
+		return $body;
+	}
+	if ( empty( $body['_ec_affinity_client'] ) ) {
+		$client_ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+		if ( '' !== $client_ip && false !== filter_var( $client_ip, FILTER_VALIDATE_IP ) ) {
+			$body['_ec_affinity_client']      = hash_hmac( 'sha256', $client_ip, wp_salt( 'nonce' ) );
+			$body['_ec_affinity_remote_addr'] = $client_ip;
+		}
+	}
+	$encoded = $request->get_param( EXTRACHILL_API_BOOKING_FILES );
+	if ( is_string( $encoded ) ) {
+		$decoded = json_decode( $encoded, true );
+		if ( is_array( $decoded ) ) {
+			$body[ EXTRACHILL_API_BOOKING_FILES ] = $decoded;
+		}
+		return $body;
+	}
+	$files = extrachill_api_normalize_booking_files( $request );
+	if ( is_wp_error( $files ) || ! $files ) {
+		return $body;
+	}
+	foreach ( $body as $key => $value ) {
+		if ( is_array( $value ) ) {
+			$body[ $key ] = wp_json_encode( $value );
+		}
+	}
+	$body[ EXTRACHILL_API_BOOKING_FILES ] = extrachill_api_booking_file_descriptors( $files );
+	return $body;
+}
+
+/** Return signed descriptors used to verify the loopback multipart body. */
+function extrachill_api_booking_file_descriptors( array $files ) {
+	$descriptors = array();
+	foreach ( $files as $file ) {
+		$descriptors[] = array(
+			'name'    => sanitize_file_name( $file['name'] ),
+			'size'    => (int) $file['size'],
+			'purpose' => $file['purpose'],
+			'hash'    => $file['sha256'],
+		);
+	}
+	return $descriptors;
+}
+
+/** Preserve multipart booking files over the signed Events-site loopback. */
+function extrachill_api_booking_affinity_file_forward( $response, $target_site, $path, $args, WP_REST_Request $request ) {
+	if ( 'events' !== $target_site || ! preg_match( '#^/venues/\d+/booking-inquiries$#', $path ) || ! $request->get_file_params() ) {
+		return $response;
+	}
+	$files = extrachill_api_normalize_booking_files( $request );
+	if ( is_wp_error( $files ) ) {
+		return $files;
+	}
+	$site_url = ec_get_site_url( $target_site );
+	$host     = wp_parse_url( $site_url, PHP_URL_HOST );
+	if ( ! $host ) {
+		return new WP_Error( 'route_affinity_target_invalid', 'Could not resolve route-affinity target host.', array( 'status' => 500 ) );
+	}
+	$boundary = 'ec-' . wp_generate_password( 32, false, false );
+	$body     = extrachill_api_booking_multipart_body( (array) ( $args['body'] ?? array() ), $files, $boundary );
+	if ( is_wp_error( $body ) ) {
+		return $body;
+	}
+	$headers  = array_merge(
+		(array) ( $args['headers'] ?? array() ),
+		array(
+			'Host'         => $host,
+			'Accept'       => 'application/json',
+			'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
+		)
+	);
+	return wp_remote_request(
+		'https://127.0.0.1/wp-json/extrachill/v1' . $path,
+		array(
+			'method'    => 'POST',
+			'headers'   => $headers,
+			'body'      => $body,
+			'timeout'   => 30,
+			'sslverify' => false,
+		)
+	);
+}
+
+/** Build the one endpoint-specific multipart loopback body. */
+function extrachill_api_booking_multipart_body( array $fields, array $files, $boundary ) {
+	$eol  = "\r\n";
+	$body = '';
+	foreach ( $fields as $name => $value ) {
+		if ( EXTRACHILL_API_BOOKING_FILES === $name ) {
+			$value = wp_json_encode( $value );
+		} elseif ( is_array( $value ) ) {
+			$value = wp_json_encode( $value );
+		}
+		$body .= '--' . $boundary . $eol;
+		$body .= 'Content-Disposition: form-data; name="' . sanitize_key( $name ) . '"' . $eol . $eol;
+		$body .= (string) $value . $eol;
+	}
+	foreach ( $files as $file ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Server-controlled temporary upload, not a URL.
+		$bytes = file_get_contents( $file['tmp_name'] );
+		if ( false === $bytes ) {
+			return new WP_Error( 'booking_attachment_transport_failed', __( 'A booking attachment could not be forwarded.', 'extrachill-api' ), array( 'status' => 502 ) );
+		}
+		$body .= '--' . $boundary . $eol;
+		$body .= 'Content-Disposition: form-data; name="attachments[]"; filename="' . sanitize_file_name( $file['name'] ) . '"' . $eol;
+		$body .= 'Content-Type: application/octet-stream' . $eol . $eol;
+		$body .= $bytes;
+		$body .= $eol;
+	}
+	return $body . '--' . $boundary . '--' . $eol;
+}

--- a/inc/routes/events/booking-inquiries.php
+++ b/inc/routes/events/booking-inquiries.php
@@ -18,7 +18,30 @@ const EXTRACHILL_API_BOOKING_MAX_AGGREGATE_BYTES = 50 * MB_IN_BYTES;
 add_filter( 'ec_route_site_affinity_map', 'extrachill_api_add_booking_route_affinity' );
 add_filter( 'extrachill_api_route_affinity_signature_body', 'extrachill_api_booking_affinity_signature_body', 10, 2 );
 add_filter( 'extrachill_api_route_affinity_file_forward', 'extrachill_api_booking_affinity_file_forward', 10, 5 );
+add_filter( 'rest_post_dispatch', 'extrachill_api_booking_transport_error_headers', 20, 3 );
 add_action( 'extrachill_api_register_routes', 'extrachill_api_register_booking_inquiry_route' );
+
+/** Promote only stable booking error headers out of REST JSON metadata. */
+function extrachill_api_booking_transport_error_headers( $response, $server, $request ) {
+	unset( $server );
+	$route = $request->get_route();
+	if ( ! preg_match( '#^/extrachill/v1/(?:venues/\d+/booking-inquiries|events/bookings/\d+/attachments/\d+/download)$#', $route ) ) {
+		return $response;
+	}
+	$data    = $response->get_data();
+	$headers = is_array( $data ) && is_array( $data['data']['headers'] ?? null ) ? $data['data']['headers'] : array();
+	foreach ( array( 'Retry-After', 'Content-Range' ) as $name ) {
+		if ( isset( $headers[ $name ] ) && is_scalar( $headers[ $name ] ) ) {
+			$response->header( $name, (string) $headers[ $name ] );
+		}
+	}
+	if ( $headers ) {
+		unset( $data['data']['headers'] );
+		$response->set_data( $data );
+	}
+
+	return $response;
+}
 
 /** Route booking inquiries to the Events site on a segment boundary. */
 function extrachill_api_add_booking_route_affinity( $affinity_map ) {
@@ -289,8 +312,8 @@ function extrachill_api_normalize_booking_files( WP_REST_Request $request ) {
 		if ( $aggregate_size > EXTRACHILL_API_BOOKING_MAX_AGGREGATE_BYTES ) {
 			return new WP_Error( 'booking_attachment_aggregate_size_invalid', __( 'The combined booking attachments are too large.', 'extrachill-api' ), array( 'status' => 413 ) );
 		}
-		$file['name'] = sanitize_file_name( (string) $file['name'] );
-		$file['size'] = $actual_size;
+		$file['name']   = sanitize_file_name( (string) $file['name'] );
+		$file['size']   = $actual_size;
 		$file['sha256'] = hash_file( 'sha256', $file['tmp_name'] );
 		if ( false === $file['sha256'] ) {
 			return new WP_Error( 'booking_attachment_upload_failed', __( 'A booking attachment could not be received.', 'extrachill-api' ), array( 'status' => 400 ) );
@@ -326,9 +349,28 @@ function extrachill_api_booking_public_error( WP_Error $error ) {
 	if ( $status < 400 || $status > 599 ) {
 		$status = 0 === strpos( $code, 'invalid_' ) || false !== strpos( $code, '_required' ) ? 400 : 503;
 	}
-	$public_code = in_array( $status, array( 400, 403, 409, 413, 429 ), true ) ? $code : 'booking_inquiry_unavailable';
-	$message     = in_array( $status, array( 400, 403, 409, 413, 429 ), true ) ? $error->get_error_message() : __( 'Booking inquiry processing is temporarily unavailable.', 'extrachill-api' );
-	return new WP_Error( $public_code, $message, array( 'status' => $status ) );
+	$safe = in_array( $status, array( 400, 403, 409, 413, 429 ), true ) || 'booking_inquiry_reconciliation_required' === $code;
+	if ( ! $safe ) {
+		$status = 503;
+	}
+	$public_code = $code;
+	if ( 409 === $status && false !== strpos( $code, 'config' ) ) {
+		$public_code = 'booking_inquiry_stale_config';
+	} elseif ( in_array( $status, array( 400, 413 ), true ) && false !== strpos( $code, 'attachment' ) ) {
+		$public_code = 'booking_attachment_rejected';
+	}
+	$public_data = array( 'status' => $status );
+	foreach ( array( 'retryable', 'reconciliation_required', 'retry_after', 'headers' ) as $key ) {
+		if ( array_key_exists( $key, $data ) ) {
+			$public_data[ $key ] = $data[ $key ];
+		}
+	}
+
+	return new WP_Error(
+		$safe ? $public_code : 'booking_inquiry_unavailable',
+		$safe ? $error->get_error_message() : __( 'Booking inquiry processing is temporarily unavailable.', 'extrachill-api' ),
+		$public_data
+	);
 }
 
 /** Add file descriptors to the affinity signature without exposing bytes. */
@@ -397,7 +439,7 @@ function extrachill_api_booking_affinity_file_forward( $response, $target_site, 
 	if ( is_wp_error( $body ) ) {
 		return $body;
 	}
-	$headers  = array_merge(
+	$headers = array_merge(
 		(array) ( $args['headers'] ?? array() ),
 		array(
 			'Host'         => $host,

--- a/tests/Unit/middleware/RouteAffinityTest.php
+++ b/tests/Unit/middleware/RouteAffinityTest.php
@@ -41,6 +41,9 @@ class Route_AffinityTest extends WP_UnitTestCase {
 	/** @var array<int, array<string, mixed>> */
 	private $delivery_outcomes = array();
 
+	/** @var string */
+	private $loopback_error_bytes = '';
+
 	/**
 	 * Original server values changed by tests.
 	 *
@@ -65,6 +68,7 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		$_SERVER['REMOTE_ADDR']    = '203.0.113.10';
 		$this->downstream_response = $this->http_response( 200, array( 'ok' => true ) );
 		$this->delivery_outcomes   = array();
+		$this->loopback_error_bytes = '';
 		wp_set_current_user( 0 );
 		unset( $_SERVER['HTTP_COOKIE'], $_SERVER['HTTP_X_WP_NONCE'], $_SERVER['HTTP_X_EC_INTERNAL_USER'], $_SERVER['HTTP_X_EC_INTERNAL_TIMESTAMP'], $_SERVER['HTTP_X_EC_INTERNAL_SIGNATURE'] );
 
@@ -102,6 +106,8 @@ class Route_AffinityTest extends WP_UnitTestCase {
 	public function tear_down() {
 		remove_filter( 'pre_http_request', array( $this, 'intercept_loopback' ), 10 );
 		wp_unregister_ability( 'extrachill/record-booking-attachment-delivery' );
+		remove_all_filters( 'extrachill_api_private_affinity_spool_path' );
+		remove_all_filters( 'extrachill_api_private_affinity_spool_protected' );
 
 		foreach ( $this->original_server as $key => $value ) {
 			if ( null === $value ) {
@@ -281,6 +287,62 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		$this->assertSame( 'failed', $this->delivery_outcomes[0]['outcome'] );
 		$this->assertSame( 0, $this->delivery_outcomes[0]['bytes_sent'] );
 		$this->assertFileDoesNotExist( $spool );
+	}
+
+	/** A nonempty failed loopback records the exact bounded partial byte count. */
+	public function test_private_stream_wp_error_records_partial_spool_bytes() {
+		wp_set_current_user( self::factory()->user->create() );
+		$this->loopback_error_bytes = 'part';
+		$this->downstream_response  = new WP_Error( 'http_request_failed', 'Stream reset after partial body.', array( 'status' => 502 ) );
+		$response = $this->dispatch_affinity( new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/12/attachments/34/download' ) );
+
+		$this->assertWPError( $response );
+		$this->assertCount( 1, $this->delivery_outcomes );
+		$this->assertSame( 'partial', $this->delivery_outcomes[0]['outcome'] );
+		$this->assertSame( 4, $this->delivery_outcomes[0]['bytes_sent'] );
+		$this->assertFileDoesNotExist( $this->last_http_args['filename'] );
+	}
+
+	/** Exceptions converge on the same finalizer and invoke it exactly once. */
+	public function test_private_stream_exception_finalizes_once() {
+		wp_set_current_user( self::factory()->user->create() );
+		$throw = static function () {
+			throw new RuntimeException( 'post-preflight failure' );
+		};
+		add_filter( 'extrachill_api_route_affinity_file_forward', $throw, PHP_INT_MAX );
+		$response = $this->dispatch_affinity( new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/12/attachments/34/download' ) );
+		remove_filter( 'extrachill_api_route_affinity_file_forward', $throw, PHP_INT_MAX );
+
+		$this->assertWPError( $response );
+		$this->assertCount( 1, $this->delivery_outcomes );
+		$this->assertSame( 'failed', $this->delivery_outcomes[0]['outcome'] );
+		$this->assertSame( 0, $this->delivery_outcomes[0]['bytes_sent'] );
+	}
+
+	/** Spool setup fails before descriptor issuance, leaving no correlation behind. */
+	public function test_private_stream_spool_setup_failures_do_not_issue_handoff() {
+		wp_set_current_user( self::factory()->user->create() );
+		$path_failure = static function ( $path ) {
+			if ( is_string( $path ) && file_exists( $path ) ) {
+				unlink( $path );
+			}
+			return false;
+		};
+		add_filter( 'extrachill_api_private_affinity_spool_path', $path_failure );
+		$missing = $this->dispatch_affinity( new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/12/attachments/34/download' ) );
+		remove_filter( 'extrachill_api_private_affinity_spool_path', $path_failure );
+
+		$protect_failure = '__return_false';
+		add_filter( 'extrachill_api_private_affinity_spool_protected', $protect_failure );
+		$unprotected = $this->dispatch_affinity( new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/12/attachments/34/download' ) );
+		remove_filter( 'extrachill_api_private_affinity_spool_protected', $protect_failure );
+
+		$this->assertWPError( $missing );
+		$this->assertWPError( $unprotected );
+		$this->assertSame( 503, $missing->get_error_data()['status'] );
+		$this->assertSame( 503, $unprotected->get_error_data()['status'] );
+		$this->assertSame( 0, $this->request_count, 'Descriptor preflight must not run until spool setup succeeds.' );
+		$this->assertSame( array(), $this->delivery_outcomes );
 	}
 
 	/**
@@ -653,6 +715,9 @@ class Route_AffinityTest extends WP_UnitTestCase {
 					'mime_type'      => 'text/plain',
 				)
 			);
+		}
+		if ( ! empty( $args['stream'] ) && is_wp_error( $this->downstream_response ) && '' !== $this->loopback_error_bytes ) {
+			file_put_contents( $args['filename'], $this->loopback_error_bytes );
 		}
 		if ( ! empty( $args['stream'] ) && is_array( $this->downstream_response ) ) {
 			$nonce = (string) ( $args['headers']['X-EC-Affinity-Nonce'] ?? '' );

--- a/tests/Unit/middleware/RouteAffinityTest.php
+++ b/tests/Unit/middleware/RouteAffinityTest.php
@@ -427,6 +427,61 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		}
 	}
 
+	/** JSON booking transport failures use the stable booking error contract. */
+	public function test_json_booking_transport_failure_does_not_leak_network_error() {
+		$this->downstream_response = new WP_Error( 'http_request_failed', 'cURL error 28: private upstream timed out.', array( 'status' => 502 ) );
+		$response = $this->dispatch_affinity( $this->json_request( 'POST', '/extrachill/v1/venues/42/booking-inquiries', array( 'venue' => 42 ) ) );
+
+		$this->assertSame( 503, $response->get_status() );
+		$this->assertSame( 'booking_inquiry_unavailable', $response->get_data()['code'] );
+		$this->assertStringNotContainsString( 'cURL', wp_json_encode( $response->get_data() ) );
+		$this->assertStringNotContainsString( 'http_request_failed', wp_json_encode( $response->get_data() ) );
+	}
+
+	/** Multipart booking transport failures use the same stable contract. */
+	public function test_multipart_booking_transport_failure_does_not_leak_network_error() {
+		$file = wp_tempnam( 'booking-affinity-failure' );
+		file_put_contents( $file, 'press notes' );
+		add_filter( 'extrachill_api_allow_test_booking_file', '__return_true' );
+		try {
+			$request = new WP_REST_Request( 'POST', '/extrachill/v1/venues/42/booking-inquiries' );
+			$request->set_body_params( array( 'venue' => 42, 'attachment_purposes' => array( 'press_release' ) ) );
+			$request->set_file_params(
+				array(
+					'attachments' => array(
+						'name'     => 'press.txt',
+						'type'     => 'text/plain',
+						'tmp_name' => $file,
+						'error'    => UPLOAD_ERR_OK,
+						'size'     => filesize( $file ),
+					),
+				)
+			);
+			$this->downstream_response = new WP_Error( 'http_request_failed', 'cURL error 7: private host refused.', array( 'status' => 502 ) );
+			$response = $this->dispatch_affinity( $request );
+
+			$this->assertSame( 503, $response->get_status() );
+			$this->assertSame( 'booking_inquiry_unavailable', $response->get_data()['code'] );
+			$this->assertStringNotContainsString( 'cURL', wp_json_encode( $response->get_data() ) );
+			$this->assertStringNotContainsString( 'http_request_failed', wp_json_encode( $response->get_data() ) );
+		} finally {
+			remove_filter( 'extrachill_api_allow_test_booking_file', '__return_true' );
+			if ( file_exists( $file ) ) {
+				unlink( $file );
+			}
+		}
+	}
+
+	/** Generic affinity routes retain their existing transport error envelope. */
+	public function test_generic_transport_failure_preserves_original_error() {
+		$this->downstream_response = new WP_Error( 'transport_failed', 'Loopback failed.', array( 'status' => 502 ) );
+		$response = $this->dispatch_affinity( new WP_REST_Request( 'GET', '/extrachill/v1/artists/42' ) );
+
+		$this->assertSame( 502, $response->get_status() );
+		$this->assertSame( 'ec_cross_site_request_failed', $response->get_data()['code'] );
+		$this->assertStringContainsString( 'Loopback failed.', $response->get_data()['message'] );
+	}
+
 	/**
 	 * Successful downstream status and headers are preserved.
 	 *

--- a/tests/Unit/middleware/RouteAffinityTest.php
+++ b/tests/Unit/middleware/RouteAffinityTest.php
@@ -65,6 +65,29 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		unset( $_SERVER['HTTP_COOKIE'], $_SERVER['HTTP_X_WP_NONCE'], $_SERVER['HTTP_X_EC_INTERNAL_USER'], $_SERVER['HTTP_X_EC_INTERNAL_TIMESTAMP'], $_SERVER['HTTP_X_EC_INTERNAL_SIGNATURE'] );
 
 		add_filter( 'pre_http_request', array( $this, 'intercept_loopback' ), 10, 3 );
+		if ( ! wp_has_ability_category( 'extrachill-api-tests' ) ) {
+			WP_Ability_Categories_Registry::get_instance()->register(
+				'extrachill-api-tests',
+				array(
+					'label'       => 'Extra Chill API Tests',
+					'description' => 'Controlled affinity contracts.',
+				)
+			);
+		}
+		WP_Abilities_Registry::get_instance()->register(
+			'extrachill/record-booking-attachment-delivery',
+			array(
+				'label'               => 'Record test delivery',
+				'description'         => 'Controlled affinity delivery callback.',
+				'category'            => 'extrachill-api-tests',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array( 'type' => 'object' ),
+				'permission_callback' => '__return_true',
+				'execute_callback'    => static function () {
+					return array( 'recorded' => true );
+				},
+			)
+		);
 	}
 
 	/**
@@ -72,6 +95,7 @@ class Route_AffinityTest extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		remove_filter( 'pre_http_request', array( $this, 'intercept_loopback' ), 10 );
+		wp_unregister_ability( 'extrachill/record-booking-attachment-delivery' );
 
 		foreach ( $this->original_server as $key => $value ) {
 			if ( null === $value ) {
@@ -114,6 +138,7 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		$request->set_header( 'X-EC-Affinity-Signature', str_repeat( 'a', 64 ) );
 		$request->set_header( 'X-EC-Affinity-Target', 'artist.example.com' );
 		$request->set_header( 'X-EC-Affinity-Nonce', wp_generate_uuid4() );
+		$request->set_header( 'X-EC-Affinity-Verified', '1' );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $this->dispatch_affinity( $request ) );
 		$this->assertSame( 1, $this->request_count );
@@ -195,13 +220,14 @@ class Route_AffinityTest extends WP_UnitTestCase {
 				'Content-Type'              => 'text/plain',
 				'Content-Disposition'       => 'attachment; filename="rider.txt"',
 				'Content-Range'             => 'bytes 2-5/10',
-				'X-EC-Download-Correlation' => wp_generate_uuid4(),
 			)
 		);
 		$response = $this->dispatch_affinity( $request );
 
 		$this->assertSame( 206, $response->get_status() );
 		$this->assertNull( $response->get_data() );
+		$this->assertArrayNotHasKey( 'X-EC-Download-Correlation', $response->get_headers() );
+		$this->assertArrayNotHasKey( 'X-EC-Affinity-Delivery', $response->get_headers() );
 		$this->assertSame( 'bytes=2-5', $this->last_http_args['headers']['range'] );
 		$this->assertTrue( $this->last_http_args['stream'] );
 		$this->assertSame( extrachill_api_booking_attachment_max_bytes() + 1, $this->last_http_args['limit_response_size'] );
@@ -281,6 +307,8 @@ class Route_AffinityTest extends WP_UnitTestCase {
 
 		$reentry = $this->reentry_request( $source );
 		$this->assertNull( $this->dispatch_affinity( $reentry ) );
+		$this->assertSame( '203.0.113.10', extrachill_api_route_affinity_context( $reentry )['remote_addr'] );
+		$this->assertSame( '', (string) $reentry->get_header( 'X-EC-Affinity-Verified' ) );
 		$this->assert_reentry_rejected( $reentry );
 		$this->assertSame( 1, $this->request_count );
 	}
@@ -329,6 +357,74 @@ class Route_AffinityTest extends WP_UnitTestCase {
 
 		$this->assertTrue( ec_cross_site_authenticate_internal_request( null ) );
 		$this->assertSame( $user_id, get_current_user_id() );
+	}
+
+	/** Caller-supplied affinity identity is removed and replaced from the socket. */
+	public function test_affinity_client_spoof_is_overwritten_before_signing() {
+		$request = $this->json_request(
+			'POST',
+			'/extrachill/v1/artists',
+			array(
+				'name'                     => 'Signed',
+				'_ec_affinity_client'      => str_repeat( 'a', 64 ),
+				'_ec_affinity_remote_addr' => '192.0.2.200',
+			)
+		);
+		$request->set_header( 'X-EC-Affinity-Client', str_repeat( 'b', 64 ) );
+		$request->set_header( 'X-EC-Affinity-Remote-Addr', '192.0.2.201' );
+		$request->set_header( 'X-EC-Affinity-Verified', '1' );
+
+		$this->dispatch_affinity( $request );
+		$body = json_decode( $this->last_http_args['body'], true );
+
+		$this->assertArrayNotHasKey( '_ec_affinity_client', $body );
+		$this->assertArrayNotHasKey( '_ec_affinity_remote_addr', $body );
+		$this->assertSame( '203.0.113.10', $this->last_http_args['headers']['x-ec-affinity-remote-addr'] );
+		$this->assertSame( hash_hmac( 'sha256', '203.0.113.10', wp_salt( 'nonce' ) ), $this->last_http_args['headers']['x-ec-affinity-client'] );
+	}
+
+	/** Multipart forwarding uses the same signed canonical user transport as JSON. */
+	public function test_multipart_forwarding_preserves_signed_canonical_user() {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		$file = wp_tempnam( 'booking-affinity-auth' );
+		file_put_contents( $file, 'press notes' );
+		add_filter( 'extrachill_api_allow_test_booking_file', '__return_true' );
+		try {
+			$request = new WP_REST_Request( 'POST', '/extrachill/v1/venues/42/booking-inquiries' );
+			$request->set_body_params(
+				array(
+					'venue'               => 42,
+					'idempotency_key'     => 'multipart-auth',
+					'intake'              => wp_json_encode( array( 'message' => 'Hello' ) ),
+					'attachment_purposes' => wp_json_encode( array( 'press_release' ) ),
+					'turnstile_response'  => 'test',
+				)
+			);
+			$request->set_file_params(
+				array(
+					'attachments' => array(
+						'name'     => 'press.txt',
+						'type'     => 'text/plain',
+						'tmp_name' => $file,
+						'error'    => UPLOAD_ERR_OK,
+						'size'     => filesize( $file ),
+					),
+				)
+			);
+
+			$this->dispatch_affinity( $request );
+			$headers = $this->last_http_args['headers'];
+			$this->assertSame( (string) $user_id, $headers['X-EC-Internal-User'] );
+			$this->assertTrue( ec_cross_site_verify_signature( $user_id, (int) $headers['X-EC-Internal-Timestamp'], $headers['X-EC-Internal-Signature'] ) );
+			$this->assertStringStartsWith( 'multipart/form-data; boundary=', $headers['Content-Type'] );
+			$this->assertStringContainsString( 'press notes', $this->last_http_args['body'] );
+		} finally {
+			remove_filter( 'extrachill_api_allow_test_booking_file', '__return_true' );
+			if ( file_exists( $file ) ) {
+				unlink( $file );
+			}
+		}
 	}
 
 	/**
@@ -470,6 +566,19 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		$this->last_http_args = $args;
 		$this->last_http_url  = $url;
 		if ( ! empty( $args['stream'] ) && is_array( $this->downstream_response ) ) {
+			$nonce = (string) ( $args['headers']['X-EC-Affinity-Nonce'] ?? '' );
+			$status = (int) ( $this->downstream_response['response']['code'] ?? 0 );
+			if ( in_array( $status, array( 200, 206 ), true ) ) {
+				$delivery_headers = extrachill_api_booking_attachment_affinity_delivery_headers(
+					array(
+						'booking_id'     => 12,
+						'attachment_id'  => 34,
+						'correlation_id' => '11111111-1111-4111-8111-111111111111',
+					),
+					array( 'nonce' => $nonce )
+				);
+				$this->downstream_response['headers'] = array_merge( $this->downstream_response['headers'], $delivery_headers );
+			}
 			file_put_contents( $args['filename'], $this->downstream_response['body'] );
 			$this->downstream_response['body']     = '';
 			$this->downstream_response['filename'] = $args['filename'];
@@ -558,7 +667,7 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		}
 
 		foreach ( $this->last_http_args['headers'] as $name => $value ) {
-			if ( 0 === strpos( $name, 'X-EC-Affinity-' ) ) {
+			if ( 0 === strpos( strtolower( $name ), 'x-ec-affinity-' ) ) {
 				$request->set_header( $name, $value );
 			}
 		}

--- a/tests/Unit/middleware/RouteAffinityTest.php
+++ b/tests/Unit/middleware/RouteAffinityTest.php
@@ -38,6 +38,9 @@ class Route_AffinityTest extends WP_UnitTestCase {
 	 */
 	private $last_http_url = '';
 
+	/** @var array<int, array<string, mixed>> */
+	private $delivery_outcomes = array();
+
 	/**
 	 * Original server values changed by tests.
 	 *
@@ -61,6 +64,7 @@ class Route_AffinityTest extends WP_UnitTestCase {
 
 		$_SERVER['REMOTE_ADDR']    = '203.0.113.10';
 		$this->downstream_response = $this->http_response( 200, array( 'ok' => true ) );
+		$this->delivery_outcomes   = array();
 		wp_set_current_user( 0 );
 		unset( $_SERVER['HTTP_COOKIE'], $_SERVER['HTTP_X_WP_NONCE'], $_SERVER['HTTP_X_EC_INTERNAL_USER'], $_SERVER['HTTP_X_EC_INTERNAL_TIMESTAMP'], $_SERVER['HTTP_X_EC_INTERNAL_SIGNATURE'] );
 
@@ -74,6 +78,7 @@ class Route_AffinityTest extends WP_UnitTestCase {
 				)
 			);
 		}
+		$test = $this;
 		WP_Abilities_Registry::get_instance()->register(
 			'extrachill/record-booking-attachment-delivery',
 			array(
@@ -83,7 +88,8 @@ class Route_AffinityTest extends WP_UnitTestCase {
 				'input_schema'        => array( 'type' => 'object' ),
 				'output_schema'       => array( 'type' => 'object' ),
 				'permission_callback' => '__return_true',
-				'execute_callback'    => static function () {
+				'execute_callback'    => static function ( $input ) use ( $test ) {
+					$test->delivery_outcomes[] = $input;
 					return array( 'recorded' => true );
 				},
 			)
@@ -258,6 +264,22 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		$this->assertWPError( $response );
 		$this->assertSame( 404, $response->get_error_data()['status'] );
 		$this->assertStringNotContainsString( 'secret', wp_json_encode( $response->get_error_data() ) );
+		$this->assertFileDoesNotExist( $spool );
+	}
+
+	/** A post-consumption loopback error still finalizes the preissued correlation. */
+	public function test_private_stream_wp_error_finalizes_preissued_delivery() {
+		wp_set_current_user( self::factory()->user->create() );
+		$this->downstream_response = new WP_Error( 'http_request_failed', 'Stream reset after consumption.', array( 'status' => 502 ) );
+		$response = $this->dispatch_affinity( new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/12/attachments/34/download' ) );
+		$spool    = $this->last_http_args['filename'];
+
+		$this->assertWPError( $response );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
+		$this->assertCount( 1, $this->delivery_outcomes );
+		$this->assertSame( '11111111-1111-4111-8111-111111111111', $this->delivery_outcomes[0]['correlation_id'] );
+		$this->assertSame( 'failed', $this->delivery_outcomes[0]['outcome'] );
+		$this->assertSame( 0, $this->delivery_outcomes[0]['bytes_sent'] );
 		$this->assertFileDoesNotExist( $spool );
 	}
 
@@ -620,6 +642,18 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		++$this->request_count;
 		$this->last_http_args = $args;
 		$this->last_http_url  = $url;
+		if ( false !== strpos( $url, '/events/internal/booking-attachment-handoff' ) ) {
+			return $this->http_response(
+				200,
+				array(
+					'stream_token'   => str_repeat( 'a', 64 ),
+					'correlation_id' => '11111111-1111-4111-8111-111111111111',
+					'expires_at'     => '2026-07-26 20:00:00',
+					'filename'       => 'rider.txt',
+					'mime_type'      => 'text/plain',
+				)
+			);
+		}
 		if ( ! empty( $args['stream'] ) && is_array( $this->downstream_response ) ) {
 			$nonce = (string) ( $args['headers']['X-EC-Affinity-Nonce'] ?? '' );
 			$status = (int) ( $this->downstream_response['response']['code'] ?? 0 );

--- a/tests/Unit/middleware/RouteAffinityTest.php
+++ b/tests/Unit/middleware/RouteAffinityTest.php
@@ -44,6 +44,9 @@ class Route_AffinityTest extends WP_UnitTestCase {
 	/** @var string */
 	private $loopback_error_bytes = '';
 
+	/** @var bool */
+	private $handoff_failure = false;
+
 	/**
 	 * Original server values changed by tests.
 	 *
@@ -69,6 +72,7 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		$this->downstream_response = $this->http_response( 200, array( 'ok' => true ) );
 		$this->delivery_outcomes   = array();
 		$this->loopback_error_bytes = '';
+		$this->handoff_failure      = false;
 		wp_set_current_user( 0 );
 		unset( $_SERVER['HTTP_COOKIE'], $_SERVER['HTTP_X_WP_NONCE'], $_SERVER['HTTP_X_EC_INTERNAL_USER'], $_SERVER['HTTP_X_EC_INTERNAL_TIMESTAMP'], $_SERVER['HTTP_X_EC_INTERNAL_SIGNATURE'] );
 
@@ -342,6 +346,30 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		$this->assertSame( 503, $missing->get_error_data()['status'] );
 		$this->assertSame( 503, $unprotected->get_error_data()['status'] );
 		$this->assertSame( 0, $this->request_count, 'Descriptor preflight must not run until spool setup succeeds.' );
+		$this->assertSame( array(), $this->delivery_outcomes );
+	}
+
+	/** Repeated preflight failures delete each prepared spool without callback. */
+	public function test_private_stream_preflight_failures_do_not_leak_spools() {
+		wp_set_current_user( self::factory()->user->create() );
+		$this->handoff_failure = true;
+		$paths = array();
+		$capture = static function ( $path ) use ( &$paths ) {
+			$paths[] = $path;
+			return $path;
+		};
+		add_filter( 'extrachill_api_private_affinity_spool_path', $capture );
+		for ( $attempt = 0; $attempt < 3; ++$attempt ) {
+			$response = $this->dispatch_affinity( new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/12/attachments/34/download' ) );
+			$this->assertWPError( $response );
+			$this->assertSame( 502, $response->get_error_data()['status'] );
+		}
+		remove_filter( 'extrachill_api_private_affinity_spool_path', $capture );
+
+		$this->assertCount( 3, $paths );
+		foreach ( $paths as $path ) {
+			$this->assertFileDoesNotExist( $path );
+		}
 		$this->assertSame( array(), $this->delivery_outcomes );
 	}
 
@@ -705,6 +733,9 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		$this->last_http_args = $args;
 		$this->last_http_url  = $url;
 		if ( false !== strpos( $url, '/events/internal/booking-attachment-handoff' ) ) {
+			if ( $this->handoff_failure ) {
+				return new WP_Error( 'http_request_failed', 'Descriptor preflight failed.' );
+			}
 			return $this->http_response(
 				200,
 				array(

--- a/tests/Unit/middleware/RouteAffinityTest.php
+++ b/tests/Unit/middleware/RouteAffinityTest.php
@@ -183,6 +183,58 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		$this->assert_reentry_rejected( $reentry );
 	}
 
+	/** A protected stream range is forwarded only when bound to the signature. */
+	public function test_private_stream_range_is_signed_and_tamper_proof() {
+		$request = new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/12/attachments/34/download' );
+		$request->set_header( 'Range', 'bytes=2-5' );
+		$this->downstream_response = $this->raw_http_response(
+			206,
+			'vate',
+			array(
+				'Content-Length'            => '4',
+				'Content-Type'              => 'text/plain',
+				'Content-Disposition'       => 'attachment; filename="rider.txt"',
+				'Content-Range'             => 'bytes 2-5/10',
+				'X-EC-Download-Correlation' => wp_generate_uuid4(),
+			)
+		);
+		$response = $this->dispatch_affinity( $request );
+
+		$this->assertSame( 206, $response->get_status() );
+		$this->assertNull( $response->get_data() );
+		$this->assertSame( 'bytes=2-5', $this->last_http_args['headers']['range'] );
+		$this->assertTrue( $this->last_http_args['stream'] );
+		$this->assertSame( extrachill_api_booking_attachment_max_bytes() + 1, $this->last_http_args['limit_response_size'] );
+		$spool = $this->last_http_args['filename'];
+		$this->assertFileExists( $spool );
+
+		$reentry = $this->reentry_request( $request );
+		$reentry->set_header( 'Range', 'bytes=3-6' );
+		$this->assert_reentry_rejected( $reentry );
+
+		ob_start();
+		$this->assertTrue( extrachill_api_serve_private_stream( false, $response, $request, rest_get_server() ) );
+		$this->assertSame( 'vate', ob_get_clean() );
+		$this->assertFileDoesNotExist( $spool );
+	}
+
+	/** Downstream private errors are generic and their spooled bodies are deleted. */
+	public function test_private_stream_error_does_not_relay_internal_references() {
+		wp_set_current_user( self::factory()->user->create() );
+		$this->downstream_response = $this->raw_http_response(
+			403,
+			'{"storage_reference":"secret","path":"/private/root"}',
+			array( 'Content-Type' => 'application/json' )
+		);
+		$response = $this->dispatch_affinity( new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/12/attachments/34/download' ) );
+		$spool    = $this->last_http_args['filename'];
+
+		$this->assertWPError( $response );
+		$this->assertSame( 404, $response->get_error_data()['status'] );
+		$this->assertStringNotContainsString( 'secret', wp_json_encode( $response->get_error_data() ) );
+		$this->assertFileDoesNotExist( $spool );
+	}
+
 	/**
 	 * Typed query input signs the exact helper wire representation.
 	 *
@@ -417,6 +469,11 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		++$this->request_count;
 		$this->last_http_args = $args;
 		$this->last_http_url  = $url;
+		if ( ! empty( $args['stream'] ) && is_array( $this->downstream_response ) ) {
+			file_put_contents( $args['filename'], $this->downstream_response['body'] );
+			$this->downstream_response['body']     = '';
+			$this->downstream_response['filename'] = $args['filename'];
+		}
 
 		return $this->downstream_response;
 	}
@@ -524,6 +581,20 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		return array(
 			'headers'  => $headers,
 			'body'     => wp_json_encode( $body ),
+			'response' => array(
+				'code'    => $status,
+				'message' => '',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+
+	/** Build a raw byte HTTP response fixture. */
+	private function raw_http_response( $status, $body, $headers = array() ) {
+		return array(
+			'headers'  => $headers,
+			'body'     => $body,
 			'response' => array(
 				'code'    => $status,
 				'message' => '',

--- a/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
+++ b/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
@@ -304,6 +304,28 @@ namespace {
 			);
 			$this->assertWPError( $bad );
 			$this->assertFileDoesNotExist( $bad_path );
+
+			foreach ( array( 'bytes 0-3/0', 'bytes 4-7/4', 'bytes 6-9/8' ) as $content_range ) {
+				$invalid_path = wp_tempnam( 'booking-affinity-range' );
+				file_put_contents( $invalid_path, 'part' );
+				$invalid = extrachill_api_private_stream_from_affinity_response(
+					array(
+						'headers'  => array_merge(
+							array(
+								'Content-Length' => '4',
+								'Content-Range'  => $content_range,
+							),
+							extrachill_api_booking_attachment_affinity_delivery_headers( $delivery, array( 'nonce' => $nonce ) )
+						),
+						'body'     => '',
+						'response' => array( 'code' => 206 ),
+					),
+					$invalid_path,
+					$nonce
+				);
+				$this->assertWPError( $invalid, $content_range );
+				$this->assertFileDoesNotExist( $invalid_path );
+			}
 		}
 
 		/** Affinity target spooling is non-terminal; only outer client serving completes delivery. */

--- a/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
+++ b/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
@@ -379,8 +379,9 @@ namespace {
 				$this->assertWPError( $result, $label );
 				$this->assertSame( 502, $result->get_error_data()['status'], $label );
 				$this->assertCount( $before + 1, $this->delivery_outcomes, $label );
-				$this->assertSame( 'failed', $this->delivery_outcomes[ $before ]['outcome'], $label );
-				$this->assertSame( 0, $this->delivery_outcomes[ $before ]['bytes_sent'], $label );
+				$expected_bytes = 'missing spool' === $label ? 0 : 4;
+				$this->assertSame( $expected_bytes > 0 ? 'partial' : 'failed', $this->delivery_outcomes[ $before ]['outcome'], $label );
+				$this->assertSame( $expected_bytes, $this->delivery_outcomes[ $before ]['bytes_sent'], $label );
 				$this->assertFileDoesNotExist( $path, $label );
 			}
 
@@ -400,9 +401,7 @@ namespace {
 			remove_filter( 'extrachill_api_booking_attachment_max_bytes', array( $this, 'one_byte_limit' ) );
 
 			$this->assertWPError( $result, 'oversized spool' );
-			$this->assertCount( $before + 1, $this->delivery_outcomes );
-			$this->assertSame( 'failed', $this->delivery_outcomes[ $before ]['outcome'] );
-			$this->assertSame( 0, $this->delivery_outcomes[ $before ]['bytes_sent'] );
+			$this->assertCount( $before, $this->delivery_outcomes, 'An impossible spool count must remain reconcilable instead of sending false accounting.' );
 			$this->assertFileDoesNotExist( $oversized );
 		}
 

--- a/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
+++ b/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
@@ -75,6 +75,8 @@ namespace {
 		public function tear_down() {
 			extrachill_api_cleanup_private_streams();
 			remove_filter( 'extrachill_api_rate_limit_store', array( $this, 'use_test_rate_limit_store' ) );
+			remove_all_filters( 'extrachill_api_private_affinity_stream' );
+			remove_all_filters( 'extrachill_api_booking_attachment_max_bytes' );
 			foreach ( $this->registered_abilities as $name ) {
 				wp_unregister_ability( $name );
 			}
@@ -326,6 +328,82 @@ namespace {
 				$this->assertWPError( $invalid, $content_range );
 				$this->assertFileDoesNotExist( $invalid_path );
 			}
+		}
+
+		/** Every post-consumption spool failure records one terminal failed outcome. */
+		public function test_affinity_spool_failures_finalize_consumed_handoff() {
+			$nonce    = wp_generate_uuid4();
+			$delivery = array(
+				'booking_id'      => 10,
+				'attachment_id'   => 2,
+				'correlation_id'  => '11111111-1111-4111-8111-111111111110',
+				'success_outcome' => 'completed',
+			);
+			$delivery_headers = extrachill_api_booking_attachment_affinity_delivery_headers( $delivery, array( 'nonce' => $nonce ) );
+			$cases            = array(
+				'missing spool'           => array( '/tmp/missing-booking-spool-' . wp_generate_uuid4(), array( 'Content-Length' => '4' ), null ),
+				'mismatched length'       => array( null, array( 'Content-Length' => '5' ), null ),
+				'malformed content range' => array( null, array( 'Content-Length' => '4', 'Content-Range' => 'private-range' ), null ),
+				'inconsistent range total' => array( null, array( 'Content-Length' => '4', 'Content-Range' => 'bytes 6-9/8' ), null ),
+				'spool open failure'      => array( null, array( 'Content-Length' => '4' ), 'fail_open' ),
+			);
+
+			foreach ( $cases as $label => $case ) {
+				$path = $case[0] ?: wp_tempnam( 'booking-affinity-failure' );
+				if ( null === $case[0] ) {
+					file_put_contents( $path, 'part' );
+				}
+				if ( 'fail_open' === $case[2] ) {
+					add_filter(
+						'extrachill_api_private_affinity_stream',
+						static function ( $stream ) {
+							if ( is_resource( $stream ) ) {
+								fclose( $stream );
+							}
+							return false;
+						}
+					);
+				}
+				$before = count( $this->delivery_outcomes );
+				$result = extrachill_api_private_stream_from_affinity_response(
+					array(
+						'headers'  => array_merge( $case[1], $delivery_headers ),
+						'body'     => '',
+						'response' => array( 'code' => isset( $case[1]['Content-Range'] ) ? 206 : 200 ),
+					),
+					$path,
+					$nonce
+				);
+				remove_all_filters( 'extrachill_api_private_affinity_stream' );
+
+				$this->assertWPError( $result, $label );
+				$this->assertSame( 502, $result->get_error_data()['status'], $label );
+				$this->assertCount( $before + 1, $this->delivery_outcomes, $label );
+				$this->assertSame( 'failed', $this->delivery_outcomes[ $before ]['outcome'], $label );
+				$this->assertSame( 0, $this->delivery_outcomes[ $before ]['bytes_sent'], $label );
+				$this->assertFileDoesNotExist( $path, $label );
+			}
+
+			$oversized = wp_tempnam( 'booking-affinity-oversized' );
+			file_put_contents( $oversized, 'part' );
+			add_filter( 'extrachill_api_booking_attachment_max_bytes', array( $this, 'one_byte_limit' ) );
+			$before = count( $this->delivery_outcomes );
+			$result = extrachill_api_private_stream_from_affinity_response(
+				array(
+					'headers'  => array_merge( array( 'Content-Length' => '4' ), $delivery_headers ),
+					'body'     => '',
+					'response' => array( 'code' => 200 ),
+				),
+				$oversized,
+				$nonce
+			);
+			remove_filter( 'extrachill_api_booking_attachment_max_bytes', array( $this, 'one_byte_limit' ) );
+
+			$this->assertWPError( $result, 'oversized spool' );
+			$this->assertCount( $before + 1, $this->delivery_outcomes );
+			$this->assertSame( 'failed', $this->delivery_outcomes[ $before ]['outcome'] );
+			$this->assertSame( 0, $this->delivery_outcomes[ $before ]['bytes_sent'] );
+			$this->assertFileDoesNotExist( $oversized );
 		}
 
 		/** Affinity target spooling is non-terminal; only outer client serving completes delivery. */

--- a/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
+++ b/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
@@ -165,7 +165,9 @@ namespace {
 			$this->assertSame( array( 'offset' => 2, 'length' => 4, 'status' => 206 ), extrachill_api_booking_attachment_range( 'bytes=2-5', 10 ) );
 			$this->assertSame( array( 'offset' => 7, 'length' => 3, 'status' => 206 ), extrachill_api_booking_attachment_range( 'bytes=-3', 10 ) );
 			$this->assertWPError( extrachill_api_booking_attachment_range( 'bytes=0-1,4-5', 10 ) );
-			$this->assertWPError( extrachill_api_booking_attachment_range( 'bytes=20-', 10 ) );
+			$unsatisfied = extrachill_api_booking_attachment_range( 'bytes=20-', 10 );
+			$this->assertWPError( $unsatisfied );
+			$this->assertSame( 'bytes */10', $unsatisfied->get_error_data()['headers']['Content-Range'] );
 
 			add_filter( 'extrachill_api_booking_attachment_max_bytes', array( $this, 'one_byte_limit' ) );
 			$stream = fopen( 'php://temp', 'w+b' );
@@ -190,6 +192,38 @@ namespace {
 			$this->assertFalse( is_resource( $stream ) );
 		}
 
+		/** Partial reads and unserved shutdown cleanup report exact terminal outcomes. */
+		public function test_partial_and_unserved_streams_record_terminal_outcomes() {
+			wp_set_current_user( self::factory()->user->create() );
+			$partial_delivery = array(
+				'booking_id'     => 10,
+				'attachment_id'  => 2,
+				'correlation_id' => '11111111-1111-4111-8111-111111111110',
+			);
+			$stream = fopen( 'php://temp', 'w+b' );
+			fwrite( $stream, 'abc' );
+			rewind( $stream );
+			$response = extrachill_api_register_private_stream( $stream, 5, 200, array(), null, $partial_delivery );
+			$this->assertSame( 'abc', $this->serve( $response ) );
+			$this->assertSame( 'partial', $this->delivery_outcomes[0]['outcome'] );
+			$this->assertSame( 3, $this->delivery_outcomes[0]['bytes_sent'] );
+
+			$interrupted_delivery = array(
+				'booking_id'     => 11,
+				'attachment_id'  => 3,
+				'correlation_id' => '11111111-1111-4111-8111-111111111111',
+			);
+			$unserved = fopen( 'php://temp', 'w+b' );
+			fwrite( $unserved, 'pending' );
+			rewind( $unserved );
+			extrachill_api_register_private_stream( $unserved, 7, 200, array(), null, $interrupted_delivery );
+			extrachill_api_cleanup_private_streams();
+
+			$this->assertSame( 'interrupted', $this->delivery_outcomes[1]['outcome'] );
+			$this->assertSame( 0, $this->delivery_outcomes[1]['bytes_sent'] );
+			$this->assertFalse( is_resource( $unserved ) );
+		}
+
 		/** Rate limiting occurs before a second handoff can be issued. */
 		public function test_rate_limit_precedes_handoff_issuance() {
 			wp_set_current_user( self::factory()->user->create() );
@@ -201,6 +235,7 @@ namespace {
 			remove_filter( 'extrachill_api_booking_attachment_download_rate_limit', array( $this, 'one_byte_limit' ) );
 
 			$this->assertSame( 429, $second->get_status() );
+			$this->assertSame( '60', $this->response_header( $second, 'retry-after' ) );
 			$this->assertCount( 1, $this->audit );
 		}
 
@@ -328,12 +363,13 @@ namespace {
 
 		/** Dispatch one request through the real REST server. */
 		private function dispatch( $booking_id, $attachment_id ) {
-			return rest_do_request(
-				new WP_REST_Request(
-					'GET',
-					sprintf( '/extrachill/v1/events/bookings/%d/attachments/%d/download', $booking_id, $attachment_id )
-				)
+			$request  = new WP_REST_Request(
+				'GET',
+				sprintf( '/extrachill/v1/events/bookings/%d/attachments/%d/download', $booking_id, $attachment_id )
 			);
+			$response = rest_do_request( $request );
+
+			return extrachill_api_protect_booking_attachment_download_response( $response, rest_get_server(), $request );
 		}
 
 		/** Capture manual byte serving for one response. */

--- a/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
+++ b/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
@@ -42,13 +42,19 @@ namespace {
 		/** @var array<int, array<string, int|string>> */
 		private $delivery_outcomes = array();
 
+		/** @var array<string, int> */
+		private $rate_counts = array();
+
 		/** Register a controlled hidden Events ability. */
 		public function set_up() {
 			parent::set_up();
 			\ExtraChillEvents\Core\BookingAttachmentService::$consumed = array();
 			$GLOBALS['extrachill_api_private_streams']                    = array();
 			$this->delivery_outcomes                                     = array();
+			$this->rate_counts                                           = array();
 			wp_set_current_user( 0 );
+			remove_filter( 'rest_pre_dispatch', 'extrachill_api_route_affinity_dispatch', 10 );
+			add_filter( 'extrachill_api_rate_limit_store', array( $this, 'use_test_rate_limit_store' ) );
 
 			$categories = WP_Ability_Categories_Registry::get_instance();
 			if ( ! wp_has_ability_category( 'extrachill-api-tests' ) ) {
@@ -68,10 +74,12 @@ namespace {
 		/** Remove controlled state and any unserved streams. */
 		public function tear_down() {
 			extrachill_api_cleanup_private_streams();
+			remove_filter( 'extrachill_api_rate_limit_store', array( $this, 'use_test_rate_limit_store' ) );
 			foreach ( $this->registered_abilities as $name ) {
 				wp_unregister_ability( $name );
 			}
 			wp_set_current_user( 0 );
+			add_filter( 'rest_pre_dispatch', 'extrachill_api_route_affinity_dispatch', 10, 3 );
 			parent::tear_down();
 		}
 
@@ -127,9 +135,10 @@ namespace {
 			$this->assertStringContainsString( 'no-store', $headers['Cache-Control'] );
 			$this->assertSame( 'application/pdf', $headers['Content-Type'] );
 			$this->assertStringContainsString( 'safe-rider.pdf', $headers['Content-Disposition'] );
-			$this->assertMatchesRegularExpression( '/^[a-f0-9-]{36}$/i', $headers['X-EC-Download-Correlation'] );
+			$this->assertArrayNotHasKey( 'X-EC-Download-Correlation', $headers );
+			$this->assertArrayNotHasKey( 'X-EC-Affinity-Delivery', $headers );
 			$this->assertSame( array( array( 'booking_id' => 1, 'attachment_id' => 9, 'actor_id' => $user_id ) ), $this->audit );
-			$correlation_id = $headers['X-EC-Download-Correlation'];
+			$correlation_id = '11111111-1111-4111-8111-000000000001';
 			$this->assertSame( 'private booking bytes', $this->serve( $response ) );
 			$this->assertSame(
 				array(
@@ -199,6 +208,7 @@ namespace {
 				'booking_id'     => 10,
 				'attachment_id'  => 2,
 				'correlation_id' => '11111111-1111-4111-8111-111111111110',
+				'success_outcome' => 'partial',
 			);
 			$stream = fopen( 'php://temp', 'w+b' );
 			fwrite( $stream, 'abc' );
@@ -235,33 +245,47 @@ namespace {
 			remove_filter( 'extrachill_api_booking_attachment_download_rate_limit', array( $this, 'one_byte_limit' ) );
 
 			$this->assertSame( 429, $second->get_status() );
-			$this->assertSame( '60', $this->response_header( $second, 'retry-after' ) );
+			$this->assertGreaterThanOrEqual( 1, (int) $this->response_header( $second, 'retry-after' ) );
+			$this->assertLessThanOrEqual( 60, (int) $this->response_header( $second, 'retry-after' ) );
 			$this->assertCount( 1, $this->audit );
 		}
 
 		/** Affinity spools preserve private bytes without trusting unsafe headers. */
 		public function test_affinity_spool_is_bounded_sanitized_and_cleaned() {
+			$nonce = wp_generate_uuid4();
 			$path = wp_tempnam( 'booking-affinity-test' );
 			file_put_contents( $path, 'part' );
 			chmod( $path, 0600 );
+			$delivery = array(
+				'booking_id'     => 10,
+				'attachment_id'  => 2,
+				'correlation_id' => '11111111-1111-4111-8111-111111111110',
+				'success_outcome' => 'partial',
+			);
 			$response = extrachill_api_private_stream_from_affinity_response(
 				array(
-					'headers'  => array(
+					'headers'  => array_merge(
+						array(
 						'Content-Length'      => '4',
 						'Content-Type'        => 'text/plain',
 						'Content-Disposition' => 'attachment; filename="../rider.txt"',
 						'Content-Range'       => 'bytes 2-5/10',
-						'X-EC-Download-Correlation' => '11111111-1111-4111-8111-111111111111',
+						),
+						extrachill_api_booking_attachment_affinity_delivery_headers( $delivery, array( 'nonce' => $nonce ) )
 					),
 					'body'     => '',
 					'response' => array( 'code' => 206 ),
 				),
-				$path
+				$path,
+				$nonce
 			);
 
 			$this->assertSame( 206, $response->get_status() );
 			$this->assertStringNotContainsString( '..', $response->get_headers()['Content-Disposition'] );
+			$this->assertArrayNotHasKey( 'X-EC-Affinity-Delivery', $response->get_headers() );
 			$this->assertSame( 'part', $this->serve( $response ) );
+			$this->assertSame( 'partial', $this->delivery_outcomes[0]['outcome'] );
+			$this->assertSame( 4, $this->delivery_outcomes[0]['bytes_sent'] );
 			$this->assertFileDoesNotExist( $path );
 
 			$bad_path = wp_tempnam( 'booking-affinity-test' );
@@ -275,10 +299,46 @@ namespace {
 					'body'     => '',
 					'response' => array( 'code' => 206 ),
 				),
-				$bad_path
+				$bad_path,
+				$nonce
 			);
 			$this->assertWPError( $bad );
 			$this->assertFileDoesNotExist( $bad_path );
+		}
+
+		/** Affinity target spooling is non-terminal; only outer client serving completes delivery. */
+		public function test_affinity_target_does_not_complete_delivery_before_outer_stream() {
+			wp_set_current_user( self::factory()->user->create() );
+			$nonce   = wp_generate_uuid4();
+			$request = new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/1/attachments/9/download' );
+			$request->set_param( 'booking_id', 1 );
+			$request->set_param( 'attachment_id', 9 );
+			extrachill_api_set_route_affinity_context( $request, array( 'nonce' => $nonce ) );
+
+			$target = extrachill_api_download_booking_attachment( $request );
+			$this->assertInstanceOf( WP_REST_Response::class, $target );
+			$this->assertArrayHasKey( 'X-EC-Affinity-Delivery', $target->get_headers() );
+			$bytes = $this->serve( $target );
+			$this->assertSame( 'private booking bytes', $bytes );
+			$this->assertSame( array(), $this->delivery_outcomes, 'Loopback spool completion must not be terminal.' );
+
+			$path = wp_tempnam( 'booking-affinity-outer' );
+			file_put_contents( $path, $bytes );
+			chmod( $path, 0600 );
+			$outer = extrachill_api_private_stream_from_affinity_response(
+				array(
+					'headers'  => $target->get_headers(),
+					'body'     => '',
+					'response' => array( 'code' => 200 ),
+				),
+				$path,
+				$nonce
+			);
+			$this->assertArrayNotHasKey( 'X-EC-Affinity-Delivery', $outer->get_headers() );
+			$this->assertSame( $bytes, $this->serve( $outer ) );
+			$this->assertCount( 1, $this->delivery_outcomes );
+			$this->assertSame( 'completed', $this->delivery_outcomes[0]['outcome'] );
+			$this->assertSame( strlen( $bytes ), $this->delivery_outcomes[0]['bytes_sent'] );
 		}
 
 		/** HEAD and REST envelope requests cannot consume a private handoff. */
@@ -296,6 +356,17 @@ namespace {
 		/** Return a one-byte transport limit. */
 		public function one_byte_limit() {
 			return 1;
+		}
+
+		/** Return the deterministic test atomic store. */
+		public function use_test_rate_limit_store() {
+			return array( $this, 'increment_test_rate_limit' );
+		}
+
+		/** Increment one test rate counter. */
+		public function increment_test_rate_limit( $key ) {
+			$this->rate_counts[ $key ] = ( $this->rate_counts[ $key ] ?? 0 ) + 1;
+			return $this->rate_counts[ $key ];
 		}
 
 		/** Register the hidden Events descriptor contract. */

--- a/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
+++ b/tests/Unit/routes/events/BookingAttachmentDownloadTest.php
@@ -1,0 +1,358 @@
+<?php
+/**
+ * Protected booking attachment download transport tests.
+ *
+ * @package ExtraChill\API\Tests
+ */
+
+namespace ExtraChillEvents\Core {
+	/** Controlled Events service contract used by the API transport tests. */
+	class BookingAttachmentService {
+		/** @var array<string, bool> */
+		public static $consumed = array();
+
+		/** Consume one test handoff and return private bytes. */
+		public function open_download_stream( int $booking_id, int $attachment_id, string $token, int $actor_id, string $correlation_id ) {
+			unset( $attachment_id, $actor_id );
+			if ( ! wp_is_uuid( $correlation_id, 4 ) ) {
+				return new \WP_Error( 'private_stream_unavailable', 'Invalid delivery correlation.', array( 'status' => 403 ) );
+			}
+			if ( in_array( $booking_id, array( 4, 5, 6 ), true ) || isset( self::$consumed[ $token ] ) ) {
+				return new \WP_Error( 'private_stream_unavailable', 'Internal reference /private/object/leak', array( 'status' => 403 ) );
+			}
+			self::$consumed[ $token ] = true;
+			$stream                    = fopen( 'php://temp', 'w+b' );
+			fwrite( $stream, 'private booking bytes' );
+			rewind( $stream );
+			return $stream;
+		}
+	}
+}
+
+namespace {
+	/** Exercises the real REST adapter around controlled Events contracts. */
+	class Booking_Attachment_DownloadTest extends WP_UnitTestCase {
+
+		/** @var string[] */
+		private $registered_abilities = array();
+
+		/** @var array<int, array<string, int>> */
+		private $audit = array();
+
+		/** @var array<int, array<string, int|string>> */
+		private $delivery_outcomes = array();
+
+		/** Register a controlled hidden Events ability. */
+		public function set_up() {
+			parent::set_up();
+			\ExtraChillEvents\Core\BookingAttachmentService::$consumed = array();
+			$GLOBALS['extrachill_api_private_streams']                    = array();
+			$this->delivery_outcomes                                     = array();
+			wp_set_current_user( 0 );
+
+			$categories = WP_Ability_Categories_Registry::get_instance();
+			if ( ! wp_has_ability_category( 'extrachill-api-tests' ) ) {
+				$categories->register(
+					'extrachill-api-tests',
+					array(
+						'label'       => 'Extra Chill API Tests',
+						'description' => 'Controlled private transport contracts.',
+					)
+				);
+			}
+
+			$this->register_ability();
+			do_action( 'rest_api_init' );
+		}
+
+		/** Remove controlled state and any unserved streams. */
+		public function tear_down() {
+			extrachill_api_cleanup_private_streams();
+			foreach ( $this->registered_abilities as $name ) {
+				wp_unregister_ability( $name );
+			}
+			wp_set_current_user( 0 );
+			parent::tear_down();
+		}
+
+		/** Anonymous requests fail before Events is called and remain non-cacheable. */
+		public function test_anonymous_request_fails_closed_without_audit() {
+			$request  = new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/1/attachments/1/download' );
+			$response = rest_do_request( $request );
+			$response = extrachill_api_protect_booking_attachment_download_response( $response, rest_get_server(), $request );
+
+			$this->assertSame( 401, $response->get_status() );
+			$this->assertSame( 'booking_attachment_download_unavailable', $response->get_data()['code'] );
+			$this->assertStringContainsString( 'no-store', $this->response_header( $response, 'cache-control' ) );
+			$this->assertSame( array(), $this->audit );
+		}
+
+		/** Cross-venue and revoked callers receive the same generic response. */
+		public function test_cross_venue_and_revoked_access_are_indistinguishable() {
+			wp_set_current_user( self::factory()->user->create() );
+			foreach ( array( 2, 3 ) as $booking_id ) {
+				$response = $this->dispatch( $booking_id, 1 );
+				$this->assertSame( 404, $response->get_status() );
+				$this->assertSame( 'booking_attachment_download_unavailable', $response->get_data()['code'] );
+				$this->assertStringNotContainsString( 'venue', wp_json_encode( $response->get_data() ) );
+			}
+			$this->assertSame( array(), $this->audit );
+		}
+
+		/** Expired, replayed, and tampered handoffs fail after Events reauthorization. */
+		public function test_expired_replayed_and_tampered_handoffs_fail_generically() {
+			wp_set_current_user( self::factory()->user->create() );
+			foreach ( array( 4, 5, 6 ) as $booking_id ) {
+				$response = $this->dispatch( $booking_id, 1 );
+				$this->assertSame( 404, $response->get_status() );
+				$this->assertStringNotContainsString( 'private', wp_json_encode( $response->get_data() ) );
+			}
+
+			$first = $this->dispatch( 7, 1 );
+			$this->assertSame( 200, $first->get_status() );
+			$this->serve( $first );
+			$replay = $this->dispatch( 7, 1 );
+			$this->assertSame( 404, $replay->get_status() );
+		}
+
+		/** Success exposes only safe headers and manually serves the private bytes. */
+		public function test_success_is_no_store_auditable_and_reference_free() {
+			$user_id = self::factory()->user->create();
+			wp_set_current_user( $user_id );
+			$response = $this->dispatch( 1, 9 );
+			$headers  = $response->get_headers();
+
+			$this->assertSame( 200, $response->get_status() );
+			$this->assertNull( $response->get_data() );
+			$this->assertStringContainsString( 'no-store', $headers['Cache-Control'] );
+			$this->assertSame( 'application/pdf', $headers['Content-Type'] );
+			$this->assertStringContainsString( 'safe-rider.pdf', $headers['Content-Disposition'] );
+			$this->assertMatchesRegularExpression( '/^[a-f0-9-]{36}$/i', $headers['X-EC-Download-Correlation'] );
+			$this->assertSame( array( array( 'booking_id' => 1, 'attachment_id' => 9, 'actor_id' => $user_id ) ), $this->audit );
+			$correlation_id = $headers['X-EC-Download-Correlation'];
+			$this->assertSame( 'private booking bytes', $this->serve( $response ) );
+			$this->assertSame(
+				array(
+					'booking_id'     => 1,
+					'attachment_id'  => 9,
+					'correlation_id' => $correlation_id,
+					'outcome'        => 'completed',
+					'bytes_sent'     => 21,
+				),
+				$this->delivery_outcomes[0]
+			);
+			$this->assertSame( array(), $GLOBALS['extrachill_api_private_streams'] );
+		}
+
+		/** Filename and MIME metadata are defensively normalized for HTTP headers. */
+		public function test_filename_injection_and_invalid_mime_are_neutralized() {
+			$stream = fopen( 'php://temp', 'w+b' );
+			fwrite( $stream, 'x' );
+			rewind( $stream );
+			$request  = new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/1/attachments/1/download' );
+			$response = extrachill_api_create_private_stream_response( $stream, "../bad\r\nX-Leak: yes.pdf", "text/plain\r\nX-Leak: yes", $request );
+			$headers  = $response->get_headers();
+
+			$this->assertStringNotContainsString( "\r", $headers['Content-Disposition'] );
+			$this->assertStringNotContainsString( "\n", $headers['Content-Disposition'] );
+			$this->assertStringNotContainsString( '..', $headers['Content-Disposition'] );
+			$this->assertSame( 'application/octet-stream', $headers['Content-Type'] );
+			$this->serve( $response );
+		}
+
+		/** Single ranges are bounded while multiple and unsatisfiable ranges fail. */
+		public function test_range_and_size_limits_are_enforced() {
+			$this->assertSame( array( 'offset' => 2, 'length' => 4, 'status' => 206 ), extrachill_api_booking_attachment_range( 'bytes=2-5', 10 ) );
+			$this->assertSame( array( 'offset' => 7, 'length' => 3, 'status' => 206 ), extrachill_api_booking_attachment_range( 'bytes=-3', 10 ) );
+			$this->assertWPError( extrachill_api_booking_attachment_range( 'bytes=0-1,4-5', 10 ) );
+			$this->assertWPError( extrachill_api_booking_attachment_range( 'bytes=20-', 10 ) );
+
+			add_filter( 'extrachill_api_booking_attachment_max_bytes', array( $this, 'one_byte_limit' ) );
+			$stream = fopen( 'php://temp', 'w+b' );
+			fwrite( $stream, 'too large' );
+			rewind( $stream );
+			$result = extrachill_api_create_private_stream_response( $stream, 'file.txt', 'text/plain', new WP_REST_Request( 'GET', '/' ) );
+			remove_filter( 'extrachill_api_booking_attachment_max_bytes', array( $this, 'one_byte_limit' ) );
+			$this->assertWPError( $result );
+			$this->assertSame( 413, $result->get_error_data()['status'] );
+		}
+
+		/** Cleanup removes a partially served affinity spool and closes its stream. */
+		public function test_manual_stream_cleanup_unlinks_affinity_spool() {
+			$path = wp_tempnam( 'booking-download-test' );
+			file_put_contents( $path, 'abcdef' );
+			chmod( $path, 0600 );
+			$stream   = fopen( $path, 'rb' );
+			$response = extrachill_api_register_private_stream( $stream, 3, 200, extrachill_api_private_stream_headers( 'file.txt', 'text/plain', 3 ), $path );
+
+			$this->assertSame( 'abc', $this->serve( $response ) );
+			$this->assertFileDoesNotExist( $path );
+			$this->assertFalse( is_resource( $stream ) );
+		}
+
+		/** Rate limiting occurs before a second handoff can be issued. */
+		public function test_rate_limit_precedes_handoff_issuance() {
+			wp_set_current_user( self::factory()->user->create() );
+			add_filter( 'extrachill_api_booking_attachment_download_rate_limit', array( $this, 'one_byte_limit' ) );
+			$first = $this->dispatch( 8, 1 );
+			$this->assertSame( 200, $first->get_status() );
+			$this->serve( $first );
+			$second = $this->dispatch( 9, 1 );
+			remove_filter( 'extrachill_api_booking_attachment_download_rate_limit', array( $this, 'one_byte_limit' ) );
+
+			$this->assertSame( 429, $second->get_status() );
+			$this->assertCount( 1, $this->audit );
+		}
+
+		/** Affinity spools preserve private bytes without trusting unsafe headers. */
+		public function test_affinity_spool_is_bounded_sanitized_and_cleaned() {
+			$path = wp_tempnam( 'booking-affinity-test' );
+			file_put_contents( $path, 'part' );
+			chmod( $path, 0600 );
+			$response = extrachill_api_private_stream_from_affinity_response(
+				array(
+					'headers'  => array(
+						'Content-Length'      => '4',
+						'Content-Type'        => 'text/plain',
+						'Content-Disposition' => 'attachment; filename="../rider.txt"',
+						'Content-Range'       => 'bytes 2-5/10',
+						'X-EC-Download-Correlation' => '11111111-1111-4111-8111-111111111111',
+					),
+					'body'     => '',
+					'response' => array( 'code' => 206 ),
+				),
+				$path
+			);
+
+			$this->assertSame( 206, $response->get_status() );
+			$this->assertStringNotContainsString( '..', $response->get_headers()['Content-Disposition'] );
+			$this->assertSame( 'part', $this->serve( $response ) );
+			$this->assertFileDoesNotExist( $path );
+
+			$bad_path = wp_tempnam( 'booking-affinity-test' );
+			file_put_contents( $bad_path, 'part' );
+			$bad = extrachill_api_private_stream_from_affinity_response(
+				array(
+					'headers'  => array(
+						'Content-Length' => '4',
+						'Content-Range'  => 'bytes 2-8/10',
+					),
+					'body'     => '',
+					'response' => array( 'code' => 206 ),
+				),
+				$bad_path
+			);
+			$this->assertWPError( $bad );
+			$this->assertFileDoesNotExist( $bad_path );
+		}
+
+		/** HEAD and REST envelope requests cannot consume a private handoff. */
+		public function test_head_and_envelope_requests_do_not_reach_events() {
+			wp_set_current_user( self::factory()->user->create() );
+			$head = new WP_REST_Request( 'HEAD', '/extrachill/v1/events/bookings/1/attachments/1/download' );
+			$this->assertSame( 405, rest_do_request( $head )->get_status() );
+
+			$request = new WP_REST_Request( 'GET', '/extrachill/v1/events/bookings/1/attachments/1/download' );
+			$request->set_query_params( array( '_envelope' => '1' ) );
+			$this->assertSame( 400, rest_do_request( $request )->get_status() );
+			$this->assertSame( array(), $this->audit );
+		}
+
+		/** Return a one-byte transport limit. */
+		public function one_byte_limit() {
+			return 1;
+		}
+
+		/** Register the hidden Events descriptor contract. */
+		private function register_ability() {
+			$name    = 'extrachill/download-booking-attachment';
+			$ability = WP_Abilities_Registry::get_instance()->register(
+				$name,
+				array(
+					'label'               => 'Download booking attachment',
+					'description'         => 'Controlled Events handoff contract.',
+					'category'            => 'extrachill-api-tests',
+					'input_schema'        => array(
+						'type'                 => 'object',
+						'properties'           => array(
+							'booking_id'    => array( 'type' => 'integer' ),
+							'attachment_id' => array( 'type' => 'integer' ),
+						),
+						'required'             => array( 'booking_id', 'attachment_id' ),
+						'additionalProperties' => false,
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'permission_callback' => function ( array $input ) {
+						return in_array( $input['booking_id'], array( 2, 3 ), true )
+							? new WP_Error( 'venue_action_forbidden', 'Internal venue policy.', array( 'status' => 403 ) )
+							: true;
+					},
+					'execute_callback'    => function ( array $input ) {
+						$this->audit[] = array(
+							'booking_id'    => $input['booking_id'],
+							'attachment_id' => $input['attachment_id'],
+							'actor_id'      => get_current_user_id(),
+						);
+						return array(
+							'stream_token'   => str_repeat( dechex( min( 15, $input['booking_id'] ) ), 64 ),
+							'correlation_id' => '11111111-1111-4111-8111-' . str_pad( (string) $input['booking_id'], 12, '0', STR_PAD_LEFT ),
+							'expires_at'     => gmdate( 'c', time() + 300 ),
+							'filename'       => 'safe-rider.pdf',
+							'mime_type'      => 'application/pdf',
+						);
+					},
+				)
+			);
+			$this->assertInstanceOf( WP_Ability::class, $ability );
+			$this->registered_abilities[] = $name;
+
+			$name    = 'extrachill/record-booking-attachment-delivery';
+			$ability = WP_Abilities_Registry::get_instance()->register(
+				$name,
+				array(
+					'label'               => 'Record booking attachment delivery',
+					'description'         => 'Controlled terminal delivery contract.',
+					'category'            => 'extrachill-api-tests',
+					'input_schema'        => array( 'type' => 'object' ),
+					'output_schema'       => array( 'type' => 'object' ),
+					'permission_callback' => '__return_true',
+					'execute_callback'    => function ( array $input ) {
+						$this->delivery_outcomes[] = $input;
+						return array( 'recorded' => true );
+					},
+				)
+			);
+			$this->assertInstanceOf( WP_Ability::class, $ability );
+			$this->registered_abilities[] = $name;
+		}
+
+		/** Dispatch one request through the real REST server. */
+		private function dispatch( $booking_id, $attachment_id ) {
+			return rest_do_request(
+				new WP_REST_Request(
+					'GET',
+					sprintf( '/extrachill/v1/events/bookings/%d/attachments/%d/download', $booking_id, $attachment_id )
+				)
+			);
+		}
+
+		/** Capture manual byte serving for one response. */
+		private function serve( WP_REST_Response $response ) {
+			ob_start();
+			$served = extrachill_api_serve_private_stream( false, $response, new WP_REST_Request(), rest_get_server() );
+			$bytes  = ob_get_clean();
+			$this->assertTrue( $served );
+			return $bytes;
+		}
+
+		/** Return a response header without relying on retained key casing. */
+		private function response_header( WP_REST_Response $response, $name ) {
+			foreach ( $response->get_headers() as $key => $value ) {
+				if ( strtolower( $key ) === strtolower( $name ) ) {
+					return (string) $value;
+				}
+			}
+			return '';
+		}
+	}
+}

--- a/tests/Unit/routes/events/BookingInquiriesTest.php
+++ b/tests/Unit/routes/events/BookingInquiriesTest.php
@@ -135,6 +135,26 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 		$this->assertSame( '60', $result->get_error_data()['headers']['Retry-After'] );
 	}
 
+	public function test_booking_error_headers_are_allowlisted_and_removed_from_json() {
+		$error = new WP_Error(
+			'public_write_rate_limited',
+			'Too many requests.',
+			array(
+				'status'  => 429,
+				'headers' => array(
+					'Retry-After' => '60',
+					'X-Private'   => '/private/root',
+				),
+			)
+		);
+		$request  = new WP_REST_Request( 'POST', '/extrachill/v1/venues/42/booking-inquiries' );
+		$response = extrachill_api_booking_transport_error_headers( rest_convert_error_to_response( $error ), rest_get_server(), $request );
+
+		$this->assertSame( '60', $response->get_headers()['Retry-After'] );
+		$this->assertArrayNotHasKey( 'X-Private', $response->get_headers() );
+		$this->assertArrayNotHasKey( 'headers', $response->get_data()['data'] );
+	}
+
 	public function test_unsigned_remote_address_is_not_trusted() {
 		$request = $this->valid_request();
 		$request->set_param( '_ec_affinity_remote_addr', '203.0.113.99' );
@@ -223,10 +243,28 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 
 	public function test_domain_errors_map_to_stable_public_statuses() {
 		$conflict = extrachill_api_booking_public_error( new WP_Error( 'booking_idempotency_conflict', 'Conflict.', array( 'status' => 409 ) ) );
+		$stale = extrachill_api_booking_public_error( new WP_Error( 'venue_booking_config_version_conflict', 'Refresh configuration.', array( 'status' => 409 ) ) );
+		$attachment = extrachill_api_booking_public_error( new WP_Error( 'invalid_booking_attachment_type', 'Unsupported file.', array( 'status' => 400 ) ) );
+		$reconcile = extrachill_api_booking_public_error(
+			new WP_Error(
+				'booking_inquiry_reconciliation_required',
+				'Reconciliation required.',
+				array(
+					'status'                  => 503,
+					'retryable'               => true,
+					'reconciliation_required' => true,
+				)
+			)
+		);
 		$internal = extrachill_api_booking_public_error( new WP_Error( 'booking_read_failed', 'Database details.' ) );
 
 		$this->assertSame( 409, $conflict->get_error_data()['status'] );
 		$this->assertSame( 'booking_idempotency_conflict', $conflict->get_error_code() );
+		$this->assertSame( 'booking_inquiry_stale_config', $stale->get_error_code() );
+		$this->assertSame( 'booking_attachment_rejected', $attachment->get_error_code() );
+		$this->assertSame( 'booking_inquiry_reconciliation_required', $reconcile->get_error_code() );
+		$this->assertTrue( $reconcile->get_error_data()['retryable'] );
+		$this->assertTrue( $reconcile->get_error_data()['reconciliation_required'] );
 		$this->assertSame( 503, $internal->get_error_data()['status'] );
 		$this->assertSame( 'booking_inquiry_unavailable', $internal->get_error_code() );
 		$this->assertStringNotContainsString( 'Database', $internal->get_error_message() );

--- a/tests/Unit/routes/events/BookingInquiriesTest.php
+++ b/tests/Unit/routes/events/BookingInquiriesTest.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Tests for protected public booking inquiry admission.
+ *
+ * @package ExtraChill\API\Tests
+ */
+
+/** Exercises the facade without duplicating Events domain behavior. */
+class Booking_InquiriesTest extends WP_UnitTestCase {
+
+	/** @var array */
+	private $ability_inputs = array();
+
+	/** @var array */
+	private $temporary_files = array();
+
+	public function set_up() {
+		parent::set_up();
+		$this->ability_inputs  = array();
+		$this->temporary_files = array();
+		if ( isset( wp_get_abilities()[ EXTRACHILL_API_BOOKING_ABILITY ] ) ) {
+			wp_unregister_ability( EXTRACHILL_API_BOOKING_ABILITY );
+		}
+		$this->register_booking_ability();
+		$_SERVER['REMOTE_ADDR'] = '198.51.100.' . random_int( 1, 250 );
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'extrachill_bypass_turnstile_verification' );
+		remove_all_filters( 'extrachill_api_booking_inquiry_rate_limit' );
+		remove_all_filters( 'extrachill_api_allow_test_booking_file' );
+		foreach ( $this->temporary_files as $file ) {
+			if ( file_exists( $file ) ) {
+				unlink( $file );
+			}
+		}
+		if ( isset( wp_get_abilities()[ EXTRACHILL_API_BOOKING_ABILITY ] ) ) {
+			wp_unregister_ability( EXTRACHILL_API_BOOKING_ABILITY );
+		}
+		if ( isset( wp_get_ability_categories()['test'] ) ) {
+			wp_unregister_ability_category( 'test' );
+		}
+		parent::tear_down();
+	}
+
+	public function test_route_is_registered_for_anonymous_callers() {
+		do_action( 'rest_api_init' );
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/extrachill/v1/venues/(?P<venue>\d+)/booking-inquiries', $routes );
+		$this->assertSame( 'extrachill_api_booking_inquiry_permission', $routes['/extrachill/v1/venues/(?P<venue>\d+)/booking-inquiries'][0]['permission_callback'] );
+	}
+
+	public function test_route_affinity_uses_events_segment_boundary() {
+		$map = extrachill_api_add_booking_route_affinity( array() );
+
+		$this->assertSame( 'events', $map['/extrachill/v1/venues/'] );
+		$this->assertStringStartsWith( '/extrachill/v1/venues/', '/extrachill/v1/venues/42/booking-inquiries' );
+		$this->assertStringStartsNotWith( '/extrachill/v1/venues/', '/extrachill/v1/venuesfoo/42/booking-inquiries' );
+	}
+
+	public function test_anonymous_submission_invokes_hidden_ability() {
+		$request = $this->valid_request();
+		$result  = extrachill_api_handle_booking_inquiry( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( 201, $result->get_status() );
+		$this->assertSame( 42, $this->ability_inputs[0]['venue_term_id'] );
+		$this->assertArrayNotHasKey( 'user_id', $this->ability_inputs[0] );
+		$this->assertSame( 0, get_current_user_id() );
+	}
+
+	public function test_submitted_identity_is_never_forwarded() {
+		$request = $this->valid_request();
+		$request->set_param( 'user_id', 999 );
+		$request->set_param( 'submitter_user_id', 998 );
+		extrachill_api_handle_booking_inquiry( $request );
+
+		$this->assertArrayNotHasKey( 'user_id', $this->ability_inputs[0] );
+		$this->assertArrayNotHasKey( 'submitter_user_id', $this->ability_inputs[0] );
+	}
+
+	public function test_authenticated_identity_remains_request_identity() {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		extrachill_api_handle_booking_inquiry( $this->valid_request() );
+
+		$this->assertSame( $user_id, get_current_user_id() );
+		$this->assertArrayNotHasKey( 'user_id', $this->ability_inputs[0] );
+	}
+
+	public function test_missing_turnstile_primitive_fails_before_ability_execution() {
+		$request = $this->valid_request();
+		$request->set_param( 'turnstile_response', '' );
+		$result = extrachill_api_booking_inquiry_permission( $request );
+
+		$this->assertWPError( $result );
+		$this->assertContains( $result->get_error_code(), array( 'booking_security_unavailable', 'turnstile_missing_token' ) );
+		$this->assertEmpty( $this->ability_inputs );
+	}
+
+	public function test_rate_limit_returns_stable_429() {
+		$request = $this->valid_request();
+		$scope   = 'booking-test-' . wp_generate_uuid4();
+		$this->assertTrue( extrachill_api_check_public_write_rate_limit( $request, $scope, 1 ) );
+		$result = extrachill_api_check_public_write_rate_limit( $request, $scope, 1 );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'public_write_rate_limited', $result->get_error_code() );
+		$this->assertSame( 429, $result->get_error_data()['status'] );
+		$this->assertSame( '60', $result->get_error_data()['headers']['Retry-After'] );
+	}
+
+	public function test_unsigned_remote_address_is_not_trusted() {
+		$request = $this->valid_request();
+		$request->set_param( '_ec_affinity_remote_addr', '203.0.113.99' );
+
+		$this->assertNotSame( '203.0.113.99', $_SERVER['REMOTE_ADDR'] );
+		$this->assertNotSame( '1', $request->get_header( 'X-EC-Affinity-Verified' ) );
+	}
+
+	public function test_duplicate_retry_preserves_exact_ability_input() {
+		$request = $this->valid_request();
+		$first   = extrachill_api_handle_booking_inquiry( $request );
+		$second  = extrachill_api_handle_booking_inquiry( $request );
+
+		$this->assertSame( $first->get_data(), $second->get_data() );
+		$this->assertSame( $this->ability_inputs[0], $this->ability_inputs[1] );
+	}
+
+	public function test_multipart_normalization_passes_only_events_admission_fields() {
+		$request = $this->valid_request();
+		$file    = $this->uploaded_file( 'press.txt', 'press notes' );
+		$request->set_file_params( array( 'attachments' => $file ) );
+		$request->set_param( 'attachment_purposes', array( 'press_release' ) );
+
+		$files = extrachill_api_normalize_booking_files( $request );
+		$input = extrachill_api_booking_ability_input( $request, $files );
+
+		$this->assertCount( 1, $files );
+		$this->assertSame( 'press_release', $files[0]['purpose'] );
+		$this->assertSame(
+			array( 'name', 'tmp_name', 'error', 'size', 'purpose' ),
+			array_keys( $input['attachments'][0] )
+		);
+		$this->assertSame( $file['tmp_name'], $input['attachments'][0]['tmp_name'] );
+		$this->assertArrayNotHasKey( '_attachment_admission', $input['intake'] );
+	}
+
+	public function test_multipart_upload_and_purpose_failures_are_stable() {
+		$request = $this->valid_request();
+		$file    = $this->uploaded_file( 'press.txt', 'press notes' );
+		$file['error'] = UPLOAD_ERR_PARTIAL;
+		$request->set_file_params( array( 'attachments' => $file ) );
+		$request->set_param( 'attachment_purposes', array( 'press_release' ) );
+		$result = extrachill_api_normalize_booking_files( $request );
+		$this->assertSame( 'booking_attachment_upload_failed', $result->get_error_code() );
+
+		$file['error'] = UPLOAD_ERR_OK;
+		$request->set_file_params( array( 'attachments' => $file ) );
+		$request->set_param( 'attachment_purposes', array() );
+		$result = extrachill_api_normalize_booking_files( $request );
+		$this->assertSame( 'booking_attachment_purpose_mismatch', $result->get_error_code() );
+	}
+
+	public function test_verified_multipart_rejects_changed_bytes() {
+		$request = $this->valid_request();
+		$file    = $this->uploaded_file( 'press.txt', 'changed bytes' );
+		$request->set_file_params( array( 'attachments' => $file ) );
+		$request->set_param( 'attachment_purposes', array( 'press_release' ) );
+		$request->set_param( EXTRACHILL_API_BOOKING_FILES, wp_json_encode( array( array( 'name' => 'press.txt', 'size' => 1, 'purpose' => 'press_release', 'hash' => str_repeat( 'a', 64 ) ) ) ) );
+		$request->set_header( 'X-EC-Affinity-Verified', '1' );
+
+		$result = extrachill_api_normalize_booking_files( $request );
+		$this->assertSame( 'booking_attachment_transport_invalid', $result->get_error_code() );
+	}
+
+	public function test_route_fields_cover_backing_ability_schema() {
+		$args    = extrachill_api_booking_inquiry_args();
+		$ability = wp_get_abilities()[ EXTRACHILL_API_BOOKING_ABILITY ];
+		$schema  = $ability->get_input_schema();
+		$mapped  = array_diff( array_keys( $args ), array( 'venue', 'turnstile_response', 'attachment_purposes' ) );
+		$mapped[] = 'venue_term_id';
+		$mapped[] = 'attachments';
+
+		$this->assertEmpty( array_diff( $schema['required'], $mapped ) );
+		$this->assertEmpty( array_diff( $mapped, array_keys( $schema['properties'] ) ) );
+	}
+
+	public function test_hidden_ability_cannot_run_through_generic_rest() {
+		$controller = new WP_REST_Abilities_V1_Run_Controller();
+		$request    = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/' . EXTRACHILL_API_BOOKING_ABILITY . '/run' );
+		$request->set_param( 'name', EXTRACHILL_API_BOOKING_ABILITY );
+		$result = $controller->check_ability_permissions( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_ability_not_found', $result->get_error_code() );
+	}
+
+	public function test_domain_errors_map_to_stable_public_statuses() {
+		$conflict = extrachill_api_booking_public_error( new WP_Error( 'booking_idempotency_conflict', 'Conflict.', array( 'status' => 409 ) ) );
+		$internal = extrachill_api_booking_public_error( new WP_Error( 'booking_read_failed', 'Database details.' ) );
+
+		$this->assertSame( 409, $conflict->get_error_data()['status'] );
+		$this->assertSame( 'booking_idempotency_conflict', $conflict->get_error_code() );
+		$this->assertSame( 503, $internal->get_error_data()['status'] );
+		$this->assertSame( 'booking_inquiry_unavailable', $internal->get_error_code() );
+		$this->assertStringNotContainsString( 'Database', $internal->get_error_message() );
+	}
+
+	public function test_attachment_admission_does_not_construct_events_domain_services() {
+		$source = file_get_contents( dirname( __DIR__, 4 ) . '/inc/routes/events/booking-inquiries.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source contract fixture.
+		$this->assertStringNotContainsString( 'ExtraChillEvents\\Core', $source );
+		$this->assertStringNotContainsString( 'storage_reference', $source );
+		$this->assertStringNotContainsString( '_attachment_admission', $source );
+	}
+
+	private function register_booking_ability() {
+		$test = $this;
+		$register_category = static function () {
+			wp_register_ability_category(
+				'test',
+				array(
+					'label'       => 'Test',
+					'description' => 'Test-only ability contracts.',
+				)
+			);
+		};
+		add_action( 'wp_abilities_api_categories_init', $register_category );
+		do_action( 'wp_abilities_api_categories_init' );
+		remove_action( 'wp_abilities_api_categories_init', $register_category );
+
+		$register = static function () use ( $test ) {
+			wp_register_ability(
+				EXTRACHILL_API_BOOKING_ABILITY,
+				array(
+					'label'               => 'Test booking inquiry',
+					'description'         => 'Test hidden public booking inquiry contract.',
+					'category'            => 'test',
+					'input_schema'        => array(
+						'type'                 => 'object',
+						'properties'           => array(
+							'idempotency_key'     => array( 'type' => 'string' ),
+							'venue_term_id'       => array( 'type' => 'integer' ),
+							'artist_term_id'      => array( 'type' => array( 'integer', 'null' ) ),
+							'artist_profile_id'   => array( 'type' => array( 'integer', 'null' ) ),
+							'artist_name'         => array( 'type' => 'string' ),
+							'contact_name'        => array( 'type' => array( 'string', 'null' ) ),
+							'contact_email'       => array( 'type' => array( 'string', 'null' ) ),
+							'contact_phone'       => array( 'type' => array( 'string', 'null' ) ),
+							'requested_space_key' => array( 'type' => array( 'string', 'null' ) ),
+							'requested_start_at'  => array( 'type' => array( 'string', 'null' ) ),
+							'requested_end_at'    => array( 'type' => array( 'string', 'null' ) ),
+							'intake'              => array( 'type' => 'object' ),
+							'attachments'         => array( 'type' => 'array' ),
+						),
+						'required'             => array( 'idempotency_key', 'venue_term_id', 'intake' ),
+						'additionalProperties' => false,
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'permission_callback' => '__return_true',
+					'execute_callback'    => static function ( $input ) use ( $test ) {
+						$test->ability_inputs[] = $input;
+						return array(
+							'public_id'     => '11111111-1111-4111-8111-111111111111',
+							'venue_term_id' => $input['venue_term_id'],
+							'submitted_at'  => '2026-07-24 20:00:00',
+						);
+					},
+					'meta'                => array(
+						'show_in_rest' => false,
+						'annotations'  => array( 'readonly' => false, 'idempotent' => true, 'destructive' => false ),
+					),
+				)
+			);
+		};
+		add_action( 'wp_abilities_api_init', $register );
+		do_action( 'wp_abilities_api_init' );
+		remove_action( 'wp_abilities_api_init', $register );
+	}
+
+	private function valid_request() {
+		$request = new WP_REST_Request( 'POST', '/extrachill/v1/venues/42/booking-inquiries' );
+		$request->set_param( 'venue', 42 );
+		$request->set_param( 'idempotency_key', 'request-123' );
+		$request->set_param( 'artist_name', 'Test Artist' );
+		$request->set_param( 'contact_email', 'artist@example.com' );
+		$request->set_param( 'intake', array( 'message' => 'Booking request.' ) );
+		$request->set_param( 'turnstile_response', 'test-token' );
+		return $request;
+	}
+
+	private function uploaded_file( $name, $contents ) {
+		$file = tempnam( sys_get_temp_dir(), 'ec-booking-test-' );
+		file_put_contents( $file, $contents ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture.
+		$this->temporary_files[] = $file;
+		add_filter( 'extrachill_api_allow_test_booking_file', '__return_true' );
+		return array(
+			'name'     => $name,
+			'type'     => 'text/plain',
+			'tmp_name' => $file,
+			'error'    => UPLOAD_ERR_OK,
+			'size'     => filesize( $file ),
+		);
+	}
+}

--- a/tests/Unit/routes/events/BookingInquiriesTest.php
+++ b/tests/Unit/routes/events/BookingInquiriesTest.php
@@ -17,11 +17,16 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 	/** @var array */
 	private $temporary_files = array();
 
+	/** @var array<string, int> */
+	private $rate_counts = array();
+
 	public function set_up() {
 		parent::set_up();
 		$this->ability_inputs  = array();
 		$this->ability_actor_ids = array();
 		$this->temporary_files = array();
+		$this->rate_counts     = array();
+		add_filter( 'extrachill_api_rate_limit_store', array( $this, 'use_test_rate_limit_store' ) );
 		if ( isset( wp_get_abilities()[ EXTRACHILL_API_BOOKING_ABILITY ] ) ) {
 			wp_unregister_ability( EXTRACHILL_API_BOOKING_ABILITY );
 		}
@@ -34,6 +39,7 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 		remove_all_filters( 'extrachill_bypass_turnstile_verification' );
 		remove_all_filters( 'extrachill_api_booking_inquiry_rate_limit' );
 		remove_all_filters( 'extrachill_api_allow_test_booking_file' );
+		remove_filter( 'extrachill_api_rate_limit_store', array( $this, 'use_test_rate_limit_store' ) );
 		foreach ( $this->temporary_files as $file ) {
 			if ( file_exists( $file ) ) {
 				unlink( $file );
@@ -132,7 +138,8 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 		$this->assertWPError( $result );
 		$this->assertSame( 'public_write_rate_limited', $result->get_error_code() );
 		$this->assertSame( 429, $result->get_error_data()['status'] );
-		$this->assertSame( '60', $result->get_error_data()['headers']['Retry-After'] );
+		$this->assertGreaterThanOrEqual( 1, (int) $result->get_error_data()['headers']['Retry-After'] );
+		$this->assertLessThanOrEqual( 60, (int) $result->get_error_data()['headers']['Retry-After'] );
 	}
 
 	public function test_booking_error_headers_are_allowlisted_and_removed_from_json() {
@@ -155,12 +162,49 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'headers', $response->get_data()['data'] );
 	}
 
-	public function test_unsigned_remote_address_is_not_trusted() {
-		$request = $this->valid_request();
-		$request->set_param( '_ec_affinity_remote_addr', '203.0.113.99' );
+	public function test_spoofed_affinity_context_cannot_bypass_the_direct_client_cap() {
+		$spoofed = $this->valid_request();
+		$spoofed->set_header( 'X-EC-Affinity-Verified', '1' );
+		$spoofed->set_header( 'X-EC-Affinity-Client', str_repeat( 'a', 64 ) );
+		$spoofed->set_param( '_ec_affinity_client', str_repeat( 'b', 64 ) );
+		$spoofed->set_param( '_ec_affinity_remote_addr', '203.0.113.99' );
 
+		$scope = 'booking-spoof-' . wp_generate_uuid4();
+		$this->assertTrue( extrachill_api_check_public_write_rate_limit( $spoofed, $scope, 1 ) );
+		$blocked = extrachill_api_check_public_write_rate_limit( $this->valid_request(), $scope, 1 );
+
+		$this->assertWPError( $blocked );
+		$this->assertSame( 'public_write_rate_limited', $blocked->get_error_code() );
+		$this->assertSame( array(), extrachill_api_route_affinity_context( $spoofed ) );
 		$this->assertNotSame( '203.0.113.99', $_SERVER['REMOTE_ADDR'] );
-		$this->assertNotSame( '1', $request->get_header( 'X-EC-Affinity-Verified' ) );
+	}
+
+	public function test_turnstile_remote_ip_uses_only_verified_affinity_context() {
+		$observed = array();
+		$observe  = static function () use ( &$observed ) {
+			$observed[] = $_SERVER['REMOTE_ADDR'] ?? '';
+			return true;
+		};
+		add_filter( 'extrachill_bypass_turnstile_verification', $observe );
+		$direct = $this->valid_request();
+		$direct->set_header( 'X-EC-Affinity-Verified', '1' );
+		$direct->set_param( '_ec_affinity_remote_addr', '203.0.113.99' );
+		$this->assertTrue( extrachill_api_booking_inquiry_permission( $direct ) );
+
+		$verified = $this->valid_request();
+		extrachill_api_set_route_affinity_context(
+			$verified,
+			array(
+				'client'      => str_repeat( 'a', 64 ),
+				'remote_addr' => '203.0.113.88',
+				'nonce'       => wp_generate_uuid4(),
+			)
+		);
+		$this->assertTrue( extrachill_api_booking_inquiry_permission( $verified ) );
+		remove_filter( 'extrachill_bypass_turnstile_verification', $observe );
+
+		$this->assertSame( array( $_SERVER['REMOTE_ADDR'], '203.0.113.88' ), $observed );
+		$this->assertNotSame( '203.0.113.88', $_SERVER['REMOTE_ADDR'] );
 	}
 
 	public function test_duplicate_retry_preserves_exact_ability_input() {
@@ -213,7 +257,7 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 		$request->set_file_params( array( 'attachments' => $file ) );
 		$request->set_param( 'attachment_purposes', array( 'press_release' ) );
 		$request->set_param( EXTRACHILL_API_BOOKING_FILES, wp_json_encode( array( array( 'name' => 'press.txt', 'size' => 1, 'purpose' => 'press_release', 'hash' => str_repeat( 'a', 64 ) ) ) ) );
-		$request->set_header( 'X-EC-Affinity-Verified', '1' );
+		extrachill_api_set_route_affinity_context( $request, array( 'nonce' => wp_generate_uuid4() ) );
 
 		$result = extrachill_api_normalize_booking_files( $request );
 		$this->assertSame( 'booking_attachment_transport_invalid', $result->get_error_code() );
@@ -257,6 +301,7 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 			)
 		);
 		$internal = extrachill_api_booking_public_error( new WP_Error( 'booking_read_failed', 'Database details.' ) );
+		$unknown_safe_status = extrachill_api_booking_public_error( new WP_Error( 'new_domain_conflict', 'Private conflict details.', array( 'status' => 409, 'field' => '/private/root' ) ) );
 
 		$this->assertSame( 409, $conflict->get_error_data()['status'] );
 		$this->assertSame( 'booking_idempotency_conflict', $conflict->get_error_code() );
@@ -268,6 +313,10 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 		$this->assertSame( 503, $internal->get_error_data()['status'] );
 		$this->assertSame( 'booking_inquiry_unavailable', $internal->get_error_code() );
 		$this->assertStringNotContainsString( 'Database', $internal->get_error_message() );
+		$this->assertSame( 'booking_inquiry_unavailable', $unknown_safe_status->get_error_code() );
+		$this->assertSame( 503, $unknown_safe_status->get_error_data()['status'] );
+		$this->assertStringNotContainsString( 'Private', $unknown_safe_status->get_error_message() );
+		$this->assertArrayNotHasKey( 'field', $unknown_safe_status->get_error_data() );
 	}
 
 	public function test_attachment_admission_does_not_construct_events_domain_services() {
@@ -279,21 +328,17 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 
 	private function register_booking_ability() {
 		$test = $this;
-		$register_category = static function () {
-			wp_register_ability_category(
+		if ( ! isset( wp_get_ability_categories()['test'] ) ) {
+			WP_Ability_Categories_Registry::get_instance()->register(
 				'test',
 				array(
 					'label'       => 'Test',
 					'description' => 'Test-only ability contracts.',
 				)
 			);
-		};
-		add_action( 'wp_abilities_api_categories_init', $register_category );
-		do_action( 'wp_abilities_api_categories_init' );
-		remove_action( 'wp_abilities_api_categories_init', $register_category );
+		}
 
-		$register = static function () use ( $test ) {
-			wp_register_ability(
+		WP_Abilities_Registry::get_instance()->register(
 				EXTRACHILL_API_BOOKING_ABILITY,
 				array(
 					'label'               => 'Test booking inquiry',
@@ -336,10 +381,6 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 					),
 				)
 			);
-		};
-		add_action( 'wp_abilities_api_init', $register );
-		do_action( 'wp_abilities_api_init' );
-		remove_action( 'wp_abilities_api_init', $register );
 	}
 
 	private function valid_request() {
@@ -366,4 +407,16 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 			'size'     => filesize( $file ),
 		);
 	}
+
+	/** Return the test-owned deterministic atomic counter. */
+	public function use_test_rate_limit_store() {
+		return array( $this, 'increment_test_rate_limit' );
+	}
+
+	/** Increment one test counter exactly once per call. */
+	public function increment_test_rate_limit( $key ) {
+		$this->rate_counts[ $key ] = ( $this->rate_counts[ $key ] ?? 0 ) + 1;
+		return $this->rate_counts[ $key ];
+	}
+
 }

--- a/tests/Unit/routes/events/BookingInquiriesTest.php
+++ b/tests/Unit/routes/events/BookingInquiriesTest.php
@@ -12,11 +12,15 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 	private $ability_inputs = array();
 
 	/** @var array */
+	private $ability_actor_ids = array();
+
+	/** @var array */
 	private $temporary_files = array();
 
 	public function set_up() {
 		parent::set_up();
 		$this->ability_inputs  = array();
+		$this->ability_actor_ids = array();
 		$this->temporary_files = array();
 		if ( isset( wp_get_abilities()[ EXTRACHILL_API_BOOKING_ABILITY ] ) ) {
 			wp_unregister_ability( EXTRACHILL_API_BOOKING_ABILITY );
@@ -26,6 +30,7 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
+		wp_clear_auth_cookie();
 		remove_all_filters( 'extrachill_bypass_turnstile_verification' );
 		remove_all_filters( 'extrachill_api_booking_inquiry_rate_limit' );
 		remove_all_filters( 'extrachill_api_allow_test_booking_file' );
@@ -69,23 +74,43 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 		$this->assertSame( 0, get_current_user_id() );
 	}
 
-	public function test_submitted_identity_is_never_forwarded() {
+	public function test_submitted_identity_is_rejected_before_security_or_execution() {
 		$request = $this->valid_request();
 		$request->set_param( 'user_id', 999 );
 		$request->set_param( 'submitter_user_id', 998 );
-		extrachill_api_handle_booking_inquiry( $request );
+		$result = extrachill_api_booking_inquiry_permission( $request );
 
-		$this->assertArrayNotHasKey( 'user_id', $this->ability_inputs[0] );
-		$this->assertArrayNotHasKey( 'submitter_user_id', $this->ability_inputs[0] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'booking_identity_not_allowed', $result->get_error_code() );
+		$this->assertEmpty( $this->ability_inputs );
 	}
 
-	public function test_authenticated_identity_remains_request_identity() {
+	public function test_cookie_authenticated_identity_remains_canonical_context() {
 		$user_id = self::factory()->user->create();
 		wp_set_current_user( $user_id );
+		wp_set_auth_cookie( $user_id );
 		extrachill_api_handle_booking_inquiry( $this->valid_request() );
 
 		$this->assertSame( $user_id, get_current_user_id() );
 		$this->assertArrayNotHasKey( 'user_id', $this->ability_inputs[0] );
+		$this->assertSame( $user_id, $this->ability_actor_ids[0] );
+	}
+
+	public function test_bearer_authenticated_identity_uses_validated_context_not_header_data() {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		$request = $this->valid_request();
+		$request->set_header( 'Authorization', 'Bearer provider-validated-token' );
+		extrachill_api_handle_booking_inquiry( $request );
+
+		$this->assertSame( $user_id, $this->ability_actor_ids[0] );
+		$this->assertArrayNotHasKey( 'authorization', $this->ability_inputs[0] );
+	}
+
+	public function test_anonymous_identity_validation_does_not_require_registration() {
+		wp_set_current_user( 0 );
+
+		$this->assertTrue( extrachill_api_booking_validate_canonical_identity() );
 	}
 
 	public function test_missing_turnstile_primitive_fails_before_ability_execution() {
@@ -260,6 +285,7 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 					'permission_callback' => '__return_true',
 					'execute_callback'    => static function ( $input ) use ( $test ) {
 						$test->ability_inputs[] = $input;
+						$test->ability_actor_ids[] = get_current_user_id();
 						return array(
 							'public_id'     => '11111111-1111-4111-8111-111111111111',
 							'venue_term_id' => $input['venue_term_id'],

--- a/tests/Unit/routes/events/BookingInquiriesTest.php
+++ b/tests/Unit/routes/events/BookingInquiriesTest.php
@@ -142,6 +142,42 @@ class Booking_InquiriesTest extends WP_UnitTestCase {
 		$this->assertLessThanOrEqual( 60, (int) $result->get_error_data()['headers']['Retry-After'] );
 	}
 
+	/** Missing and malformed direct client addresses fail closed. */
+	public function test_rate_limit_rejects_invalid_direct_client_addresses() {
+		foreach ( array( null, 'not-an-ip' ) as $remote_addr ) {
+			if ( null === $remote_addr ) {
+				unset( $_SERVER['REMOTE_ADDR'] );
+			} else {
+				$_SERVER['REMOTE_ADDR'] = $remote_addr;
+			}
+			$result = extrachill_api_check_public_write_rate_limit( $this->valid_request(), 'invalid-direct-' . wp_generate_uuid4(), 1 );
+
+			$this->assertWPError( $result );
+			$this->assertSame( 'public_write_admission_unavailable', $result->get_error_code() );
+			$this->assertSame( 503, $result->get_error_data()['status'] );
+		}
+	}
+
+	/** Incomplete or malformed verified affinity identity also fails closed. */
+	public function test_rate_limit_rejects_invalid_verified_affinity_addresses() {
+		foreach ( array( '', 'not-an-ip' ) as $remote_addr ) {
+			$request = $this->valid_request();
+			extrachill_api_set_route_affinity_context(
+				$request,
+				array(
+					'client'      => str_repeat( 'a', 64 ),
+					'remote_addr' => $remote_addr,
+					'nonce'       => wp_generate_uuid4(),
+				)
+			);
+			$result = extrachill_api_check_public_write_rate_limit( $request, 'invalid-affinity-' . wp_generate_uuid4(), 1 );
+
+			$this->assertWPError( $result );
+			$this->assertSame( 'public_write_admission_unavailable', $result->get_error_code() );
+			$this->assertSame( 503, $result->get_error_data()['status'] );
+		}
+	}
+
 	public function test_booking_error_headers_are_allowlisted_and_removed_from_json() {
 		$error = new WP_Error(
 			'public_write_rate_limited',

--- a/tests/atomic-rate-limit-concurrency-smoke.php
+++ b/tests/atomic-rate-limit-concurrency-smoke.php
@@ -1,0 +1,107 @@
+<?php
+// phpcs:disable
+/** Standalone process-concurrency evidence for the shared inquiry/download cap. */
+
+if ( ! function_exists( 'pcntl_fork' ) ) {
+	fwrite( STDERR, "pcntl is required\n" );
+	exit( 2 );
+}
+
+define( 'ABSPATH', __DIR__ );
+
+class WP_Error {
+	public function __construct( $code = '', $message = '', $data = array() ) {}
+}
+
+function is_wp_error( $value ) {
+	return $value instanceof WP_Error;
+}
+
+function __( $message ) {
+	return $message;
+}
+
+function apply_filters( $hook, $value ) {
+	return 'extrachill_api_rate_limit_store' === $hook ? 'extrachill_api_concurrency_file_increment' : $value;
+}
+
+function wp_cache_add() {
+	return false;
+}
+
+function wp_cache_incr() {
+	return false;
+}
+
+$GLOBALS['extrachill_api_concurrency_dir'] = sys_get_temp_dir() . '/ec-api-rate-' . bin2hex( random_bytes( 8 ) );
+mkdir( $GLOBALS['extrachill_api_concurrency_dir'], 0700 );
+
+function extrachill_api_concurrency_file_increment( $key ) {
+	$path = $GLOBALS['extrachill_api_concurrency_dir'] . '/counter-' . hash( 'sha256', $key );
+	$file = fopen( $path, 'c+' );
+	if ( false === $file || ! flock( $file, LOCK_EX ) ) {
+		return new WP_Error( 'store_failed' );
+	}
+	$raw = stream_get_contents( $file );
+	$count = (int) $raw + 1;
+	rewind( $file );
+	ftruncate( $file, 0 );
+	fwrite( $file, (string) $count );
+	fflush( $file );
+	flock( $file, LOCK_UN );
+	fclose( $file );
+	return $count;
+}
+
+require dirname( __DIR__ ) . '/inc/middleware/public-write-admission.php';
+
+function extrachill_api_run_concurrent_cap( $scope, $limit, $workers ) {
+	$pids = array();
+	for ( $index = 0; $index < $workers; ++$index ) {
+		$pid = pcntl_fork();
+		if ( 0 === $pid ) {
+			$admitted = extrachill_api_atomic_rate_limit_admit( $scope, $limit, 60 );
+			file_put_contents(
+				$GLOBALS['extrachill_api_concurrency_dir'] . '/result-' . $scope . '-' . getmypid(),
+				true === $admitted ? '1' : '0'
+			);
+			exit( 0 );
+		}
+		if ( $pid < 0 ) {
+			return array( 'error' => 'fork_failed' );
+		}
+		$pids[] = $pid;
+	}
+	foreach ( $pids as $pid ) {
+		pcntl_waitpid( $pid, $status );
+		if ( ! pcntl_wifexited( $status ) || 0 !== pcntl_wexitstatus( $status ) ) {
+			return array( 'error' => 'worker_failed' );
+		}
+	}
+	$allowed = 0;
+	foreach ( glob( $GLOBALS['extrachill_api_concurrency_dir'] . '/result-' . $scope . '-*' ) as $result ) {
+		$allowed += (int) file_get_contents( $result );
+	}
+	return array(
+		'workers'  => $workers,
+		'limit'    => $limit,
+		'allowed'  => $allowed,
+		'rejected' => $workers - $allowed,
+		'passed'   => $limit === $allowed,
+	);
+}
+
+$evidence = array(
+	'schema'   => 'extrachill-api/atomic-rate-limit-concurrency/v1',
+	'inquiry'  => extrachill_api_run_concurrent_cap( 'inquiry', 7, 24 ),
+	'download' => extrachill_api_run_concurrent_cap( 'download', 5, 24 ),
+);
+$passed = true === ( $evidence['inquiry']['passed'] ?? false ) && true === ( $evidence['download']['passed'] ?? false );
+$evidence['passed'] = $passed;
+fwrite( STDOUT, json_encode( $evidence, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );
+
+foreach ( glob( $GLOBALS['extrachill_api_concurrency_dir'] . '/*' ) as $path ) {
+	unlink( $path );
+}
+rmdir( $GLOBALS['extrachill_api_concurrency_dir'] );
+exit( $passed ? 0 : 1 );


### PR DESCRIPTION
## Summary
- compose anonymous-capable booking inquiry admission, canonical optional caller identity, and authenticated private attachment streaming behind one protected API boundary
- reconcile multipart descriptors and signed `Range` forwarding into one allowlisted route-affinity payload with replay protection, bounded private spools, no-store responses, and cleanup on every exit path
- consume the final Events integration contract at `Extra-Chill/extrachill-events@5d6f28f`, including Events-owned atomic attachment admission and delivery-correlation outcomes

## Source Mapping
- API `bb7467a252e2ef3536085e716e2e2067841fa1c8` / #123 maps to `25204a3`, narrowed to pass the final Events ordered `attachments` contract instead of constructing providers, repositories, storage references, attachment idempotency keys, or compensation in API
- #124 maps to `c2eeeb4`: anonymous remains valid; cookie, bearer, and signed cross-site callers bind only the canonical WordPress current user; submitted identity fields are rejected
- API `815f918d0164e612b6e884d3883b71c2c501ec9f` / #125 maps to `baee7cb`, updated for Events correlation issuance, five-argument stream consumption, and terminal `completed` / `failed` / `interrupted` / `partial` callbacks
- `1382f1c` defines stable UI-facing inquiry/download errors, retry headers, range behavior, and the no-private-reference contract

Supersedes #135 and #134. The source PRs remain open for maintainers to close.

## Route-Affinity Conflict Resolution
The two source commits edited the same middleware from the same `origin/main` parent. This PR does not merge either snapshot blindly:

- the canonical payload signs normalized query, filtered request body, and only allowlisted forwarded headers
- inquiry multipart descriptors extend the signed body and are verified after trusted re-entry
- download forwarding signs only `Range`
- successful nonce verification marks the request for admitted client/IP handling
- multipart forwarding and private byte spooling share one dispatch path and one filter cleanup boundary
- private responses use mode-`0600`, size-bounded temporary spools; errors never relay downstream bodies or internal references

## Ownership Boundary
API owns HTTP route admission, Turnstile, fixed-window throttling and `Retry-After`, request/multipart normalization, route affinity, canonical caller context, stable public HTTP errors, range/cache headers, bounded streaming, and temporary transport-spool cleanup.

Events owns booking persistence, venue configuration/policy, authorization, idempotency semantics, private storage/admission, attachment handoff issuance and consumption, consumption-time reauthorization, activity/correlation records, compensation, reconciliation, and durable cleanup.

No storage provisioning, venue policy enablement, domain persistence, public form, settings UI, operator UI, release, or deployment is included.

## Error Contract
`docs/routes/events/booking-transport.md` documents validation field paths, immutable duplicate receipts, idempotency conflicts, missing/expired Turnstile, rate limits, stale configuration, unavailable intake, attachment policy/size/storage/scan classes, uncertain reconciliation, authentication, generic authorization/replay failures, and RFC-style range errors. Unknown domain failures remain generic. Only `Retry-After` and `Content-Range` may be promoted from error metadata into HTTP headers.

REST JSON and logs never expose temporary paths, roots, hashes, storage/object references, handoff tokens, internal identities, or private bytes.

## Verification
- focused managed booking PHPUnit: `OK (30 tests, 150 assertions)`; Homeboy run `3d5e5447-e042-4748-b0de-ae6cc0b08c05`
- PHPCS: 0 findings; PHPStan level 7: passed; Homeboy run `2d27e258-8f82-4650-88f1-93dca1ab0d3c`
- Homeboy PR audit: 0 introduced findings; run `5dfddc58-d643-4e26-b55f-5b1fce354aa6`
- Homeboy production build, package structure, and packaged PHP syntax: passed
- changed PHP syntax and `git diff --check`: passed
- unfiltered repository PHPUnit was run and reproduces the pre-existing baseline (31 failures / 64 errors), including omitted `extrachill-network` validation dependencies and unrelated legacy activity helpers; dependency composition is tracked in `Extra-Chill/homeboy-extensions#2323`

Closes #123
Closes #124
Closes #125