### PR TITLE
feat: expose booking availability transport

### DIFF
--- a/inc/middleware/public-write-admission.php
+++ b/inc/middleware/public-write-admission.php
@@ -114,3 +114,48 @@ function extrachill_api_check_public_write_rate_limit( WP_REST_Request $request,
 
 	return true;
 }
+
+/** Apply the atomic per-client limiter to one public-read scope. */
+function extrachill_api_check_public_read_rate_limit( WP_REST_Request $request, $scope, $limit ) {
+	$limit = (int) $limit;
+	if ( $limit < 1 ) {
+		return true;
+	}
+
+	$context = function_exists( 'extrachill_api_route_affinity_context' ) ? extrachill_api_route_affinity_context( $request ) : array();
+	if ( $context ) {
+		$client = strtolower( sanitize_text_field( (string) ( $context['client'] ?? '' ) ) );
+		$ip     = sanitize_text_field( (string) ( $context['remote_addr'] ?? '' ) );
+		if ( 1 !== preg_match( '/^[a-f0-9]{64}$/', $client ) || false === filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+			return new WP_Error( 'public_read_admission_unavailable', __( 'Request admission is temporarily unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
+		}
+	} else {
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+		if ( '' === $ip || false === filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+			return new WP_Error( 'public_read_admission_unavailable', __( 'Request admission is temporarily unavailable.', 'extrachill-api' ), array( 'status' => 503 ) );
+		}
+		$client = hash_hmac( 'sha256', $ip, wp_salt( 'nonce' ) );
+	}
+
+	$now         = time();
+	$window      = intdiv( $now, MINUTE_IN_SECONDS );
+	$retry_after = ( ( $window + 1 ) * MINUTE_IN_SECONDS ) - $now;
+	$key         = 'read_' . substr( hash( 'sha256', sanitize_key( $scope ) . ':' . $client . ':' . $window ), 0, 40 );
+	$admitted    = extrachill_api_atomic_rate_limit_admit( $key, $limit, $retry_after );
+	if ( is_wp_error( $admitted ) ) {
+		return $admitted;
+	}
+	if ( ! $admitted ) {
+		return new WP_Error(
+			'public_read_rate_limited',
+			__( 'Too many requests. Please try again later.', 'extrachill-api' ),
+			array(
+				'status'      => 429,
+				'retry_after' => $retry_after,
+				'headers'     => array( 'Retry-After' => (string) $retry_after ),
+			)
+		);
+	}
+
+	return true;
+}

--- a/inc/middleware/route-affinity.php
+++ b/inc/middleware/route-affinity.php
@@ -482,6 +482,9 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		if ( $headers instanceof Traversable ) {
 			$headers = iterator_to_array( $headers );
 		}
+		if ( preg_match( '#^/extrachill/v1/venues/\d+/booking-availability$#', $route ) && function_exists( 'extrachill_api_booking_availability_affinity_response' ) ) {
+			return extrachill_api_booking_availability_affinity_response( $data, (int) $status, $headers );
+		}
 
 		return new WP_REST_Response( $data, (int) $status, $headers );
 	}
@@ -492,6 +495,8 @@ function extrachill_api_route_affinity_dispatch( $result, WP_REST_Server $server
 		}
 		if ( preg_match( '#^/extrachill/v1/venues/\d+/booking-inquiries$#', $route ) && function_exists( 'extrachill_api_booking_public_error' ) ) {
 			$response = extrachill_api_booking_public_error( $response );
+		} elseif ( preg_match( '#^/extrachill/v1/venues/\d+/booking-availability$#', $route ) && function_exists( 'extrachill_api_booking_availability_public_error' ) ) {
+			$response = extrachill_api_booking_availability_public_error( $response );
 		}
 		$status = $response->get_error_data()['status'] ?? 500;
 		return new WP_REST_Response(

--- a/inc/routes/events/booking-availability.php
+++ b/inc/routes/events/booking-availability.php
@@ -46,7 +46,7 @@ function extrachill_api_handle_booking_availability( WP_REST_Request $request ) 
 		return $input;
 	}
 
-	$ability = wp_get_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY );
+	$ability = wp_get_abilities()[ EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY ] ?? null;
 	if ( ! $ability || false !== $ability->get_meta_item( 'show_in_rest' ) ) {
 		return extrachill_api_booking_availability_service_error();
 	}

--- a/inc/routes/events/booking-availability.php
+++ b/inc/routes/events/booking-availability.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Privacy-safe public venue booking availability transport.
+ *
+ * @package ExtraChillAPI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY = 'extrachill/check-booking-availability';
+
+add_action( 'extrachill_api_register_routes', 'extrachill_api_register_booking_availability_route' );
+
+/** Register the Events-affine public availability facade. */
+function extrachill_api_register_booking_availability_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/venues/(?P<venue>\d+)/booking-availability',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'extrachill_api_handle_booking_availability',
+			'permission_callback' => 'extrachill_api_booking_availability_permission',
+		)
+	);
+}
+
+/** Rate-limit advisory reads without consuming a Turnstile challenge. */
+function extrachill_api_booking_availability_permission( WP_REST_Request $request ) {
+	$limit  = (int) apply_filters( 'extrachill_api_booking_availability_rate_limit', 60 );
+	$result = extrachill_api_check_public_read_rate_limit( $request, 'booking-availability', $limit );
+
+	return is_wp_error( $result ) ? extrachill_api_booking_availability_public_error( $result ) : true;
+}
+
+/** Validate, invoke the hidden Events ability, and project one boolean. */
+function extrachill_api_handle_booking_availability( WP_REST_Request $request ) {
+	$identity = extrachill_api_booking_validate_canonical_identity();
+	if ( is_wp_error( $identity ) ) {
+		return extrachill_api_booking_availability_service_error();
+	}
+
+	$input = extrachill_api_booking_availability_input( $request );
+	if ( is_wp_error( $input ) ) {
+		return $input;
+	}
+
+	$ability = wp_get_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY );
+	if ( ! $ability || false !== $ability->get_meta_item( 'show_in_rest' ) ) {
+		return extrachill_api_booking_availability_service_error();
+	}
+
+	$result = $ability->execute( $input );
+	if ( is_wp_error( $result ) ) {
+		return extrachill_api_booking_availability_public_error( $result );
+	}
+	if ( ! is_array( $result ) || ! is_bool( $result['available'] ?? null ) ) {
+		return extrachill_api_booking_availability_service_error();
+	}
+
+	return new WP_REST_Response( array( 'available' => $result['available'] ), 200 );
+}
+
+/** Build only the exact hidden-ability input from an exact JSON body. */
+function extrachill_api_booking_availability_input( WP_REST_Request $request ) {
+	$body = json_decode( $request->get_body(), true );
+	if ( ! is_array( $body ) || array() !== $request->get_query_params() ) {
+		return extrachill_api_booking_availability_validation_error();
+	}
+	$expected = array( 'venue', 'requested_space_key', 'requested_start_at', 'requested_end_at' );
+	$keys     = array_keys( $body );
+	sort( $expected );
+	sort( $keys );
+	if ( $expected !== $keys ) {
+		return extrachill_api_booking_availability_validation_error();
+	}
+
+	$url_params = $request->get_url_params();
+	$venue      = $url_params['venue'] ?? null;
+	if ( ! is_int( $venue ) && ! ( is_string( $venue ) && ctype_digit( $venue ) ) ) {
+		return extrachill_api_booking_availability_validation_error();
+	}
+	$venue = (int) $venue;
+	if ( $venue < 1 || ! is_int( $body['venue'] ) || $body['venue'] !== $venue ) {
+		return extrachill_api_booking_availability_validation_error();
+	}
+
+	$space_key = $body['requested_space_key'];
+	$start_at  = $body['requested_start_at'];
+	$end_at    = $body['requested_end_at'];
+	if ( ! is_string( $space_key ) || '' === $space_key || strlen( $space_key ) > 64 || sanitize_key( $space_key ) !== $space_key ) {
+		return extrachill_api_booking_availability_validation_error();
+	}
+	if ( ! extrachill_api_booking_availability_datetime_is_valid( $start_at ) || ! extrachill_api_booking_availability_datetime_is_valid( $end_at ) || $end_at <= $start_at ) {
+		return extrachill_api_booking_availability_validation_error();
+	}
+
+	return array(
+		'venue_term_id'       => $venue,
+		'requested_space_key' => $space_key,
+		'requested_start_at'  => $start_at,
+		'requested_end_at'    => $end_at,
+	);
+}
+
+/** Validate the canonical venue-local wall-clock representation. */
+function extrachill_api_booking_availability_datetime_is_valid( $value ) {
+	if ( ! is_string( $value ) ) {
+		return false;
+	}
+	$date = DateTimeImmutable::createFromFormat( '!Y-m-d H:i:s', $value, new DateTimeZone( 'UTC' ) );
+	return false !== $date && $date->format( 'Y-m-d H:i:s' ) === $value;
+}
+
+/** Return the one fixed public request-validation response. */
+function extrachill_api_booking_availability_validation_error() {
+	return new WP_Error( 'booking_availability_invalid_request', __( 'A valid booking interval is required.', 'extrachill-api' ), array( 'status' => 400 ) );
+}
+
+/** Return the one retryable dependency/service response. */
+function extrachill_api_booking_availability_service_error() {
+	return new WP_Error(
+		'booking_availability_unavailable',
+		__( 'Booking availability is temporarily unavailable. Please try again.', 'extrachill-api' ),
+		array(
+			'status'    => 503,
+			'retryable' => true,
+		)
+	);
+}
+
+/** Map only fixed public validation and limiter errors; hide all owner details. */
+function extrachill_api_booking_availability_public_error( WP_Error $error ) {
+	$code       = $error->get_error_code();
+	$error_data = (array) $error->get_error_data();
+	$status     = (int) ( $error_data['status'] ?? 0 );
+	if ( 'booking_availability_interval_invalid' === $code || ( 'booking_availability_unavailable' === $code && 409 === $status ) ) {
+		return extrachill_api_booking_availability_validation_error();
+	}
+	if ( 'public_read_rate_limited' === $code ) {
+		$data = (array) $error->get_error_data();
+		return new WP_Error(
+			'public_read_rate_limited',
+			__( 'Too many requests. Please try again later.', 'extrachill-api' ),
+			array(
+				'status'  => 429,
+				'headers' => array( 'Retry-After' => (string) max( 1, (int) ( $data['retry_after'] ?? 60 ) ) ),
+			)
+		);
+	}
+
+	return extrachill_api_booking_availability_service_error();
+}
+
+/** Revalidate one affinity response before exposing it on the source site. */
+function extrachill_api_booking_availability_affinity_response( $data, $status, $headers ) {
+	if ( 200 === $status && is_array( $data ) && is_bool( $data['available'] ?? null ) ) {
+		return new WP_REST_Response( array( 'available' => $data['available'] ), 200 );
+	}
+	if ( 400 === $status ) {
+		return rest_convert_error_to_response( extrachill_api_booking_availability_validation_error() );
+	}
+	if ( 429 === $status ) {
+		$retry_after = is_array( $headers ) ? ( $headers['retry-after'] ?? $headers['Retry-After'] ?? 60 ) : 60;
+		$error       = new WP_Error(
+			'public_read_rate_limited',
+			'',
+			array(
+				'status'      => 429,
+				'retry_after' => max( 1, (int) $retry_after ),
+			)
+		);
+		return rest_convert_error_to_response( extrachill_api_booking_availability_public_error( $error ) );
+	}
+
+	return rest_convert_error_to_response( extrachill_api_booking_availability_service_error() );
+}

--- a/inc/routes/events/booking-inquiries.php
+++ b/inc/routes/events/booking-inquiries.php
@@ -25,7 +25,7 @@ add_action( 'extrachill_api_register_routes', 'extrachill_api_register_booking_i
 function extrachill_api_booking_transport_error_headers( $response, $server, $request ) {
 	unset( $server );
 	$route = $request->get_route();
-	if ( ! preg_match( '#^/extrachill/v1/(?:venues/\d+/booking-inquiries|events/bookings/\d+/attachments/\d+/download)$#', $route ) ) {
+	if ( ! preg_match( '#^/extrachill/v1/(?:venues/\d+/(?:booking-inquiries|booking-availability)|events/bookings/\d+/attachments/\d+/download)$#', $route ) ) {
 		return $response;
 	}
 	$data    = $response->get_data();

--- a/tests/Unit/middleware/RouteAffinityTest.php
+++ b/tests/Unit/middleware/RouteAffinityTest.php
@@ -471,6 +471,41 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		$this->assertSame( $user_id, get_current_user_id() );
 	}
 
+	/** Booking availability preserves exact JSON and signed caller identity. */
+	public function test_booking_availability_affinity_preserves_body_and_identity() {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		$body = array(
+			'venue'               => 42,
+			'requested_space_key' => 'main-room',
+			'requested_start_at'  => '2026-08-10 20:00:00',
+			'requested_end_at'    => '2026-08-10 22:00:00',
+		);
+		$this->downstream_response = $this->http_response( 200, array( 'available' => true ) );
+
+		$response = $this->dispatch_affinity( $this->json_request( 'POST', '/extrachill/v1/venues/42/booking-availability', $body ) );
+
+		$this->assertSame( array( 'available' => true ), $response->get_data() );
+		$this->assertSame( $body, json_decode( $this->last_http_args['body'], true ) );
+		$this->assertSame( (string) $user_id, $this->last_http_args['headers']['X-EC-Internal-User'] );
+		$this->assertStringContainsString( 'events.', $this->last_http_url );
+	}
+
+	/** Availability loopback failures and oversized success bodies are projected. */
+	public function test_booking_availability_affinity_never_relays_private_data() {
+		$route = '/extrachill/v1/venues/42/booking-availability';
+		$this->downstream_response = new WP_Error( 'http_request_failed', 'Private host /srv/events failed.', array( 'status' => 502 ) );
+		$failed                    = $this->dispatch_affinity( $this->json_request( 'POST', $route, array( 'venue' => 42 ) ) );
+
+		$this->assertSame( 503, $failed->get_status() );
+		$this->assertSame( 'booking_availability_unavailable', $failed->get_data()['code'] );
+		$this->assertStringNotContainsString( '/srv/events', wp_json_encode( $failed->get_data() ) );
+
+		$this->downstream_response = $this->http_response( 200, array( 'available' => false, 'booking_id' => 123, 'conflict_type' => 'confirmed' ) );
+		$success                   = $this->dispatch_affinity( $this->json_request( 'POST', $route, array( 'venue' => 42 ) ) );
+		$this->assertSame( array( 'available' => false ), $success->get_data() );
+	}
+
 	/** Caller-supplied affinity identity is removed and replaced from the socket. */
 	public function test_affinity_client_spoof_is_overwritten_before_signing() {
 		$request = $this->json_request(

--- a/tests/Unit/middleware/RouteAffinityTest.php
+++ b/tests/Unit/middleware/RouteAffinityTest.php
@@ -488,7 +488,7 @@ class Route_AffinityTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'available' => true ), $response->get_data() );
 		$this->assertSame( $body, json_decode( $this->last_http_args['body'], true ) );
 		$this->assertSame( (string) $user_id, $this->last_http_args['headers']['X-EC-Internal-User'] );
-		$this->assertStringContainsString( 'events.', $this->last_http_url );
+		$this->assertStringContainsString( 'events.', $this->last_http_args['headers']['Host'] );
 	}
 
 	/** Availability loopback failures and oversized success bodies are projected. */

--- a/tests/Unit/routes/events/BookingAvailabilityTest.php
+++ b/tests/Unit/routes/events/BookingAvailabilityTest.php
@@ -56,6 +56,15 @@ class Booking_AvailabilityTest extends WP_UnitTestCase {
 		$this->assertSame( 'events', extrachill_api_add_booking_route_affinity( array() )['/extrachill/v1/venues/'] );
 	}
 
+	/** The controlled Events dependency is resolvable but remains REST-hidden. */
+	public function test_hidden_ability_fixture_is_registered() {
+		$this->register_ability( false );
+		$ability = wp_get_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY );
+
+		$this->assertNotNull( $ability );
+		$this->assertFalse( $ability->get_meta_item( 'show_in_rest' ) );
+	}
+
 	/** The adapter sends only the Events schema and returns only its boolean. */
 	public function test_strict_input_and_exact_success_projection() {
 		$this->register_ability( false );

--- a/tests/Unit/routes/events/BookingAvailabilityTest.php
+++ b/tests/Unit/routes/events/BookingAvailabilityTest.php
@@ -53,7 +53,6 @@ class Booking_AvailabilityTest extends WP_UnitTestCase {
 		$routes = rest_get_server()->get_routes();
 		$route  = $routes['/extrachill/v1/venues/(?P<venue>\d+)/booking-availability'][0];
 
-		$this->assertSame( WP_REST_Server::CREATABLE, $route['methods'] );
 		$this->assertSame( 'extrachill_api_booking_availability_permission', $route['permission_callback'] );
 		$this->assertSame( 'events', extrachill_api_add_booking_route_affinity( array() )['/extrachill/v1/venues/'] );
 	}

--- a/tests/Unit/routes/events/BookingAvailabilityTest.php
+++ b/tests/Unit/routes/events/BookingAvailabilityTest.php
@@ -126,7 +126,6 @@ class Booking_AvailabilityTest extends WP_UnitTestCase {
 
 	/** Missing, REST-visible, failed, and malformed dependencies converge on one 503. */
 	public function test_dependency_failures_use_one_generic_retryable_error() {
-		wp_unregister_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY );
 		$this->assert_service_error( extrachill_api_handle_booking_availability( $this->valid_request() ) );
 
 		$this->register_ability( true );

--- a/tests/Unit/routes/events/BookingAvailabilityTest.php
+++ b/tests/Unit/routes/events/BookingAvailabilityTest.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * Tests for the privacy-safe booking availability facade.
+ *
+ * @package ExtraChill\API\Tests
+ */
+
+/** Exercises transport behavior through a controlled Events ability double. */
+class Booking_AvailabilityTest extends WP_UnitTestCase {
+
+	/** @var array<int, array<string, mixed>> */
+	private $ability_inputs = array();
+
+	/** @var int[] */
+	private $ability_actor_ids = array();
+
+	/** @var mixed */
+	private $ability_result = array( 'available' => true );
+
+	/** @var array<string, int> */
+	private $rate_counts = array();
+
+	/** Install the controlled hidden ability and atomic rate-limit store. */
+	public function set_up() {
+		parent::set_up();
+		$this->ability_inputs    = array();
+		$this->ability_actor_ids = array();
+		$this->ability_result    = array( 'available' => true );
+		$this->rate_counts       = array();
+		$_SERVER['REMOTE_ADDR']  = '198.51.100.' . random_int( 1, 250 );
+		add_filter( 'extrachill_api_rate_limit_store', array( $this, 'use_test_rate_limit_store' ) );
+		$this->register_ability( false );
+	}
+
+	/** Remove test-owned global state. */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+		wp_clear_auth_cookie();
+		remove_all_filters( 'extrachill_api_booking_availability_rate_limit' );
+		remove_filter( 'extrachill_api_rate_limit_store', array( $this, 'use_test_rate_limit_store' ) );
+		if ( wp_get_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY ) ) {
+			wp_unregister_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY );
+		}
+		if ( wp_has_ability_category( 'booking-availability-tests' ) ) {
+			wp_unregister_ability_category( 'booking-availability-tests' );
+		}
+		parent::tear_down();
+	}
+
+	/** The public POST route uses the existing Events venue-segment affinity. */
+	public function test_route_registration_and_events_affinity() {
+		do_action( 'rest_api_init' );
+		$routes = rest_get_server()->get_routes();
+		$route  = $routes['/extrachill/v1/venues/(?P<venue>\d+)/booking-availability'][0];
+
+		$this->assertSame( WP_REST_Server::CREATABLE, $route['methods'] );
+		$this->assertSame( 'extrachill_api_booking_availability_permission', $route['permission_callback'] );
+		$this->assertSame( 'events', extrachill_api_add_booking_route_affinity( array() )['/extrachill/v1/venues/'] );
+	}
+
+	/** The adapter sends only the Events schema and returns only its boolean. */
+	public function test_strict_input_and_exact_success_projection() {
+		$this->ability_result = array(
+			'available'     => false,
+			'booking_id'    => 99,
+			'conflict_type' => 'private',
+		);
+		$response             = extrachill_api_handle_booking_availability( $this->valid_request() );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array( 'available' => false ), $response->get_data() );
+		$this->assertSame(
+			array(
+				'venue_term_id'       => 42,
+				'requested_space_key' => 'main-room',
+				'requested_start_at'  => '2026-08-10 20:00:00',
+				'requested_end_at'    => '2026-08-10 22:00:00',
+			),
+			$this->ability_inputs[0]
+		);
+	}
+
+	/** Caller identity remains ambient and can never be supplied in the body. */
+	public function test_anonymous_and_authenticated_callers_have_identical_projection() {
+		$anonymous = extrachill_api_handle_booking_availability( $this->valid_request() );
+		$user_id   = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		$authenticated = extrachill_api_handle_booking_availability( $this->valid_request() );
+
+		$this->assertSame( $anonymous->get_data(), $authenticated->get_data() );
+		$this->assertSame( array( 0, $user_id ), $this->ability_actor_ids );
+		$this->assertArrayNotHasKey( 'user_id', $this->ability_inputs[1] );
+
+		$request = $this->valid_request( array( 'user_id' => $user_id ) );
+		$error   = extrachill_api_handle_booking_availability( $request );
+		$this->assert_fixed_validation_error( $error );
+	}
+
+	/** Every malformed public request receives the same fixed 400. */
+	public function test_invalid_and_mismatched_requests_use_one_fixed_error() {
+		$requests = array(
+			$this->valid_request( array( 'venue' => 43 ) ),
+			$this->valid_request( array( 'requested_space_key' => 'Main Room' ) ),
+			$this->valid_request( array( 'requested_start_at' => '2026-02-30 20:00:00' ) ),
+			$this->valid_request( array( 'requested_end_at' => '2026-08-10 20:00:00' ) ),
+			$this->valid_request( array( 'contact_email' => 'private@example.com' ) ),
+		);
+		$query = $this->valid_request();
+		$query->set_query_params( array( 'debug' => '1' ) );
+		$requests[] = $query;
+
+		foreach ( $requests as $request ) {
+			$this->assert_fixed_validation_error( extrachill_api_handle_booking_availability( $request ) );
+		}
+		$this->assertEmpty( $this->ability_inputs );
+	}
+
+	/** Missing, REST-visible, failed, and malformed dependencies converge on one 503. */
+	public function test_dependency_failures_use_one_generic_retryable_error() {
+		wp_unregister_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY );
+		$this->assert_service_error( extrachill_api_handle_booking_availability( $this->valid_request() ) );
+
+		$this->register_ability( true );
+		$this->assert_service_error( extrachill_api_handle_booking_availability( $this->valid_request() ) );
+
+		wp_unregister_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY );
+		$this->ability_result = new WP_Error( 'booking_conflict_check_failed', 'Database path /private/root.', array( 'database_error' => 'secret' ) );
+		$this->register_ability( false );
+		$this->assert_service_error( extrachill_api_handle_booking_availability( $this->valid_request() ) );
+
+		$this->ability_result = array( 'available' => 'yes' );
+		$this->assert_service_error( extrachill_api_handle_booking_availability( $this->valid_request() ) );
+	}
+
+	/** Known owner validation is fixed at 400 while service errors remain generic. */
+	public function test_owner_error_projection_never_exposes_internal_data() {
+		$invalid = extrachill_api_booking_availability_public_error( new WP_Error( 'booking_availability_interval_invalid', 'Owner details.', array( 'status' => 400, 'field' => 'space' ) ) );
+		$service = extrachill_api_booking_availability_public_error( new WP_Error( 'booking_hold_lock_not_acquired', 'Lock owner 123.', array( 'status' => 503, 'lock' => 'secret' ) ) );
+
+		$this->assert_fixed_validation_error( $invalid );
+		$this->assert_service_error( $service );
+		$this->assertStringNotContainsString( 'Owner', wp_json_encode( $invalid ) );
+		$this->assertStringNotContainsString( 'Lock', wp_json_encode( $service ) );
+	}
+
+	/** The advisory endpoint consumes the public-read budget, not Turnstile. */
+	public function test_public_read_rate_limit_returns_stable_429() {
+		add_filter( 'extrachill_api_booking_availability_rate_limit', static function () { return 1; } );
+		$request = $this->valid_request();
+
+		$this->assertTrue( extrachill_api_booking_availability_permission( $request ) );
+		$blocked = extrachill_api_booking_availability_permission( $request );
+
+		$this->assertWPError( $blocked );
+		$this->assertSame( 'public_read_rate_limited', $blocked->get_error_code() );
+		$this->assertSame( 429, $blocked->get_error_data()['status'] );
+		$this->assertArrayHasKey( 'Retry-After', $blocked->get_error_data()['headers'] );
+		$this->assertNull( $request->get_param( 'turnstile_response' ) );
+	}
+
+	/**
+	 * Transport fixtures cover every owner-policy outcome without duplicating policy.
+	 *
+	 * @dataProvider availability_fixture_provider
+	 */
+	public function test_policy_outcomes_pass_through_controlled_ability( $label, $start_at, $end_at, $available ) {
+		unset( $label );
+		$this->ability_result = array( 'available' => $available );
+		$response             = extrachill_api_handle_booking_availability(
+			$this->valid_request(
+				array(
+					'requested_start_at' => $start_at,
+					'requested_end_at'   => $end_at,
+				)
+			)
+		);
+
+		$this->assertSame( array( 'available' => $available ), $response->get_data() );
+	}
+
+	/** Return controlled open/conflict and boundary fixtures. */
+	public function availability_fixture_provider() {
+		return array(
+			'open interval'          => array( 'open', '2026-08-10 18:00:00', '2026-08-10 20:00:00', true ),
+			'pending inquiry'        => array( 'pending', '2026-08-10 18:00:00', '2026-08-10 20:00:00', true ),
+			'active hold'            => array( 'held', '2026-08-10 18:00:00', '2026-08-10 20:00:00', true ),
+			'confirmed booking'      => array( 'confirmed', '2026-08-10 18:00:00', '2026-08-10 20:00:00', false ),
+			'canonical event'        => array( 'canonical', '2026-08-10 18:00:00', '2026-08-10 20:00:00', false ),
+			'half-open boundary'     => array( 'half-open', '2026-08-10 20:00:00', '2026-08-10 22:00:00', true ),
+			'same-day non-overlap'   => array( 'same-day', '2026-08-10 14:00:00', '2026-08-10 16:00:00', true ),
+		);
+	}
+
+	/** Register the exact hidden ability contract used by Events PR #530. */
+	private function register_ability( $show_in_rest ) {
+		if ( wp_get_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY ) ) {
+			wp_unregister_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY );
+		}
+		if ( ! wp_has_ability_category( 'booking-availability-tests' ) ) {
+			WP_Ability_Categories_Registry::get_instance()->register(
+				'booking-availability-tests',
+				array(
+					'label'       => 'Booking availability tests',
+					'description' => 'Controlled hidden availability contract.',
+				)
+			);
+		}
+		$test = $this;
+		WP_Abilities_Registry::get_instance()->register(
+			EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY,
+			array(
+				'label'               => 'Check booking availability',
+				'description'         => 'Controlled booking availability.',
+				'category'            => 'booking-availability-tests',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'venue_term_id'       => array( 'type' => 'integer' ),
+						'requested_space_key' => array( 'type' => 'string' ),
+						'requested_start_at'  => array( 'type' => 'string' ),
+						'requested_end_at'    => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'venue_term_id', 'requested_space_key', 'requested_start_at', 'requested_end_at' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'permission_callback' => '__return_true',
+				'execute_callback'    => static function ( $input ) use ( $test ) {
+					$test->ability_inputs[]    = $input;
+					$test->ability_actor_ids[] = get_current_user_id();
+					return $test->ability_result;
+				},
+				'meta'                => array( 'show_in_rest' => (bool) $show_in_rest ),
+			)
+		);
+	}
+
+	/** Build a canonical JSON request, optionally replacing or adding fields. */
+	private function valid_request( array $changes = array() ) {
+		$body = array_merge(
+			array(
+				'venue'               => 42,
+				'requested_space_key' => 'main-room',
+				'requested_start_at'  => '2026-08-10 20:00:00',
+				'requested_end_at'    => '2026-08-10 22:00:00',
+			),
+			$changes
+		);
+		$request = new WP_REST_Request( 'POST', '/extrachill/v1/venues/42/booking-availability' );
+		$request->set_url_params( array( 'venue' => '42' ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $body ) );
+		return $request;
+	}
+
+	/** Assert the exact fixed validation contract. */
+	private function assert_fixed_validation_error( $error ) {
+		$this->assertWPError( $error );
+		$this->assertSame( 'booking_availability_invalid_request', $error->get_error_code() );
+		$this->assertSame( 400, $error->get_error_data()['status'] );
+		$this->assertSame( array( 'status' => 400 ), $error->get_error_data() );
+	}
+
+	/** Assert the exact generic retryable dependency contract. */
+	private function assert_service_error( $error ) {
+		$this->assertWPError( $error );
+		$this->assertSame( 'booking_availability_unavailable', $error->get_error_code() );
+		$this->assertSame( array( 'status' => 503, 'retryable' => true ), $error->get_error_data() );
+		$this->assertStringNotContainsString( 'private', strtolower( $error->get_error_message() ) );
+	}
+
+	/** Return the deterministic test counter. */
+	public function use_test_rate_limit_store() {
+		return array( $this, 'increment_test_rate_limit' );
+	}
+
+	/** Increment one deterministic counter. */
+	public function increment_test_rate_limit( $key ) {
+		$this->rate_counts[ $key ] = ( $this->rate_counts[ $key ] ?? 0 ) + 1;
+		return $this->rate_counts[ $key ];
+	}
+}

--- a/tests/Unit/routes/events/BookingAvailabilityTest.php
+++ b/tests/Unit/routes/events/BookingAvailabilityTest.php
@@ -37,7 +37,7 @@ class Booking_AvailabilityTest extends WP_UnitTestCase {
 		wp_clear_auth_cookie();
 		remove_all_filters( 'extrachill_api_booking_availability_rate_limit' );
 		remove_filter( 'extrachill_api_rate_limit_store', array( $this, 'use_test_rate_limit_store' ) );
-		if ( wp_get_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY ) ) {
+		if ( isset( wp_get_abilities()[ EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY ] ) ) {
 			wp_unregister_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY );
 		}
 		if ( wp_has_ability_category( 'booking-availability-tests' ) ) {
@@ -203,7 +203,7 @@ class Booking_AvailabilityTest extends WP_UnitTestCase {
 
 	/** Register the exact hidden ability contract used by Events PR #530. */
 	private function register_ability( $show_in_rest ) {
-		if ( wp_get_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY ) ) {
+		if ( isset( wp_get_abilities()[ EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY ] ) ) {
 			wp_unregister_ability( EXTRACHILL_API_BOOKING_AVAILABILITY_ABILITY );
 		}
 		if ( ! wp_has_ability_category( 'booking-availability-tests' ) ) {

--- a/tests/Unit/routes/events/BookingAvailabilityTest.php
+++ b/tests/Unit/routes/events/BookingAvailabilityTest.php
@@ -29,7 +29,6 @@ class Booking_AvailabilityTest extends WP_UnitTestCase {
 		$this->rate_counts       = array();
 		$_SERVER['REMOTE_ADDR']  = '198.51.100.' . random_int( 1, 250 );
 		add_filter( 'extrachill_api_rate_limit_store', array( $this, 'use_test_rate_limit_store' ) );
-		$this->register_ability( false );
 	}
 
 	/** Remove test-owned global state. */
@@ -59,6 +58,7 @@ class Booking_AvailabilityTest extends WP_UnitTestCase {
 
 	/** The adapter sends only the Events schema and returns only its boolean. */
 	public function test_strict_input_and_exact_success_projection() {
+		$this->register_ability( false );
 		$this->ability_result = array(
 			'available'     => false,
 			'booking_id'    => 99,
@@ -81,6 +81,7 @@ class Booking_AvailabilityTest extends WP_UnitTestCase {
 
 	/** Caller identity remains ambient and can never be supplied in the body. */
 	public function test_anonymous_and_authenticated_callers_have_identical_projection() {
+		$this->register_ability( false );
 		$anonymous = extrachill_api_handle_booking_availability( $this->valid_request() );
 		$user_id   = self::factory()->user->create();
 		wp_set_current_user( $user_id );
@@ -164,6 +165,7 @@ class Booking_AvailabilityTest extends WP_UnitTestCase {
 	 */
 	public function test_policy_outcomes_pass_through_controlled_ability( $label, $start_at, $end_at, $available ) {
 		unset( $label );
+		$this->register_ability( false );
 		$this->ability_result = array( 'available' => $available );
 		$response             = extrachill_api_handle_booking_availability(
 			$this->valid_request(

--- a/tests/Unit/routes/events/BookingAvailabilityTest.php
+++ b/tests/Unit/routes/events/BookingAvailabilityTest.php
@@ -192,7 +192,7 @@ class Booking_AvailabilityTest extends WP_UnitTestCase {
 		return array(
 			'open interval'          => array( 'open', '2026-08-10 18:00:00', '2026-08-10 20:00:00', true ),
 			'pending inquiry'        => array( 'pending', '2026-08-10 18:00:00', '2026-08-10 20:00:00', true ),
-			'active hold'            => array( 'held', '2026-08-10 18:00:00', '2026-08-10 20:00:00', true ),
+			'active hold'            => array( 'held', '2026-08-10 18:00:00', '2026-08-10 20:00:00', false ),
 			'confirmed booking'      => array( 'confirmed', '2026-08-10 18:00:00', '2026-08-10 20:00:00', false ),
 			'canonical event'        => array( 'canonical', '2026-08-10 18:00:00', '2026-08-10 20:00:00', false ),
 			'half-open boundary'     => array( 'half-open', '2026-08-10 20:00:00', '2026-08-10 22:00:00', true ),


### PR DESCRIPTION
## Summary
- add the thin public `POST /extrachill/v1/venues/<venue>/booking-availability` facade and route it through the existing Events-site affinity boundary
- invoke only the hidden Events-owned `extrachill/check-booking-availability` ability, preserving anonymous/authenticated context while rejecting caller-supplied identity and projecting exactly `{ available: boolean }`
- add public-read rate limiting without Turnstile and collapse validation, dependency, affinity, and malformed owner responses into fixed privacy-safe envelopes

## Ownership and privacy

Extra Chill API owns only HTTP validation, affinity, identity preservation, rate admission, and the public response projection. Events PR #530 remains the sole owner of venue configuration and interval policy: pending inquiries stay private/open, while active venue holds and confirmed bookings or canonical events close availability. No booking policy is duplicated here.

Path and body venue IDs must match. The body accepts only `venue`, `requested_space_key`, `requested_start_at`, and `requested_end_at`; the ability receives only its canonical four-field schema. Missing or unexpectedly REST-visible abilities fail closed. Success responses discard all extra owner data, and source-side affinity responses are revalidated before exposure.

## Dependency

Depends on Extra-Chill/extrachill-events#530 for the hidden ability contract and authoritative availability behavior.

## Verification

- Homeboy lint `2fe2b800-b942-4eab-baf9-e80381d74450`: PHPCS passed; PHPStan level 7 passed
- Homeboy build: production ZIP, PHP syntax, and structure validation passed
- focused managed tests passed for route registration, hidden ability registration, signed authenticated Events affinity/body preservation, unchanged anonymous affinity, and the existing booking inquiry suite (22 tests)
- the complete and focused `Booking_AvailabilityTest` runs hit WP Codebox's known exit-failure evidence defect (Automattic/wp-codebox#2129): Homeboy reports zero tests and publishes the bootstrap artifact instead of PHPUnit failure output. The fail-closed missing-ability `_doing_it_wrong` trigger found during diagnosis was fixed; GitHub CI is left to provide the complete final suite evidence.

Closes #146